### PR TITLE
Migrate rascsi data to piscsi with easyinstall

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -245,7 +245,7 @@ function createImagesDir() {
 function createCfgDir() {
     if [ -d "$HOME/.config/rascsi" ]; then
         sudo mv "$HOME/.config/rascsi" "$CFG_PATH"
-        echo "Renamed the rascsi config dir at $CFG_PATH."
+        echo "Renamed the rascsi config dir as $CFG_PATH."
     elif [ -d "$CFG_PATH" ]; then
         echo "The $CFG_PATH directory already exists."
     else

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1201,7 +1201,7 @@ function runChoice() {
               echo "- Modify the Raspberry Pi boot configuration (may require a reboot)"
               sudoCheck
               preparePythonCommon
-              disableLegacyServices
+              migrateLegacyData
               installPiscsiScreen
               showPiscsiScreenStatus
               echo "Installing / Updating PiSCSI OLED Screen - Complete!"
@@ -1215,7 +1215,7 @@ function runChoice() {
               echo "- Modify the Raspberry Pi boot configuration (may require a reboot)"
               sudoCheck
               preparePythonCommon
-              disableLegacyServices
+              migrateLegacyData
               installPiscsiCtrlBoard
               showPiscsiCtrlBoardStatus
               echo "Installing / Updating PiSCSI Control Board UI - Complete!"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -96,9 +96,9 @@ function sudoCheck() {
 
 # Delete file if it exists
 function deleteFile() {
-    if sudo test -f "$1"; then
-        sudo rm "$1" || exit 1
-        echo "Deleted $1"
+    if sudo test -f "$1/$2"; then
+        sudo rm "$1/$2" || exit 1
+        echo "Deleted $1/$2"
     fi
 }
 
@@ -159,21 +159,25 @@ function compilePiscsi() {
     make CXX="$COMPILER" CONNECT_TYPE="$CONNECT_TYPE" -j "$CORES" all </dev/null
 }
 
-function cleanupOutdatedManPage() {
-    OUTDATED_MAN_PAGE_DIR=/usr/share/man/man1/
-    if [ -f "${OUTDATED_MAN_PAGE_DIR}/$1" ]; then
-      sudo rm "${OUTDATED_MAN_PAGE_DIR}/$1"
-    fi
-}
-
 # install the PiSCSI binaries and modify the service configuration
 function installPiscsi() {
-    # clean up outdated man pages if they exist
-    cleanupOutdatedManPage "rascsi.1"
-    cleanupOutdatedManPage "rasctl.1"
-    cleanupOutdatedManPage "scsimon.1"
-    cleanupOutdatedManPage "rasdump.1"
-    cleanupOutdatedManPage "sasidump.1"
+    OUTDATED_MAN_PAGE_DIR="/usr/share/man/man1"
+    CURRENT_MAN_PAGE_DIR="/usr/local/man/man1"
+    CURRENT_BIN_DIR="/usr/local/bin"
+    # clean up outdated binaries and man pages if they exist
+    deleteFile "$OUTDATED_MAN_PAGE_DIR" "rascsi.1"
+    deleteFile "$OUTDATED_MAN_PAGE_DIR" "rasctl.1"
+    deleteFile "$OUTDATED_MAN_PAGE_DIR" "scsimon.1"
+    deleteFile "$OUTDATED_MAN_PAGE_DIR" "rasdump.1"
+    deleteFile "$OUTDATED_MAN_PAGE_DIR" "sasidump.1"
+    deleteFile "$CURRENT_MAN_PAGE_DIR" "rascsi.1"
+    deleteFile "$CURRENT_MAN_PAGE_DIR" "rasctl.1"
+    deleteFile "$CURRENT_MAN_PAGE_DIR" "rasdump.1"
+    deleteFile "$CURRENT_MAN_PAGE_DIR" "sasidump.1"
+    deleteFile "$CURRENT_BIN_DIR" "rascsi"
+    deleteFile "$CURRENT_BIN_DIR" "rasctl"
+    deleteFile "$CURRENT_BIN_DIR" "rasdump"
+    deleteFile "$CURRENT_BIN_DIR" "sasidump"
 
     # install
     sudo make install CONNECT_TYPE="$CONNECT_TYPE" </dev/null
@@ -190,14 +194,15 @@ function installPiscsi() {
 
 # Prepare shared Python code
 function preparePythonCommon() {
-    deleteFile "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
-    deleteFile "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
-    deleteFile "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
-    deleteFile "$WEB_INSTALL_PATH/src/piscsi_interface_pb2.py"
-    deleteFile "$OLED_INSTALL_PATH/src/piscsi_interface_pb2.py"
-    deleteFile "$PYTHON_COMMON_PATH/src/piscsi_interface_pb2.py"
+    PISCSI_PYTHON_PROTO="piscsi_interface_pb2.py"
+    deleteFile "$WEB_INSTALL_PATH/src" "rascsi_interface_pb2.py"
+    deleteFile "$OLED_INSTALL_PATH/src" "rascsi_interface_pb2.py"
+    deleteFile "$PYTHON_COMMON_PATH/src" "rascsi_interface_pb2.py"
+    deleteFile "$WEB_INSTALL_PATH/src" "$PISCSI_PYTHON_PROTO"
+    deleteFile "$OLED_INSTALL_PATH/src" "$PISCSI_PYTHON_PROTO"
+    deleteFile "$PYTHON_COMMON_PATH/src" "$PISCSI_PYTHON_PROTO"
 
-    echo "Compiling the Python protobuf library piscsi_interface_pb2.py..."
+    echo "Compiling the Python protobuf library $PISCSI_PYTHON_PROTO..."
     protoc -I="$CPP_PATH" --python_out="$PYTHON_COMMON_PATH/src" piscsi_interface.proto
 }
 
@@ -208,8 +213,8 @@ function installPiscsiWebInterface() {
 
     sudo usermod -a -G $USER www-data
 
-    deleteFile "$SSL_CERTS_PATH/rascsi-web.crt"
-    deleteFile "$SSL_KEYS_PATH/rascsi-web.key"
+    deleteFile "$SSL_CERTS_PATH" "rascsi-web.crt"
+    deleteFile "$SSL_KEYS_PATH" "rascsi-web.key"
 
     if [ -f "$SSL_CERTS_PATH/piscsi-web.crt" ]; then
         echo "SSL certificate $SSL_CERTS_PATH/piscsi-web.crt already exists."

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -532,25 +532,6 @@ function showMacproxyStatus() {
     systemctl status macproxy | tee
 }
 
-# Creates a drive image file with specific parameters
-function createDrive600M() {
-    createDrive 600 "HD600"
-}
-
-# Creates a drive image file and prompts for parameters
-function createDriveCustom() {
-    driveSize=-1
-    until [ $driveSize -ge "10" ] && [ $driveSize -le "4000" ]; do
-        echo "What drive size would you like (in MiB) (10-4000)"
-        read driveSize
-
-        echo "How would you like to name that drive?"
-        read driveName
-    done
-
-    createDrive "$driveSize" "$driveName"
-}
-
 # Clone, compile and install 'hfdisk', partition tool
 function installHfdisk() {
     HFDISK_VERSION="2022.11"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -46,9 +46,11 @@ logo="""
 echo -e $logo
 }
 
-COMPILER="clang++-11"
 CONNECT_TYPE="FULLSPEC"
-CORES=$(nproc)
+# clang v11 is the latest distributed by Buster
+COMPILER="clang++-11"
+# Takes half of the CPU cores available, to avoid running out of memory on low spec devices
+CORES=$(awk 'BEGIN { x = '$(nproc)'; y = 2; print (x / y) }' | numfmt --round=up --format=%.0f)
 USER=$(whoami)
 BASE=$(dirname "$(readlink -f "${0}")")
 CPP_PATH="$BASE/cpp"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -410,6 +410,16 @@ function migrateLegacyData() {
         sudo mv "$SYSTEMD_PATH/rascsi-ctrlboard.service" "$SYSTEMD_PATH/piscsi-ctrlboard.service"
         echo "Renamed rascsi-ctrlboard.service to piscsi-ctrlboard.service"
     fi
+    if [[ -f "/etc/rsyslog.d/rascsi.conf" ]]; then
+        sudo rm "/etc/rsyslog.d/rascsi.conf"
+        sudo cp "$CPP_PATH/os_integration/piscsi.conf" "/etc/rsyslog.d"
+        echo "Replaced rascsi.conf with piscsi.conf"
+    fi
+    if [[ -f "/etc/network/interfaces.d/rascsi_bridge" ]]; then
+        sudo rm "/etc/rsyslog.d/rascsi.conf"
+        sudo cp "$CPP_PATH/os_integration/piscsi_bridge" "/etc/network/interfaces.d"
+        echo "Replaced rascsi_bridge with piscsi_bridge"
+    fi
     if [ $(getent group rascsi) ]; then
         sudo groupmod --new-name piscsi rascsi
         echo "Renamed the rascsi group to piscsi"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1348,7 +1348,7 @@ function readChoice() {
    choice=-1
 
    until [ $choice -ge "0" ] && [ $choice -le "15" ]; do
-       echo -n "Enter your choice (0-14) or CTRL-C to exit: "
+       echo -n "Enter your choice (0-15) or CTRL-C to exit: "
        read -r choice
    done
 
@@ -1396,7 +1396,7 @@ while [ "$1" != "" ]; do
             ;;
         -r | --run_choice)
             if ! [[ $VALUE =~ ^[1-9][0-9]?$ && $VALUE -ge 1 && $VALUE -le 15 ]]; then
-                echo "ERROR: The run choice parameter must have a numeric value between 1 and 14"
+                echo "ERROR: The run choice parameter must have a numeric value between 1 and 15"
                 exit 1
             fi
             RUN_CHOICE=$VALUE

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1420,7 +1420,7 @@ while [ "$1" != "" ]; do
         -s | --skip_packages)
             SKIP_PACKAGES=1
             ;;
-        -c | --skip_make_clean)
+        -l | --skip_make_clean)
             SKIP_MAKE_CLEAN=1
             ;;
         *)

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -94,6 +94,14 @@ function sudoCheck() {
     sudo -v
 }
 
+# Delete file if it exists
+function deleteFile() {
+    if sudo test -f "$1"; then
+        sudo rm "$1" || exit 1
+        echo "Deleted $1"
+    fi
+}
+
 # install all dependency packages for PiSCSI Service
 function installPackages() {
     if [[ $SKIP_PACKAGES ]]; then
@@ -129,7 +137,6 @@ function installPackagesWeb() {
         $APT_PACKAGES_PYTHON \
         $APT_PACKAGES_WEB
 }
-
 
 # cache the pip packages
 function cachePipPackages(){
@@ -181,14 +188,6 @@ function installPiscsi() {
     echo "Configured piscsi.service to use $VIRTUAL_DRIVER_PATH as default image dir."
 }
 
-# Delete file if it exists
-function deleteFile() {
-    if [ -f "$1" ]; then
-        sudo rm "$1" || exit 1
-        echo "Deleted $1"
-    fi
-}
-
 # Prepare shared Python code
 function preparePythonCommon() {
     deleteFile "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
@@ -209,12 +208,8 @@ function installPiscsiWebInterface() {
 
     sudo usermod -a -G $USER www-data
 
-    if [ -f "$SSL_CERTS_PATH/rascsi-web.crt" ]; then
-        sudo rm "$SSL_CERTS_PATH/rascsi-web.crt"
-    fi
-    if [ -f "$SSL_KEYS_PATH/rascsi-web.key" ]; then
-        sudo rm "$SSL_KEYS_PATH/rascsi-web.key"
-    fi
+    deleteFile "$SSL_CERTS_PATH/rascsi-web.crt"
+    deleteFile "$SSL_KEYS_PATH/rascsi-web.key"
 
     if [ -f "$SSL_CERTS_PATH/piscsi-web.crt" ]; then
         echo "SSL certificate $SSL_CERTS_PATH/piscsi-web.crt already exists."

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -143,7 +143,11 @@ function compilePiscsi() {
     cd "$CPP_PATH" || exit 1
 
     echo "Compiling $CONNECT_TYPE with $COMPILER on $CORES simultaneous cores..."
-    make clean </dev/null
+    if [[ $SKIP_MAKE_CLEAN ]]; then
+        echo "Skipping 'make clean'"
+    else
+        make clean </dev/null
+    fi
 
     make CXX="$COMPILER" CONNECT_TYPE="$CONNECT_TYPE" -j "$CORES" all </dev/null
 }
@@ -1415,6 +1419,9 @@ while [ "$1" != "" ]; do
             ;;
         -s | --skip_packages)
             SKIP_PACKAGES=1
+            ;;
+        -c | --skip_make_clean)
+            SKIP_MAKE_CLEAN=1
             ;;
         *)
             echo "ERROR: Unknown parameter \"$PARAM\""

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -48,7 +48,7 @@ echo -e $logo
 
 COMPILER="clang++-11"
 CONNECT_TYPE="FULLSPEC"
-CORES=1
+CORES=$(nproc)
 USER=$(whoami)
 BASE=$(dirname "$(readlink -f "${0}")")
 CPP_PATH="$BASE/cpp"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -177,31 +177,23 @@ function installPiscsi() {
     echo "Configured piscsi.service to use $VIRTUAL_DRIVER_PATH as default image dir."
 }
 
+# Delete file if it exists
+function deleteFile() {
+    if [ -f "$1" ]; then
+        sudo rm "$1" || exit 1
+        echo "Deleted $1"
+    fi
+}
+
+# Prepare shared Python code
 function preparePythonCommon() {
-    if [ -f "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py" ]; then
-        sudo rm "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
-    fi
-    if [ -f "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py" ]; then
-        sudo rm "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
-    fi
-    if [ -f "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py" ]; then
-        sudo rm "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
-    fi
-    if [ -f "$WEB_INSTALL_PATH/src/piscsi_interface_pb2.py" ]; then
-        sudo rm "$WEB_INSTALL_PATH/src/piscsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $WEB_INSTALL_PATH/src/piscsi_interface_pb2.py"
-    fi
-    if [ -f "$OLED_INSTALL_PATH/src/piscsi_interface_pb2.py" ]; then
-        sudo rm "$OLED_INSTALL_PATH/src/piscsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $OLED_INSTALL_PATH/src/piscsi_interface_pb2.py"
-    fi
-    if [ -f "$PYTHON_COMMON_PATH/src/piscsi_interface_pb2.py" ]; then
-        sudo rm "$PYTHON_COMMON_PATH/src/piscsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library $PYTHON_COMMON_PATH/src/piscsi_interface_pb2.py"
-    fi
+    deleteFile "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
+    deleteFile "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
+    deleteFile "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
+    deleteFile "$WEB_INSTALL_PATH/src/piscsi_interface_pb2.py"
+    deleteFile "$OLED_INSTALL_PATH/src/piscsi_interface_pb2.py"
+    deleteFile "$PYTHON_COMMON_PATH/src/piscsi_interface_pb2.py"
+
     echo "Compiling the Python protobuf library piscsi_interface_pb2.py..."
     protoc -I="$CPP_PATH" --python_out="$PYTHON_COMMON_PATH/src" piscsi_interface.proto
 }
@@ -402,8 +394,6 @@ function disableLegacyServices() {
         disableService "rascsi-ctrlboard"
         sudo mv "$SYSTEMD_PATH/rascsi-ctrlboard.service" "$SYSTEMD_PATH/piscsi-ctrlboard.service"
     fi
-
-    sudo systemctl daemon-reload
 }
 
 # Stops a service if it is running

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -416,7 +416,7 @@ function migrateLegacyData() {
         echo "Replaced rascsi.conf with piscsi.conf"
     fi
     if [[ -f "/etc/network/interfaces.d/rascsi_bridge" ]]; then
-        sudo rm "/etc/rsyslog.d/rascsi.conf"
+        sudo rm "/etc/network/interfaces.d/rascsi_bridge"
         sudo cp "$CPP_PATH/os_integration/piscsi_bridge" "/etc/network/interfaces.d"
         echo "Replaced rascsi_bridge with piscsi_bridge"
     fi

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -491,7 +491,7 @@ function isPiscsiCtrlBoardRunning() {
 function startPiscsiScreen() {
     if [[ $(isPiscsiScreenInstalled) -eq 0 ]] && [[ $(isPiscsiScreenRunning) -ne 1 ]]; then
         sudo systemctl start piscsi-oled.service
-        showPiscsiScreenStatus
+        showServiceStatus "piscsi-oled"
     fi
 }
 
@@ -499,7 +499,7 @@ function startPiscsiScreen() {
 function startPiscsiCtrlBoard() {
     if [[ $(isPiscsiCtrlBoardInstalled) -eq 0 ]] && [[ $(isPiscsiCtrlBoardRunning) -ne 1 ]]; then
         sudo systemctl start piscsi-ctrlboard.service
-        showPiscsiCtrlBoardStatus
+        showServiceStatus "piscsi-ctrlboard"
     fi
 }
 
@@ -507,33 +507,13 @@ function startPiscsiCtrlBoard() {
 function startMacproxy() {
     if [ -f "$SYSTEMD_PATH/macproxy.service" ]; then
         sudo systemctl start macproxy.service
-        showMacproxyStatus
+        showServiceStatus "macproxy"
     fi
 }
 
 # Shows status for the piscsi service
-function showPiscsiStatus() {
-    systemctl status piscsi | tee
-}
-
-# Shows status for the piscsi-web service
-function showPiscsiWebStatus() {
-    systemctl status piscsi-web | tee
-}
-
-# Shows status for the piscsi-oled service
-function showPiscsiScreenStatus() {
-    systemctl status piscsi-oled | tee
-}
-
-# Shows status for the piscsi-ctrlboard service
-function showPiscsiCtrlBoardStatus() {
-    systemctl status piscsi-ctrlboard | tee
-}
-
-# Shows status for the macproxy service
-function showMacproxyStatus() {
-    systemctl status macproxy | tee
+function showServiceStatus() {
+    systemctl status "$1.service" | tee
 }
 
 # Clone, compile and install 'hfdisk', partition tool
@@ -1161,10 +1141,10 @@ function runChoice() {
               cachePipPackages
               installPiscsiWebInterface
               installWebInterfaceService
-              showPiscsiScreenStatus
-              showPiscsiCtrlBoardStatus
-              showPiscsiStatus
-              showPiscsiWebStatus
+              showServiceStatus "piscsi-oled"
+              showServiceStatus "piscsi-ctrlboard"
+              showServiceStatus "piscsi"
+              showServiceStatus "piscsi-web"
               notifyBackup
               echo "Installing / Updating PiSCSI Service ($CONNECT_TYPE) + Web Interface - Complete!"
           ;;
@@ -1199,9 +1179,9 @@ function runChoice() {
                   echo "Detected piscsi control board service; will run the installation steps for the control board ui."
                   installPiscsiCtrlBoard
               fi
-              showPiscsiScreenStatus
-              showPiscsiCtrlBoardStatus
-              showPiscsiStatus
+              showServiceStatus "piscsi-oled"
+              showServiceStatus "piscsi-ctrlboard"
+              showServiceStatus "piscsi"
               notifyBackup
               echo "Installing / Updating PiSCSI Service ($CONNECT_TYPE) - Complete!"
           ;;
@@ -1215,7 +1195,7 @@ function runChoice() {
               preparePythonCommon
               migrateLegacyData
               installPiscsiScreen
-              showPiscsiScreenStatus
+              showServiceStatus "piscsi-oled"
               echo "Installing / Updating PiSCSI OLED Screen - Complete!"
           ;;
           4)
@@ -1229,7 +1209,7 @@ function runChoice() {
               preparePythonCommon
               migrateLegacyData
               installPiscsiCtrlBoard
-              showPiscsiCtrlBoardStatus
+              showServiceStatus "piscsi-ctrlboard"
               echo "Installing / Updating PiSCSI Control Board UI - Complete!"
           ;;
           5)

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -801,7 +801,11 @@ function installMacproxy {
         echo "Using the default port $PORT"
     fi
 
-    ( sudo apt-get update && sudo apt-get install python3 python3-venv --assume-yes ) </dev/null
+    if [[ $SKIP_PACKAGES ]]; then
+        echo "Skipping package installation"
+    else
+        sudo apt-get update && sudo apt-get install python3 python3-venv --assume-yes </dev/null
+    fi
 
     MACPROXY_VER="22.8"
     MACPROXY_PATH="$HOME/macproxy-$MACPROXY_VER"
@@ -929,7 +933,11 @@ function installPiscsiScreen() {
     disableService "piscsi-ctrlboard"
     updatePiscsiGit
 
-    sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config -y </dev/null
+    if [[ $SKIP_PACKAGES ]]; then
+        echo "Skipping package installation"
+    else
+        sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config -y </dev/null
+    fi
 
     if [[ $(grep -c "^dtparam=i2c_arm=on" /boot/config.txt) -ge 1 ]]; then
         echo "NOTE: I2C support seems to have been configured already."
@@ -999,9 +1007,13 @@ function installPiscsiCtrlBoard() {
     stopService "piscsi-ctrlboard"
     updatePiscsiGit
 
-    sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config -y </dev/null
-    # install python packages through apt that need compilation
-    sudo apt-get install python3-cbor2 -y </dev/null
+    if [[ $SKIP_PACKAGES ]]; then
+        echo "Skipping package installation"
+    else
+        sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config -y </dev/null
+        # install python packages through apt that need compilation
+        sudo apt-get install python3-cbor2 -y </dev/null
+    fi
 
     # enable i2c
     if [[ $(grep -c "^dtparam=i2c_arm=on" /boot/config.txt) -ge 1 ]]; then


### PR DESCRIPTION
Hybrid approach of:
- Always checking for legacy services for each workflow that involves installing new services, then disable and rename them.
- Check for the rascsi group, as well as old rascsi.conf, rascsi_bridge, config dir and secret file inline whenever the script interacts with them, then rename them.
- Check for the old self signed cert and key, as well as compiled protobuf libs, and delete them when the web ui is installed

Also fixed:
- the old manpage renaming script which should keep the old 'rascsi' names.
- removed the ancient apache cleanup, since it's been over 2 years now since the PHP webapp was deprecated.
- general purpose stop/disable/status functions for systemd services
- general purpose deleteFile function
- default to half of the max no. of cores for compiling
- use the SKIP_PACKAGES flag in more functions
- introduce a SKIP_MAKE_CLEAN flag