### PR TITLE
Hide the auth disabled element on small screens

### DIFF
--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -276,18 +276,13 @@ div.header div.authentication-disabled a {
 
 @media (max-width: 900px) {
   div.header {
+    flex-wrap: wrap;
     min-height: 3.5rem; /* Safari 14 iOS and iPad OS */
     background: var(--dark);
   }
 
   body.auth-enabled:not(.logged-in) div.header {
-    flex-wrap: wrap;
     min-height: 8.875rem; /* Safari 14 iOS and iPad OS */
-  }
-
-  body.auth-disabled div.header {
-    flex-wrap: wrap;
-    min-height: 7rem;
   }
 
   div.header div.title span.subtitle {
@@ -353,11 +348,7 @@ div.header div.authentication-disabled a {
   }
 
   div.header div.authentication-disabled {
-    flex: 0 0 100%;
-    align-items: end;
-    padding: 0.5rem;
-    background: var(--danger);
-    color: #fff;
+    display: none;
   }
 }
 


### PR DESCRIPTION
The Web UI auth disabled span with red background was too dominating, permanently taking up a lot of screen real estate on small screens. Since there are legitimate reasons for someone to permanently run the web UI without auth, I think it makes more sense to display it only when there is room to spare on the screen.