### PR TITLE
Tweak dropzone config and introduce dedicated Upload page

### DIFF
--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -142,6 +142,10 @@ select {
   flex-wrap: wrap;
 }
 
+.dropzone label {
+  padding: 1rem 1rem;
+}
+
 .dropzone p,
 .dropzone .dz-default {
   flex: 0 0 100%;

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -140,9 +140,6 @@ select {
 .dropzone {
   display: flex;
   flex-wrap: wrap;
-}
-
-.dropzone form {
   align-items: center;
 }
 

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -143,7 +143,7 @@ select {
 }
 
 .dropzone label {
-  padding: 1rem 1rem;
+  padding: 0 0.5rem;
 }
 
 .dropzone p,

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -777,13 +777,13 @@ section#upload {
 section#upload a {
   margin: auto;
   display: block;
-  padding: 0 0 0 2rem;
+  padding: 0.25rem 0 0.25rem 2rem;
   background: url("icons/upload-in-progress.svg") no-repeat left center;
-  font-size: medium;
+  font-weight: bold;
 }
 
 section#upload a p {
-  margin: 1;
+  margin: 0;
 }
 
 /*
@@ -837,13 +837,13 @@ section#create-drive {
 section#create-drive a {
   margin: auto;
   display: block;
-  padding: 0 0 0 2rem;
+  padding: 0.25rem 0 0.25rem 2rem;
   background: url("icons/device-other.svg") no-repeat left center;
-  font-size: medium;
+  font-weight: bold;
 }
 
 section#create-drive a p {
-  margin: 1;
+  margin: 0;
 }
 
 /*
@@ -884,9 +884,9 @@ section#manual {
 section#manual a {
   margin: auto;
   display: block;
-  padding: 0 0 0 2rem;
+  padding: 0.25rem 0 0.25rem 2rem;
   background: url("icons/manual.svg") no-repeat left center;
-  font-size: medium;
+  font-weight: bold;
 }
 
 section#manual a p {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -767,6 +767,27 @@ section#files p {
 
 /*
  ------------------------------------------------------------------------------
+ Index > Section: Upload
+ ------------------------------------------------------------------------------
+ */
+section#upload {
+  margin: 1rem 0 1rem;
+}
+
+section#upload a {
+  margin: auto;
+  display: block;
+  padding: 0 0 0 2rem;
+  background: url("icons/upload-in-progress.svg") no-repeat left center;
+  font-size: medium;
+}
+
+section#upload a p {
+  margin: 1;
+}
+
+/*
+ ------------------------------------------------------------------------------
  Index > Section: Attach peripheral devices
  ------------------------------------------------------------------------------
  */
@@ -802,6 +823,27 @@ section#attach-devices form {
 section#create-image > p a {
   display: block;
   margin-top: 1rem;
+}
+
+/*
+ ------------------------------------------------------------------------------
+ Index > Section: Create drive
+ ------------------------------------------------------------------------------
+ */
+section#create-drive {
+  margin: 1rem 0 1rem;
+}
+
+section#create-drive a {
+  margin: auto;
+  display: block;
+  padding: 0 0 0 2rem;
+  background: url("icons/device-other.svg") no-repeat left center;
+  font-size: medium;
+}
+
+section#create-drive a p {
+  margin: 1;
 }
 
 /*
@@ -844,7 +886,7 @@ section#manual a {
   display: block;
   padding: 0 0 0 2rem;
   background: url("icons/manual.svg") no-repeat left center;
-  font-weight: bold;
+  font-size: medium;
 }
 
 section#manual a p {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -771,7 +771,7 @@ section#files p {
  ------------------------------------------------------------------------------
  */
 section#upload {
-  margin: 1rem 0 1rem;
+  margin: 1rem 0;
 }
 
 section#upload a {
@@ -831,7 +831,7 @@ section#create-image > p a {
  ------------------------------------------------------------------------------
  */
 section#create-drive {
-  margin: 1rem 0 1rem;
+  margin: 1rem 0;
 }
 
 section#create-drive a {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -142,6 +142,10 @@ select {
   flex-wrap: wrap;
 }
 
+.dropzone form {
+  align-items: center;
+}
+
 .dropzone label {
   padding: 0 0.5rem;
 }

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -453,69 +453,10 @@
 
 <hr/>
 
-<section id="upload">
-<details>
-    <summary class="heading">
-        {{ _("Upload File from Local Computer") }}
-    </summary>
-    <ul>
-        <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
-        <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling or moving away from this page.") }}</li>
-        <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
-    </ul>
-</details>
-
-<form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
-    <p>
-    <label for="upload_destination">{{ _("Target directory:") }}</label>
-    <select name="destination" id="upload_destination">
-        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
-        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
-    </select>
-    </p>
-</form>
-
-<script type="application/javascript">
-    Dropzone.options.dropper = {
-        paramName: 'file',
-        url: '/files/upload',
-        maxFilesize: {{ max_file_size }}, // max allowed file size in MiB
-        chunking: true,
-        forceChunking: true,
-        parallelChunkUploads: false,
-        chunkSize: 1048576, // 1 MiB
-        retryChunks: true,
-        retryChunksLimit: 3,
-        createImageThumbnails: false,
-        addRemoveLinks: true,
-        dictDefaultMessage: "{{ _("Drop files here to upload") }}",
-        dictFallbackMessage: "{{ _("Your browser does not support drag'n'drop file uploads.") }}",
-        dictFallbackText: "{{ _("Please use the fallback form below to upload your files like in the olden days.") }}",
-        dictFileTooBig: "{{ _("File is too big: {{filesize}}MiB. Max filesize: {{maxFilesize}}MiB.") }}",
-        dictInvalidFileType: "{{ _("You can't upload files of this type.") }}",
-        dictResponseError: "{{ _("Server responded with code: {{statusCode}}") }}",
-        dictCancelUpload:" {{ _("Click here to cancel; stay on page to continue") }}",
-        dictUploadCanceled: "{{ _("Upload canceled.") }}",
-        dictCancelUploadConfirmation: "{{ _("Are you sure you want to cancel this upload?") }}",
-        dictRemoveFile: "{{ _("Dismiss") }}",
-        dictMaxFilesExceeded: "{{ _("You can not upload any more files.") }}",
-        dictFileSizeUnits: {
-            tb: "{{ _("TiB") }}",
-            gb: "{{ _("GiB") }}",
-            mb: "{{ _("MiB") }}",
-            kb: "{{ _("KiB") }}",
-            b: "{{ _("B") }}"
-        }
-    }
-</script>
-</section>
-
-<hr/>
-
 <section id="download-url">
 <details>
     <summary class="heading">
-        {{ _("Download File from the Web") }}
+        {{ _("Transfer files to the PiSCSI") }}
     </summary>
     <ul>
         <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
@@ -532,6 +473,7 @@
     <input name="url" id="download_url" required="" type="url">
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
 </form>
+<p><a href="/upload" target="_blank">{{ _("Go to file uploading page (new tab)") }}</a></p>
 </section>
 
 <hr/>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -478,21 +478,26 @@
 <script type="application/javascript">
     Dropzone.options.dropper = {
         paramName: 'file',
+        url: '/files/upload',
+        maxFilesize: {{ max_file_size }}, // max allowed file size in MiB
         chunking: true,
         forceChunking: true,
-        url: '/files/upload',
-        maxFilesize: {{ max_file_size }}, // MiB
-        chunkSize: 1000000, // bytes
+        parallelChunkUploads: false,
+        chunkSize: 1048576, // 1 MiB
+        retryChunks: true,
+        retryChunksLimit: 3,
+        createImageThumbnails: false,
+        addRemoveLinks: true,
         dictDefaultMessage: "{{ _("Drop files here to upload") }}",
         dictFallbackMessage: "{{ _("Your browser does not support drag'n'drop file uploads.") }}",
         dictFallbackText: "{{ _("Please use the fallback form below to upload your files like in the olden days.") }}",
         dictFileTooBig: "{{ _("File is too big: {{filesize}}MiB. Max filesize: {{maxFilesize}}MiB.") }}",
         dictInvalidFileType: "{{ _("You can't upload files of this type.") }}",
         dictResponseError: "{{ _("Server responded with code: {{statusCode}}") }}",
-        dictCancelUpload:" {{ _("Cancel upload") }}",
+        dictCancelUpload:" {{ _("Click here to cancel; stay on page to continue") }}",
         dictUploadCanceled: "{{ _("Upload canceled.") }}",
         dictCancelUploadConfirmation: "{{ _("Are you sure you want to cancel this upload?") }}",
-        dictRemoveFile: "{{ _("Remove file") }}",
+        dictRemoveFile: "{{ _("Dismiss") }}",
         dictMaxFilesExceeded: "{{ _("You can not upload any more files.") }}",
         dictFileSizeUnits: {
             tb: "{{ _("TiB") }}",

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -353,6 +353,34 @@
 
 <hr/>
 
+<section id="download-url">
+<details>
+    <summary class="heading">
+        {{ _("Transfer Files to the PiSCSI") }}
+    </summary>
+    <ul>
+        <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
+    </ul>
+</details>
+
+<form action="/files/download_url" method="post">
+    <label for="download_url">{{ _("Download file from URL:") }}</label>
+    <input name="url" id="download_url" required="" type="url">
+    <label for="download_destination">{{ _("Destination:") }}</label>
+    <select name="destination" id="download_destination">
+        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
+        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
+    </select>
+    <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
+</form>
+</section>
+
+<section id="upload">
+    <a href="/upload" target="_blank"><p>{{ _("Upload Files (new tab)") }}</p></a>
+</section>
+
+<hr/>
+
 <section id="attach-devices">
 <details>
     <summary class="heading">
@@ -449,34 +477,6 @@
     </tr>
     {% endfor %}
 </table>
-</section>
-
-<hr/>
-
-<section id="download-url">
-<details>
-    <summary class="heading">
-        {{ _("Transfer files to the PiSCSI") }}
-    </summary>
-    <ul>
-        <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
-    </ul>
-</details>
-
-<p>
-<form action="/files/download_url" method="post">
-    <label for="download_url">{{ _("Download file from URL:") }}</label>
-    <input name="url" id="download_url" required="" type="url">
-    <label for="download_destination">{{ _("Destination:") }}</label>
-    <select name="destination" id="download_destination">
-        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
-        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
-    </select>
-    <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
-</form>
-</p>
-
-<p><a href="/upload" target="_blank">{{ _("Go to file uploading page (new tab)") }}</a></p>
 </section>
 
 <hr/>
@@ -586,8 +586,10 @@
     </select>
     <input type="submit" value="{{ _("Create") }}">
 </form>
+</section>
 
-<p><a href="/drive/list">{{ _("Create a named disk image that mimics real-life drives") }}</a></p>
+<section id="create-drive">
+    <a href="/drive/list"><p>{{ _("Create Disk Image With Properties") }}</p></a>
 </section>
 
 <hr/>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -463,16 +463,19 @@
     </ul>
 </details>
 
+<p>
 <form action="/files/download_url" method="post">
-    <label for="download_destination">{{ _("Target directory:") }}</label>
+    <label for="download_url">{{ _("Download file from URL:") }}</label>
+    <input name="url" id="download_url" required="" type="url">
+    <label for="download_destination">{{ _("Destination:") }}</label>
     <select name="destination" id="download_destination">
         <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
         <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
     </select>
-    <label for="download_url">{{ _("URL:") }}</label>
-    <input name="url" id="download_url" required="" type="url">
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
 </form>
+</p>
+
 <p><a href="/upload" target="_blank">{{ _("Go to file uploading page (new tab)") }}</a></p>
 </section>
 

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -460,7 +460,7 @@
     </summary>
     <ul>
         <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
-        <li>{{ _("File uploads will progress only if you stay on this page. If you navigate away before the transfer is completed, you will end up with an incomplete file.") }}</li>
+        <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling or moving away from this page.") }}</li>
         <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
     </ul>
 </details>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -359,6 +359,8 @@
         {{ _("Transfer Files to the PiSCSI") }}
     </summary>
     <ul>
+        <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
+        <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
         <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
     </ul>
 </details>
@@ -366,11 +368,10 @@
 <form action="/files/download_url" method="post">
     <label for="download_url">{{ _("Download file from URL:") }}</label>
     <input name="url" id="download_url" required="" type="url">
-    <label for="download_destination">{{ _("Destination:") }}</label>
-    <select name="destination" id="download_destination">
-        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
-        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
-    </select>
+    <label for="disk_images">{{ _("Disk Images") }}</label>
+    <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
+    <label for="shared_files">{{ _("Shared Files") }}</label>
+    <input type="radio" name="destination" id="shared_files" value="shared_files">
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
 </form>
 </section>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -494,7 +494,7 @@
 </details>
 
 <form action="/files/download_to_iso" method="post">
-    <label for="iso_url">{{ _("URL:") }}</label>
+    <label for="iso_url">{{ _("Download file from URL:") }}</label>
     <input name="url" id="iso_url" required="" type="url">
     <label for="iso_type">{{ _("Type:") }}</label>
     <select name="type" id="iso_type">

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -6,16 +6,16 @@
 <ul>
     <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
     <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling the upload or closing this page.") }}</li>
+        <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
+        <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
 </ul>
 
+<h3>{{ _("Destination") }}</h3>
 <form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
-    <p>
-    <label for="upload_destination">{{ _("Destination:") }}</label>
-    <select name="destination" id="upload_destination">
-        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
-        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
-    </select>
-    </p>
+    <label for="disk_images">{{ _("Disk Images") }}</label>
+    <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
+    <label for="shared_files">{{ _("Shared Files") }}</label>
+    <input type="radio" name="destination" id="shared_files" value="shared_files">
 </form>
 
 <script type="application/javascript">

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -2,12 +2,11 @@
 
 {% block content %}
 <h2>{{ _("Upload File from Local Computer") }}</h2>
-<section id="upload">
 <ul>
     <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
     <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling the upload or closing this page.") }}</li>
-        <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
-        <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
+    <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
+    <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
 </ul>
 
 <h3>{{ _("Destination") }}</h3>
@@ -51,6 +50,5 @@
         }
     }
 </script>
-</section>
 
 {% endblock content %}

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>{{ _("Upload File from Local Computer") }}</h2>
+<section id="upload">
+<ul>
+    <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
+    <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling or moving away from this page.") }}</li>
+    <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
+</ul>
+
+<form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
+    <p>
+    <label for="upload_destination">{{ _("Target directory:") }}</label>
+    <select name="destination" id="upload_destination">
+        <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
+        <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
+    </select>
+    </p>
+</form>
+
+<script type="application/javascript">
+    Dropzone.options.dropper = {
+        paramName: 'file',
+        url: '/files/upload',
+        maxFilesize: {{ max_file_size }}, // max allowed file size in MiB
+        chunking: true,
+        forceChunking: true,
+        parallelChunkUploads: false,
+        chunkSize: 1048576, // 1 MiB
+        retryChunks: true,
+        retryChunksLimit: 3,
+        createImageThumbnails: false,
+        addRemoveLinks: true,
+        dictDefaultMessage: "{{ _("Drop files here to upload") }}",
+        dictFallbackMessage: "{{ _("Your browser does not support drag'n'drop file uploads.") }}",
+        dictFallbackText: "{{ _("Please use the fallback form below to upload your files like in the olden days.") }}",
+        dictFileTooBig: "{{ _("File is too big: {{filesize}}MiB. Max filesize: {{maxFilesize}}MiB.") }}",
+        dictInvalidFileType: "{{ _("You can't upload files of this type.") }}",
+        dictResponseError: "{{ _("Server responded with code: {{statusCode}}") }}",
+        dictCancelUpload:" {{ _("Click here to cancel; stay on page to continue") }}",
+        dictUploadCanceled: "{{ _("Upload canceled.") }}",
+        dictCancelUploadConfirmation: "{{ _("Are you sure you want to cancel this upload?") }}",
+        dictRemoveFile: "{{ _("Dismiss") }}",
+        dictMaxFilesExceeded: "{{ _("You can not upload any more files.") }}",
+        dictFileSizeUnits: {
+            tb: "{{ _("TiB") }}",
+            gb: "{{ _("GiB") }}",
+            mb: "{{ _("MiB") }}",
+            kb: "{{ _("KiB") }}",
+            b: "{{ _("B") }}"
+        }
+    }
+</script>
+</section>
+<p class="home"><a href="/">{{ _("Go to Home") }}</a></p>
+
+{% endblock content %}

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -5,13 +5,12 @@
 <section id="upload">
 <ul>
     <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
-    <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling or moving away from this page.") }}</li>
-    <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
+    <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling the upload or closing this page.") }}</li>
 </ul>
 
 <form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
     <p>
-    <label for="upload_destination">{{ _("Target directory:") }}</label>
+    <label for="upload_destination">{{ _("Destination:") }}</label>
     <select name="destination" id="upload_destination">
         <option value="images">{{ _("Disk Images") }} - {{ env["image_dir"] }}</option>
         <option value="file_server">{{ _("File Server") }} - {{ FILE_SERVER_DIR }}</option>
@@ -38,7 +37,7 @@
         dictFileTooBig: "{{ _("File is too big: {{filesize}}MiB. Max filesize: {{maxFilesize}}MiB.") }}",
         dictInvalidFileType: "{{ _("You can't upload files of this type.") }}",
         dictResponseError: "{{ _("Server responded with code: {{statusCode}}") }}",
-        dictCancelUpload:" {{ _("Click here to cancel; stay on page to continue") }}",
+        dictCancelUpload:" {{ _("Cancel upload") }}",
         dictUploadCanceled: "{{ _("Upload canceled.") }}",
         dictCancelUploadConfirmation: "{{ _("Are you sure you want to cancel this upload?") }}",
         dictRemoveFile: "{{ _("Dismiss") }}",
@@ -53,6 +52,5 @@
     }
 </script>
 </section>
-<p class="home"><a href="/">{{ _("Go to Home") }}</a></p>
 
 {% endblock content %}

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -955,7 +955,7 @@ def download_file():
     """
     destination = request.form.get("destination")
     url = request.form.get("url")
-    if destination == "file_server":
+    if destination == "shared_files":
         destination_dir = FILE_SERVER_DIR
     else:
         server_info = piscsi_cmd.get_server_info()

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -311,6 +311,17 @@ def drive_list():
     )
 
 
+@APP.route("/upload", methods=["GET"])
+def upload_page():
+    """
+    Sets up the data structures and kicks off the rendering of the file uploading page
+    """
+
+    return response(
+        template="upload.html",
+    )
+
+
 @APP.route("/login", methods=["POST"])
 def login():
     """

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -276,7 +276,6 @@ def index():
         reserved_scsi_ids=reserved_scsi_ids,
         image_suffixes_to_create=image_suffixes_to_create,
         valid_image_suffixes=valid_image_suffixes,
-        max_file_size=int(int(MAX_FILE_SIZE) / 1024 / 1024),
         drive_properties=format_drive_properties(APP.config["PISCSI_DRIVE_PROPERTIES"]),
         RESERVATIONS=RESERVATIONS,
         CFG_DIR=CFG_DIR,
@@ -319,6 +318,8 @@ def upload_page():
 
     return response(
         template="upload.html",
+        max_file_size=int(int(MAX_FILE_SIZE) / 1024 / 1024),
+        FILE_SERVER_DIR=FILE_SERVER_DIR,
     )
 
 


### PR DESCRIPTION
- Introduce a dedicated Upload page and move the upload form there
- Style the utility hyperlinks on the index page with icons and bold text
- Display the cancel / dismiss downloads link, and tweak the link text to make more sense. Note: Cancelled downloads won't remove the partially uploaded file.
- Hide image preview thumbnails. Not relevant to our usecase, and mess up the layout when it happens.
- Turn on chunk retries and tweaks chunk size to be a full MiB (probably won't make a big difference)