### PR TITLE
Web Interface: more layout tweaks

### DIFF
--- a/python/web/src/static/themes/classic/style.css
+++ b/python/web/src/static/themes/classic/style.css
@@ -110,6 +110,7 @@ ul.inline_list {
 
 .dropzone {
   position: relative;
+  word-break: break-all;
 }
 
 .dropzone .dz-button {
@@ -123,7 +124,7 @@ ul.inline_list {
 .dropzone .dz-preview {
   position: relative;
   display: inline-block;
-  width: 120px;
+  width: 180px;
   margin: .5em;
 }
 
@@ -147,17 +148,6 @@ ul.inline_list {
 
 .dropzone .dz-preview.dz-error .dz-error-message {
   display: block;
-}
-
-.dropzone .dz-preview.dz-error .dz-error-mark {
-  display: block;
-  filter: drop-shadow(0px 0px 2px red);
-  opacity: 0;
-}
-
-.dropzone .dz-preview.dz-success .dz-success-mark {
-  display: block;
-  filter: drop-shadow(0px 0px 2px green);
 }
 
 .dropzone .dz-preview .dz-error-mark, .dropzone .dz-preview .dz-success-mark {

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -648,16 +648,18 @@
 
 <hr/>
 
-<section id="language">
+<section id="system">
 <details>
     <summary class="heading">
-        {{ _("Language") }}
+        {{ _("System Operations") }}
     </summary>
     <ul>
-        <li>{{ _("Change the Web Interface language.") }}</li>
+        <li>{{ _("The System Name is the \"pretty\" hostname if set, with a fallback to the regular hostname.") }}</li>
+        <li>{{ _("IMPORTANT: Always shut down the system before turning off the power. Failing to do so may lead to data loss.") }}</li>
     </ul>
 </details>
 
+<div>
 <form action="/language" method="post">
     <label for="locale">{{ _("Language:") }}</label>
     <select name="locale" id="locale">
@@ -673,21 +675,7 @@
     </select>
     <input type="submit" value="{{ _("Change Language") }}">
 </form>
-</section>
-
-<hr/>
-
-<section id="system">
-<details>
-    <summary class="heading">
-        {{ _("System Operations") }}
-    </summary>
-    <ul>
-        <li>{{ _("The System Name is the \"pretty\" hostname if set, with a fallback to the regular hostname.") }}</li>
-        <li>{{ _("IMPORTANT: Always shut down the system before turning off the power. Failing to do so may lead to data loss.") }}</li>
-    </ul>
-</details>
-
+</div>
 <div>
 <form action="/sys/rename" method="post">
     <label for="system_name">{{ _("System Name:") }}</label>


### PR DESCRIPTION
- Upload page, Classic theme: Wider preview boxes, with forced text wrapping. Removed the success tick overlay, since we have other indicators of success now.
- Folded the Language section into System Commands to simplify the index page.