### PR TITLE
Fixed shutdown issues

### DIFF
--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -5,7 +5,7 @@
 //
 //	Powered by XM6 TypeG Technology.
 //	Copyright (C) 2016-2020 GIMONS
-//	Copyright (C) 2020-2022 Contributors to the PiSCSI project
+//	Copyright (C) 2020-2023 Contributors to the PiSCSI project
 //
 //---------------------------------------------------------------------------
 
@@ -146,11 +146,11 @@ PbDeviceType Piscsi::ParseDeviceType(const string& value) const
 	return type;
 }
 
-void Piscsi::TerminationHandler(int signum)
+void Piscsi::TerminationHandler(int)
 {
 	Cleanup();
 
-	exit(signum);
+	// Process will terminate automatically
 }
 
 Piscsi::optargs_type Piscsi::ParseArguments(const vector<char *>& args, int& port) const

--- a/cpp/scsictl/scsictl_core.cpp
+++ b/cpp/scsictl/scsictl_core.cpp
@@ -5,7 +5,7 @@
 //
 //	Powered by XM6 TypeG Technology.
 //	Copyright (C) 2016-2020 GIMONS
-//	Copyright (C) 2020-2022 Contributors to the PiSCSI project
+//	Copyright (C) 2020-2023 Contributors to the PiSCSI project
 //
 //---------------------------------------------------------------------------
 

--- a/cpp/scsictl/scsictl_core.cpp
+++ b/cpp/scsictl/scsictl_core.cpp
@@ -239,7 +239,7 @@ int ScsiCtl::run(const vector<char *>& args) const
 
 			case 'X':
 				command.set_operation(SHUT_DOWN);
-				SetParam(command, "mode", "piscsi");
+				SetParam(command, "mode", "rascsi");
 				break;
 
 			case 'z':


### PR DESCRIPTION
I thought this had been tested, but anyway: scsictl cannot shut down piscsi. The shutdown string remains 'rascsi' for backwards compatibility, also see piscsi_interface.proto.
In addition, the exit() call in the piscsi termination handler often resulted in a segfault (race condition).