### PR TITLE
Fix handling of properties files when they're in subdirs

### DIFF
--- a/python/common/src/piscsi/file_cmds.py
+++ b/python/common/src/piscsi/file_cmds.py
@@ -102,20 +102,13 @@ class FileCmds:
         result = proto.PbResult()
         result.ParseFromString(data)
 
-        # Get a list of all *.properties files in CFG_DIR
-        prop_data = self.list_files(PROPERTIES_SUFFIX, CFG_DIR)
-        # Get the first index of the lists in the list, containing the prop file name
-        # Then strip ".properties" for matching with the image file name
-        prop_files = [Path(x[0]).with_suffix("") for x in prop_data]
-
         server_info = self.piscsi.get_server_info()
         files = []
         for file in result.image_files_info.image_files:
+            prop_file_path = Path(CFG_DIR) / f"{file.name}.{PROPERTIES_SUFFIX}"
             # Add properties meta data for the image, if matching prop file is found
-            if Path(CFG_DIR) / file.name in prop_files:
-                process = self.read_drive_properties(
-                    Path(CFG_DIR) / f"{file.name}.{PROPERTIES_SUFFIX}"
-                )
+            if prop_file_path.exists():
+                process = self.read_drive_properties(prop_file_path)
                 prop = process["conf"]
             else:
                 prop = False

--- a/python/common/src/piscsi/file_cmds.py
+++ b/python/common/src/piscsi/file_cmds.py
@@ -4,7 +4,7 @@ Module for methods reading from and writing to the file system
 
 import logging
 import asyncio
-from os import path, walk
+from os import walk
 from functools import lru_cache
 from pathlib import PurePath, Path
 from zipfile import ZipFile, is_zipfile

--- a/python/common/src/piscsi/file_cmds.py
+++ b/python/common/src/piscsi/file_cmds.py
@@ -189,6 +189,8 @@ class FileCmds:
         Returns (dict) with (bool) status, (str) msg, (dict) parameters
         """
         parameters = {"target_path": target_path}
+        if not target_path.parent.exists():
+            target_path.parent.mkdir(parents=True)
         if target_path.parent.exists() and not target_path.exists():
             file_path.rename(target_path)
             return {
@@ -211,6 +213,8 @@ class FileCmds:
         Returns (dict) with (bool) status, (str) msg, (dict) parameters
         """
         parameters = {"target_path": target_path}
+        if not target_path.parent.exists():
+            target_path.parent.mkdir(parents=True)
         if target_path.parent.exists() and not target_path.exists():
             copyfile(str(file_path), str(target_path))
             return {
@@ -224,16 +228,18 @@ class FileCmds:
             "parameters": parameters,
         }
 
-    def create_empty_image(self, file_path, size):
+    def create_empty_image(self, target_path, size):
         """
-        Takes (Path) file_path and (int) size in bytes
+        Takes (Path) target_path and (int) size in bytes
         Creates a new empty binary file to use as image
         Returns (dict) with (bool) status, (str) msg, (dict) parameters
         """
-        parameters = {"target_path": file_path}
-        if file_path.parent.exists() and not file_path.exists():
+        parameters = {"target_path": target_path}
+        if not target_path.parent.exists():
+            target_path.parent.mkdir(parents=True)
+        if target_path.parent.exists() and not target_path.exists():
             try:
-                with open(f"{file_path}", "wb") as out:
+                with open(f"{target_path}", "wb") as out:
                     out.seek(size - 1)
                     out.write(b"\0")
             except OSError as error:

--- a/python/common/src/piscsi/file_cmds.py
+++ b/python/common/src/piscsi/file_cmds.py
@@ -55,26 +55,6 @@ class FileCmds:
         return self.sock_cmd.send_pb_command(command.SerializeToString())
 
     # noinspection PyMethodMayBeStatic
-    # pylint: disable=no-self-use
-    def list_files(self, file_types, dir_path):
-        """
-        Takes a (list) or (tuple) of (str) file_types - e.g. ('hda', 'hds')
-        Returns (list) of (list)s files_list:
-        index 0 is (str) file path and index 1 is (int) size in bytes
-        """
-        files_list = []
-        for file_path, _dirs, files in walk(dir_path):
-            # Only list selected file types
-            files = [file for file in files if file.lower().endswith(file_types)]
-            files_list.extend(
-                [
-                    (path.join(file_path, file), path.getsize(path.join(file_path, file)))
-                    for file in files
-                ],
-            )
-        return files_list
-
-    # noinspection PyMethodMayBeStatic
     def list_config_files(self):
         """
         Finds fils with file ending CONFIG_FILE_SUFFIX in CFG_DIR.

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -388,7 +388,7 @@ def drive_create():
     Creates the image and properties file pair
     """
     drive_name = request.form.get("drive_name")
-    file_name = Path(request.form.get("file_name")).name
+    file_name = Path(request.form.get("file_name"))
 
     properties = get_properties_by_drive_name(APP.config["PISCSI_DRIVE_PROPERTIES"], drive_name)
 
@@ -431,7 +431,7 @@ def drive_cdrom():
     Creates a properties file for a CD-ROM image
     """
     drive_name = request.form.get("drive_name")
-    file_name = Path(request.form.get("file_name")).name
+    file_name = Path(request.form.get("file_name"))
 
     # Creating the drive properties file
     file_name = f"{file_name}.{PROPERTIES_SUFFIX}"


### PR DESCRIPTION
- File operation class methods create parent dirs if they don't exist
- Avoid stripping path from file names in several places
- Simplify prop file matching logic: check for existence of file
- Remove list_files() method which is now unused