### PR TITLE
Ability to download and upload config files

### DIFF
--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -49,6 +49,10 @@ a:hover {
   text-decoration: none;
 }
 
+input[type="radio"] {
+  margin: 0 0.1rem 0 0.75rem;
+}
+
 /*
  ------------------------------------------------------------------------------
  Tables
@@ -143,10 +147,6 @@ select {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-}
-
-.dropzone label {
-  padding: 0 0.5rem;
 }
 
 .dropzone p,

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -30,7 +30,7 @@
     </select>
     <input name="load" type="submit" value="{{ _("Load") }}" onclick="return confirm('{{ _("Detach all current device and Load configuration?") }}')">
     <input name="delete" type="submit" value="{{ _("Delete") }}" onclick="return confirm('{{ _("Delete configuration file?") }}')">
-    <input name="download" type="submit" value="{{ _("Download") }}">
+    <input name="send" type="submit" value="{{ _("Download") }}">
 </form>
 </p>
 

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -13,7 +13,7 @@
 </details>
 
 <p>
-<form action="/config/load" method="post" id="config-actions">
+<form action="/config/action" method="post" id="config-actions">
     <label for="config_load_name">{{ _("File Name:") }}</label>
     <select name="name" id="config_load_name" required="" width="14">
         {% if config_files %}
@@ -30,6 +30,7 @@
     </select>
     <input name="load" type="submit" value="{{ _("Load") }}" onclick="return confirm('{{ _("Detach all current device and Load configuration?") }}')">
     <input name="delete" type="submit" value="{{ _("Delete") }}" onclick="return confirm('{{ _("Delete configuration file?") }}')">
+    <input name="download" type="submit" value="{{ _("Download") }}">
 </form>
 </p>
 

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -369,10 +369,10 @@
 <form action="/files/download_url" method="post">
     <label for="download_url">{{ _("Download file from URL:") }}</label>
     <input name="url" id="download_url" required="" type="url">
-    <label for="disk_images">{{ _("Disk Images") }}</label>
     <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
-    <label for="shared_files">{{ _("Shared Files") }}</label>
+    <label for="disk_images">{{ _("Disk Images") }}</label>
     <input type="radio" name="destination" id="shared_files" value="shared_files">
+    <label for="shared_files">{{ _("Shared Files") }}</label>
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
 </form>
 </section>

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -12,12 +12,12 @@
 
 <h3>{{ _("Destination") }}</h3>
 <form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
-    <label for="disk_images">{{ _("Disk Images") }}</label>
     <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
-    <label for="shared_files">{{ _("Shared Files") }}</label>
+    <label for="disk_images">{{ _("Disk Images") }}</label>
     <input type="radio" name="destination" id="shared_files" value="shared_files">
-    <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
+    <label for="shared_files">{{ _("Shared Files") }}</label>
     <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
+    <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
 </form>
 
 <script type="application/javascript">

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -7,6 +7,7 @@
     <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling the upload or closing this page.") }}</li>
     <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
     <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
+    <li>{{ _("PiSCSI Config") }} = {{ CFG_DIR }}</li>
 </ul>
 
 <h3>{{ _("Destination") }}</h3>
@@ -15,6 +16,8 @@
     <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
     <label for="shared_files">{{ _("Shared Files") }}</label>
     <input type="radio" name="destination" id="shared_files" value="shared_files">
+    <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
+    <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
 </form>
 
 <script type="application/javascript">

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -495,12 +495,12 @@ def config_action():
 
         return response(error=True, message=process["msg"])
 
-    if "download" in request.form:
+    if "send" in request.form:
         return send_from_directory(CFG_DIR, str(file_name), as_attachment=True)
 
     return response(
         error=True,
-        message="No known operation in request header. Expected one of: load, delete, download",
+        message="No known operation in request header. Expected one of: load, delete, send",
     )
 
 

--- a/python/web/tests/api/test_settings.py
+++ b/python/web/tests/api/test_settings.py
@@ -167,14 +167,7 @@ def test_download_configs(env, http_client, delete_file):
         },
     )
 
-    response_data = response.json()
-
     assert response.status_code == 200
-    assert response_data["status"] == STATUS_SUCCESS
-    assert response_data["messages"][0]["message"] == (
-        f"File created: {env['cfg_dir']}/{config_json_file}"
-    )
-
     assert config_json_file in http_client.get("/").json()["data"]["config_files"]
 
     # Download the saved config
@@ -202,11 +195,6 @@ def test_download_configs(env, http_client, delete_file):
     response_data = response.json()
 
     assert response.status_code == 200
-    assert response_data["status"] == STATUS_SUCCESS
-    assert response_data["messages"][0]["message"] == (
-        f"File deleted: {env['cfg_dir']}/{config_json_file}"
-    )
-
     assert config_json_file not in http_client.get("/").json()["data"]["config_files"]
 
 

--- a/python/web/tests/api/test_settings.py
+++ b/python/web/tests/api/test_settings.py
@@ -115,7 +115,7 @@ def test_save_load_and_delete_configs(env, http_client):
 
     # Load the saved config
     response = http_client.post(
-        "/config/load",
+        "/config/action",
         data={
             "name": config_json_file,
             "load": True,
@@ -135,7 +135,7 @@ def test_save_load_and_delete_configs(env, http_client):
 
     # Delete the saved config
     response = http_client.post(
-        "/config/load",
+        "/config/action",
         data={
             "name": config_json_file,
             "delete": True,

--- a/python/web/tests/api/test_settings.py
+++ b/python/web/tests/api/test_settings.py
@@ -192,8 +192,6 @@ def test_download_configs(env, http_client, delete_file):
         },
     )
 
-    response_data = response.json()
-
     assert response.status_code == 200
     assert config_json_file not in http_client.get("/").json()["data"]["config_files"]
 


### PR DESCRIPTION
- Rename `/config/load` endpoint to `/config/action` since it has multiple functions
- Add a `send` function to above endpoint, which triggers a download of the config file, and use it with a new Download button on the index page
- Add an option to upload to the CFG_DIR
- Improve layout of the file transfer destination web form: radio buttons before labels, and better padding between options
- Add a test for config downloading