### PR TITLE
Web UI: Noscript fallback messages; relocate js into templates

### DIFF
--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -53,6 +53,15 @@ input[type="radio"] {
   margin: 0 0.1rem 0 0.75rem;
 }
 
+div.noscriptmsg {
+  background: var(--danger);
+  border-radius: var(--border-radius);
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  display: inline-block;
+  color: #fff;
+}
+
 /*
  ------------------------------------------------------------------------------
  Tables

--- a/python/web/src/templates/base.html
+++ b/python/web/src/templates/base.html
@@ -23,20 +23,6 @@
     <meta name="theme-color" content="#ffffff">
 
     <link rel="stylesheet" href="{{ url_for('static', filename=current_theme_stylesheet) }}">
-
-    <script type="application/javascript">
-        var processNotify = function(Notification) {
-            document.getElementById("flash").innerHTML = "<div class=\"info\"><div>" + Notification + "{{ _(" This process may take a while, and will continue in the background if you navigate away from this page.") }}</div></div>";
-            window.scrollTo(0,0);
-        }
-
-        var shutdownNotify = function(Notification) {
-            document.getElementById("flash").innerHTML = "<div class=\"warning\"><div>" + Notification + "{{ _(" The Web Interface will become unresponsive momentarily. Reload this page after the Pi has started up again.") }}</div></div>";
-            window.scrollTo(0,0);
-        }
-    </script>
-
-    <script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
 </head>
 
 <body class="{{ body_classes|join(' ') }}">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -1,6 +1,18 @@
 {% extends "base.html" %}
 {% block content %}
 
+<script type="application/javascript">
+    var processNotify = function(Notification) {
+        document.getElementById("flash").innerHTML = "<div class=\"info\"><div>" + Notification + "{{ _(" This process may take a while, and will continue in the background if you navigate away from this page.") }}</div></div>";
+        window.scrollTo(0,0);
+    }
+
+    var shutdownNotify = function(Notification) {
+        document.getElementById("flash").innerHTML = "<div class=\"warning\"><div>" + Notification + "{{ _(" The Web Interface will become unresponsive momentarily. Reload this page after the Pi has started up again.") }}</div></div>";
+        window.scrollTo(0,0);
+    }
+</script>
+
 <section id="current-config">
 <details>
     <summary class="heading">
@@ -380,6 +392,14 @@
 <section id="upload">
     <a href="/upload" target="_blank"><p>{{ _("Upload Files (new tab)") }}</p></a>
 </section>
+<noscript>
+    <style type="text/css">
+        section#upload { display: none; }
+    </style>
+    <div class="noscriptmsg">
+        {{ _("The file uploading functionality requires JavaScript.") }}
+    </div>
+</noscript>
 
 <hr/>
 

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -20,6 +20,8 @@
     <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
 </form>
 
+<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
+
 <script type="application/javascript">
     Dropzone.options.dropper = {
         paramName: 'file',
@@ -54,6 +56,10 @@
     }
 </script>
 
-<noscript><p>{{ _("The file uploading functionality requires JavaScript.") }}</p></noscript>
+<noscript>
+    <div class="noscriptmsg">
+        {{ _("The file uploading functionality requires JavaScript.") }}
+    </div>
+</noscript>
 
 {% endblock content %}


### PR DESCRIPTION
- Flesh out and style the noscript messages. Hide the link to the upload page when scripts are disabled.
- Move embedded scripts to the specific template where they're used, to save vintage browsers the effort (and avoid unhelpful errors)