### PR TITLE
Add support for SCSI-1 CD Drives, .is1 extension

### DIFF
--- a/cpp/devices/device_factory.cpp
+++ b/cpp/devices/device_factory.cpp
@@ -59,6 +59,7 @@ DeviceFactory::DeviceFactory()
 	extension_mapping["hdr"] = SCRM;
 	extension_mapping["mos"] = SCMO;
 	extension_mapping["iso"] = SCCD;
+	extension_mapping["is1"] = SCCD;
 
 	device_mapping["bridge"] = SCBR;
 	device_mapping["daynaport"] = SCDP;
@@ -118,7 +119,8 @@ shared_ptr<PrimaryDevice> DeviceFactory::CreateDevice(PbDeviceType type, int lun
 		break;
 
 	case SCCD:
-		device = make_shared<SCSICD>(lun, sector_sizes.find(SCCD)->second);
+		device = make_shared<SCSICD>(lun, sector_sizes.find(SCCD)->second,
+            GetExtensionLowerCase(filename) == "is1" ? scsi_level::SCSI_1_CCS : scsi_level::SCSI_2);
 		device->SetProduct("SCSI CD-ROM");
 		break;
 

--- a/cpp/devices/scsicd.cpp
+++ b/cpp/devices/scsicd.cpp
@@ -21,7 +21,8 @@
 using namespace scsi_defs;
 using namespace scsi_command_util;
 
-SCSICD::SCSICD(int lun, const unordered_set<uint32_t>& sector_sizes) : Disk(SCCD, lun)
+SCSICD::SCSICD(int lun, const unordered_set<uint32_t>& sector_sizes, scsi_defs::scsi_level level) 
+	: Disk(SCCD, lun), scsi_level(level)
 {
 	SetSectorSizes(sector_sizes);
 
@@ -164,7 +165,7 @@ void SCSICD::ReadToc()
 
 vector<uint8_t> SCSICD::InquiryInternal() const
 {
-	return HandleInquiry(device_type::CD_ROM, scsi_level::SCSI_2, true);
+	return HandleInquiry(device_type::CD_ROM, scsi_level, true);
 }
 
 void SCSICD::SetUpModePages(map<int, vector<byte>>& pages, int page, bool changeable) const

--- a/cpp/devices/scsicd.h
+++ b/cpp/devices/scsicd.h
@@ -22,7 +22,7 @@ class SCSICD : public Disk, private ScsiMmcCommands
 {
 public:
 
-	SCSICD(int, const unordered_set<uint32_t>&);
+	SCSICD(int, const unordered_set<uint32_t>&, scsi_defs::scsi_level = scsi_level::SCSI_2);
 	~SCSICD() override = default;
 
 	bool Init(const unordered_map<string, string>&) override;
@@ -43,6 +43,7 @@ private:
 
 	void AddCDROMPage(map<int, vector<byte>>&, bool) const;
 	void AddCDDAPage(map<int, vector<byte>>&, bool) const;
+	scsi_defs::scsi_level scsi_level;
 
 	void OpenIso();
 	void OpenPhysical();

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -62,7 +62,8 @@ void Piscsi::Banner(const vector<char *>& args) const
 		cout << "  hdi : SCSI HD image (Anex86 HD image)\n";
 		cout << "  nhd : SCSI HD image (T98Next HD image)\n";
 		cout << "  mos : SCSI MO image (MO image)\n";
-		cout << "  iso : SCSI CD image (ISO 9660 image)\n" << flush;
+		cout << "  iso : SCSI CD image (ISO 9660 image)\n";
+		cout << "  is1 : SCSI CD image (ISO 9660 image, SCSI-1)\n" << flush;
 
 		exit(EXIT_SUCCESS);
 	}

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -29,6 +29,7 @@ TEST(DeviceFactoryTest, GetTypeForFile)
 	EXPECT_EQ(device_factory.GetTypeForFile("test.hdr"), SCRM);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.mos"), SCMO);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.iso"), SCCD);
+	EXPECT_EQ(device_factory.GetTypeForFile("test.is1"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.suffix.iso"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("bridge"), SCBR);
 	EXPECT_EQ(device_factory.GetTypeForFile("daynaport"), SCDP);
@@ -89,6 +90,7 @@ TEST(DeviceFactoryTest, GetExtensionMapping)
 	EXPECT_EQ(SCRM, mapping["hdr"]);
 	EXPECT_EQ(SCMO, mapping["mos"]);
 	EXPECT_EQ(SCCD, mapping["iso"]);
+	EXPECT_EQ(SCCD, mapping["is1"]);
 }
 
 TEST(DeviceFactoryTest, GetDefaultParams)

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -80,7 +80,7 @@ TEST(DeviceFactoryTest, GetExtensionMapping)
 	DeviceFactory device_factory;
 
 	unordered_map<string, PbDeviceType> mapping = device_factory.GetExtensionMapping();
-	EXPECT_EQ(9, mapping.size());
+	EXPECT_EQ(10, mapping.size());
 	EXPECT_EQ(SCHD, mapping["hd1"]);
 	EXPECT_EQ(SCHD, mapping["hds"]);
 	EXPECT_EQ(SCHD, mapping["hda"]);

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -221,5 +221,5 @@ TEST(PiscsiResponseTest, GetMappingInfo)
 
 	const auto& info = response.GetMappingInfo(result);
 	EXPECT_TRUE(result.status());
-	EXPECT_EQ(9, info->mapping().size());
+	EXPECT_EQ(10, info->mapping().size());
 }

--- a/cpp/test/scsicd_test.cpp
+++ b/cpp/test/scsicd_test.cpp
@@ -30,6 +30,8 @@ void ScsiCdTest_SetUpModePages(map<int, vector<byte>>& pages)
 TEST(ScsiCdTest, Inquiry)
 {
 	TestInquiry(SCCD, device_type::CD_ROM, scsi_level::SCSI_2, "PiSCSI  SCSI CD-ROM     ", 0x1f, true);
+
+	TestInquiry(SCCD, device_type::CD_ROM, scsi_level::SCSI_1_CCS, "PiSCSI  SCSI CD-ROM     ", 0x1f, true, ".is1");
 }
 
 TEST(ScsiCdTest, SetUpModePages)

--- a/doc/piscsi.1
+++ b/doc/piscsi.1
@@ -34,6 +34,7 @@ PiSCSI will determine the type of device based upon the file extension of the FI
     hda: SCSI Hard Disk image (Apple compatible - typically used with Macintosh computers)
     mos: SCSI Magneto-Optical image (generic - typically used with NeXT, X68000, etc.)
     iso: SCSI CD-ROM or DVD-ROM image (ISO 9660 image)
+    is1: SCSI CD-ROM or DVD-ROM image (ISO 9660 image, SCSI-1)
   
 For example, if you want to specify an Apple-compatible HD image on ID 0, you can use the following command:
     sudo piscsi -ID0 /path/to/drive/hdimage.hda

--- a/doc/piscsi_man_page.txt
+++ b/doc/piscsi_man_page.txt
@@ -29,6 +29,7 @@ DESCRIPTION
            hda: SCSI Hard Disk image (Apple compatible - typically used with Macintosh computers)
            mos: SCSI Magneto-Optical image (generic - typically used with NeXT, X68000, etc.)
            iso: SCSI CD-ROM or DVD-ROM image (ISO 9660 image)
+           is1: SCSI CD-ROM or DVD-ROM image (ISO 9660 image, SCSI-1)
 
        For example, if you want to specify an Apple-compatible HD image on ID 0, you can use the following command:
            sudo piscsi -ID0 /path/to/drive/hdimage.hda


### PR DESCRIPTION
I ran into the same issue as described in https://github.com/PiSCSI/piscsi/issues/799, except with a CD Drive.
To fix this, I copied everything that was implemented for .hd1 SCSI-1 image files over to the scsicd device.
I chose .is1 as the file extension to remain consistent with the .hd1 extension.

This fixes my issues booting from an emulated cd drive on a VAXstation 3100. I also tested that everything is still working as expected on a SPARCstation 5.

I also edited the tests, they pass in the github workflow.