### PR TITLE
Bump to Netatalk 2.x 230301

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -712,7 +712,7 @@ function setupWirelessNetworking() {
 
 # Downloads, compiles, and installs Netatalk (AppleShare server)
 function installNetatalk() {
-    NETATALK_VERSION="230202"
+    NETATALK_VERSION="230301"
     NETATALK_CONFIG_PATH="/etc/netatalk"
     NETATALK_OPTIONS="--cores=$CORES --share-name='$FILE_SHARE_NAME' --share-path='$FILE_SHARE_PATH'"
 


### PR DESCRIPTION
This version notably make the netatalk services start up more reliably on a wifi only device such as RPi Zero