### PR TITLE
Web UI: Remove git hash info

### DIFF
--- a/python/common/src/piscsi/sys_cmds.py
+++ b/python/common/src/piscsi/sys_cmds.py
@@ -21,23 +21,8 @@ class SysCmds:
     @staticmethod
     def running_env():
         """
-        Returns (str) git and (str) env
-        git contains the git hash of the checked out code
-        env is the various system information where this app is running
+        Returns (str) env, with details on the system hardware and software
         """
-        try:
-            ra_git_version = (
-                subprocess.run(
-                    ["git", "rev-parse", "HEAD"],
-                    capture_output=True,
-                    check=True,
-                )
-                .stdout.decode("utf-8")
-                .strip()
-            )
-        except subprocess.CalledProcessError as error:
-            logging.warning(SHELL_ERROR, error.cmd, error.stderr.decode("utf-8"))
-            ra_git_version = ""
 
         PROC_MODEL_PATH = "/proc/device-tree/model"
         SYS_VENDOR_PATH = "/sys/devices/virtual/dmi/id/sys_vendor"
@@ -67,7 +52,6 @@ class SysCmds:
 
         env = uname()
         return {
-            "git": ra_git_version,
             "env": f"{hardware}, {env.system} {env.release} {env.machine}",
         }
 

--- a/python/web/src/templates/base.html
+++ b/python/web/src/templates/base.html
@@ -117,7 +117,7 @@
             {% endif %}
         </div>
         <div>
-            {{ _("PiSCSI version:") }} <b>{{ env["version"] }} <a href="https://github.com/PiSCSI/piscsi/commit/{{ env["running_env"]["git"] }}" target="_blank">{{ env["running_env"]["git"][:7] }}</a></b>
+	    {{ _("PiSCSI software version:") }} <b>{{ env["version"] }}</b>
         </div>
         <div>
             {{ _("Hardware and OS:") }} {{ env["running_env"]["env"] }}


### PR DESCRIPTION
This removes the git hash from the 'env' data structure, and from the web UI footer.
I originally added this to make troubleshooting easier, since the user could easily tell us what version of the software they're running.
However, it does not work reliably, and causes a lot of noise in logs when failing.