### PR TITLE
Web UI: Handling for non-existence of working dirs

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -383,8 +383,11 @@
     </summary>
     <ul>
         <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
+	{% if file_server_dir_exists %}
         <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
-        <li>{{ _("To access shared files remotely, you may have to install one of the file servers first.") }}</li>
+	{% else %}
+        <li>{{ _("Install a file server and create the shared files directory in order to share files between the Pi and your vintage computers.") }}</li>
+	{% endif %}
     </ul>
 </details>
 
@@ -399,6 +402,7 @@
     {% endfor %}
     <option value="/" selected>/</option>
     </select>
+    {% if file_server_dir_exists %}
     <input type="radio" name="destination" id="shared_files" value="shared_files">
     <label for="shared_files">{{ _("Shared Files") }}</label>
     <select name="shared_subdir" id="shared_subdir">
@@ -407,6 +411,7 @@
     {% endfor %}
     <option value="/" selected>/</option>
     </select>
+    {% endif %}
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">
 </form>
 </section>

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -6,7 +6,9 @@
     <li>{{ _("The largest file size accepted in this form is %(max_file_size)s MiB. Use other file transfer means for larger files.", max_file_size=max_file_size) }}</li>
     <li>{{ _("You have to manually clean up partially uploaded files, as a result of cancelling the upload or closing this page.") }}</li>
     <li>{{ _("Disk Images") }} = {{ env["image_dir"] }}</li>
+    {% if file_server_dir_exists %}
     <li>{{ _("Shared Files") }} = {{ FILE_SERVER_DIR }}</li>
+    {% endif %}
     <li>{{ _("PiSCSI Config") }} = {{ CFG_DIR }}</li>
 </ul>
 
@@ -20,6 +22,7 @@
     {% endfor %}
     <option value="/" selected>/</option>
     </select>
+    {% if file_server_dir_exists %}
     <input type="radio" name="destination" id="shared_files" value="shared_files">
     <label for="shared_files">{{ _("Shared Files") }}</label>
     <select name="shared_subdir" id="shared_subdir">
@@ -28,6 +31,7 @@
     {% endfor %}
     <option value="/" selected>/</option>
     </select>
+    {% endif %}
     <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
     <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
 </form>

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -9,11 +9,24 @@ from pathlib import Path
 from ua_parser import user_agent_parser
 from re import findall
 
-from flask import request, make_response
+from flask import request, make_response, abort
 from flask_babel import _
 from werkzeug.utils import secure_filename
 
 from piscsi.sys_cmds import SysCmds
+
+
+def working_dirs_exist(working_dirs):
+    """
+    Method for validating that working dirs exist.
+    Takes (tuple) of (str) working dirs with paths to required dirs.
+    """
+    for path in working_dirs:
+        if not Path(path).exists():
+            abort(
+                503,
+                _(f"Please create directory: {path}"),
+            )
 
 
 def get_valid_scsi_ids(devices, reserved_ids):

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -19,13 +19,13 @@ from piscsi.sys_cmds import SysCmds
 def working_dirs_exist(working_dirs):
     """
     Method for validating that working dirs exist.
-    Takes (tuple) of (str) working dirs with paths to required dirs.
+    Takes (tuple) of (str) working_dirs with paths to required dirs.
     """
-    for path in working_dirs:
-        if not Path(path).exists():
+    for dir_path in working_dirs:
+        if not Path(dir_path).exists():
             abort(
                 503,
-                _(f"Please create directory: {path}"),
+                _(f"Please create directory: {dir_path}"),
             )
 
 


### PR DESCRIPTION
- webapp utility method for checking the existence of images and cfg dirs
- immediately bail out if either is missing
- hide file sharing elements when shared files dir is missing

Bonus:
- move the backend auth check to the web server startup method, and make it an exception
- easyinstall: make sure shared files dir is created in either of the file server installation scripts