### PR TITLE
Remove SonarCloud cache setup as it is now offered by default

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -93,28 +93,16 @@ jobs:
         working-directory: cpp
         run: gcov --preserve-paths $(find -name '*.gcno')
 
-      - uses: actions/cache@v3
-        name: Cache SonarCloud scan cache
-        id: sonar-scan-cache
-        with:
-          path: ~/.sonar_cache/
-          key: sonar-scan-cache-${{ env.SONAR_SCANNER_VERSION }}-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-          restore-keys: |
-            sonar-scan-cache-${{ env.SONAR_SCANNER_VERSION }}-${{ github.ref_name }}
-
       - name: Run sonar-scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
-          (mkdir -p $HOME/.sonar_cache || true) &&
           $HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin/sonar-scanner
           --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"
           --define sonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
           --define sonar.organization=${{ env.SONAR_ORGANIZATION }}
           --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
           --define sonar.cfamily.gcov.reportsPath=.
-          --define sonar.cfamily.cache.enabled=true
-          --define sonar.cfamily.cache.path="$HOME/.sonar_cache/"
           --define sonar.coverage.exclusions="cpp/**/test/**"
           --define sonar.cpd.exclusions="cpp/**/test/**"
           --define sonar.inclusions="cpp/**,python/**"


### PR DESCRIPTION
No need to configure the cache anymore, SonarCloud now has an automatic analysis caching. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.