### PR TITLE
Fixed a potential issue with the unit test order (reserved file cleanup was missing)

### DIFF
--- a/cpp/hal/gpiobus_raspberry.cpp
+++ b/cpp/hal/gpiobus_raspberry.cpp
@@ -87,7 +87,7 @@ bool GPIOBUS_Raspberry::Init(mode_e mode)
     // Map peripheral region memory
     void *map = mmap(NULL, 0x1000100, PROT_READ | PROT_WRITE, MAP_SHARED, fd, baseaddr);
     if (map == MAP_FAILED) {
-        LOGERROR("Error: Unable to map memory")
+        LOGERROR("Error: Unable to map memory: %s", strerror(errno))
         close(fd);
         return false;
     }

--- a/cpp/test/piscsi_image_test.cpp
+++ b/cpp/test/piscsi_image_test.cpp
@@ -39,6 +39,8 @@ TEST(PiscsiImageTest, CreateImage)
 	PbCommand command;
 	PiscsiImage image;
 
+	StorageDevice::UnreserveAll();
+
 	EXPECT_FALSE(image.CreateImage(context, command)) << "Filename must be reported as missing";
 
 	SetParam(command, "file", "/a/b/c/filename");
@@ -63,6 +65,8 @@ TEST(PiscsiImageTest, DeleteImage)
 	PbCommand command;
 	PiscsiImage image;
 
+	StorageDevice::UnreserveAll();
+
 	EXPECT_FALSE(image.DeleteImage(context, command)) << "Filename must be reported as missing";
 
 	SetParam(command, "file", "/a/b/c/filename");
@@ -82,6 +86,8 @@ TEST(PiscsiImageTest, RenameImage)
 	PbCommand command;
 	PiscsiImage image;
 
+	StorageDevice::UnreserveAll();
+
 	EXPECT_FALSE(image.RenameImage(context, command)) << "Source filename must be reported as missing";
 
 	SetParam(command, "from", "/a/b/c/filename_from");
@@ -99,6 +105,8 @@ TEST(PiscsiImageTest, CopyImage)
 	PbCommand command;
 	PiscsiImage image;
 
+	StorageDevice::UnreserveAll();
+
 	EXPECT_FALSE(image.CopyImage(context, command)) << "Source filename must be reported as missing";
 
 	SetParam(command, "from", "/a/b/c/filename_from");
@@ -115,6 +123,8 @@ TEST(PiscsiImageTest, SetImagePermissions)
 	MockCommandContext context;
 	PbCommand command;
 	PiscsiImage image;
+
+	StorageDevice::UnreserveAll();
 
 	EXPECT_FALSE(image.SetImagePermissions(context, command)) << "Filename must be reported as missing";
 


### PR DESCRIPTION
In addition updated the error handling to be more precise in case mmap() fails on kernels where CONFIG_STRICT_DEVMEM is set.