### PR TITLE
Remove bogus pkg-resources library from requirements.txt

### DIFF
--- a/python/oled/requirements.txt
+++ b/python/oled/requirements.txt
@@ -1,4 +1,3 @@
-pkg-resources==0.0.0
 adafruit-circuitpython-ssd1306==2.12.11
 Pillow==9.3.0
 protobuf==3.20.2


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463