### PR TITLE
Remove use of deprecated before_first_request decorator

### DIFF
--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1369,15 +1369,16 @@ def healthcheck():
     return "", 200
 
 
-@APP.before_first_request
+@APP.before_request
 def detect_locale():
     """
     Get the detected locale to use for UI string translations.
     This requires the Flask app to have started first.
     """
-    session["language"] = get_locale()
-    piscsi_cmd.locale = session["language"]
-    file_cmd.locale = session["language"]
+    if "language" not in session.keys():
+        session["language"] = get_locale()
+        piscsi_cmd.locale = session["language"]
+        file_cmd.locale = session["language"]
 
 
 @APP.before_request


### PR DESCRIPTION
This runs the `detect_locale()` check for each request, but adds a check if `session["language"]` has already been set.