### PR TITLE
Always assign locale in detect_locale()

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
       context: ..
       dockerfile: docker/web/Dockerfile
       args:
-        - OS_VERSION=buster
+        - OS_VERSION=bullseye
     volumes:
       - ./volumes/images:/home/pi/images:delegated
     init: true

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1377,8 +1377,9 @@ def detect_locale():
     """
     if "language" not in session.keys():
         session["language"] = get_locale()
-        piscsi_cmd.locale = session["language"]
-        file_cmd.locale = session["language"]
+
+    piscsi_cmd.locale = session["language"]
+    file_cmd.locale = session["language"]
 
 
 @APP.before_request

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1373,7 +1373,7 @@ def healthcheck():
 def detect_locale():
     """
     Get the detected locale to use for UI string translations.
-    This requires the Flask app to have started first.
+    Assign the language string to objects to be used for requests.
     """
     if "language" not in session.keys():
         session["language"] = get_locale()


### PR DESCRIPTION
Turns out there are scenarios when session["language"] is set but not assigned to the respective piscsi_cmd and file_cmd object members. 

This change always executes said assignment in detect_locale().