### PR TITLE
WebUI: Proper handling of custom image dirs, #1170

### DIFF
--- a/python/common/src/piscsi/sys_cmds.py
+++ b/python/common/src/piscsi/sys_cmds.py
@@ -102,12 +102,12 @@ class SysCmds:
         return False
 
     @staticmethod
-    def disk_space():
+    def disk_space(path):
         """
-        Returns a (dict) with (int) total (int) used (int) free
-        This is the disk space information of the volume where this app is running
+        Takes (str) path with the path to the dir / mount point to inspect
+        Returns a (dict) with (int) total (int) used (int) free disk space
         """
-        total, used, free = disk_usage(__file__)
+        total, used, free = disk_usage(path)
         return {"total": total, "used": used, "free": free}
 
     @staticmethod

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -218,7 +218,7 @@
 <div>
 {% for subdir, group in formatted_image_files.items() %}
 
-<details class="subdir"{% if subdir == "images/" %} open{% endif %}>
+<details class="subdir"{% if subdir == env["image_root_dir"] + "/" %} open{% endif %}>
     <summary class="dirname">
         {{ subdir }}
     </summary>
@@ -371,7 +371,7 @@
 {% endfor %}
 </div>
 {% endif %}
-<p><small>{{ _("%(disk_space)s MiB disk space remaining on the system", disk_space=env["free_disk_space"]) }}</small></p>
+<p><small>{{ _("%(disk_space)s MiB disk space remaining for images", disk_space=env["free_disk_space"]) }}</small></p>
 </section>
 
 <hr/>

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -96,10 +96,11 @@ def get_env_info():
         "ip_addr": ip_addr,
         "host": host,
         "system_name": sys_cmd.get_pretty_host(),
-        "free_disk_space": int(sys_cmd.disk_space()["free"] / 1024 / 1024),
+        "free_disk_space": int(sys_cmd.disk_space(server_info["image_dir"])["free"] / 1024 / 1024),
         "locale": get_locale(),
         "version": server_info["version"],
         "image_dir": server_info["image_dir"],
+        "image_root_dir": Path(server_info["image_dir"]).name,
         "netatalk_configured": sys_cmd.running_proc("afpd"),
         "macproxy_configured": sys_cmd.running_proc("macproxy"),
         "cd_suffixes": tuple(server_info["sccd"]),
@@ -217,7 +218,9 @@ def index():
     image_files = file_cmd.list_images()
     config_files = file_cmd.list_config_files()
     ip_addr, host = sys_cmd.get_ip_and_host()
-    formatted_image_files = format_image_list(image_files["files"], device_types)
+    formatted_image_files = format_image_list(
+        image_files["files"], Path(server_info["image_dir"]).name, device_types
+    )
 
     attached_images = []
     units = 0

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -160,9 +160,12 @@ def get_image_description(file_suffix):
     return file_suffix
 
 
-def format_image_list(image_files, device_types=None):
+def format_image_list(image_files, rootdir, device_types=None):
     """
-    Takes a (list) of (dict) image_files and optional (list) device_types
+    Takes:
+    - (list) of (dict) image_files
+    - (str) rootdir, the name of the images root dir
+    - optional (list) device_types
     Returns a formatted (dict) with groups of image_files per subdir key
     """
 
@@ -174,16 +177,16 @@ def format_image_list(image_files, device_types=None):
         subdir_path = findall("^.*/", image["name"])
         if subdir_path:
             subdir = subdir_path[0]
-            if f"images/{subdir}" in subdir_image_files.keys():
-                subdir_image_files[f"images/{subdir}"].append(image)
+            if f"{rootdir}/{subdir}" in subdir_image_files.keys():
+                subdir_image_files[f"{rootdir}/{subdir}"].append(image)
             else:
-                subdir_image_files[f"images/{subdir}"] = [image]
+                subdir_image_files[f"{rootdir}/{subdir}"] = [image]
         else:
             root_image_files.append(image)
 
     formatted_image_files = dict(sorted(subdir_image_files.items()))
     if root_image_files:
-        formatted_image_files["images/"] = root_image_files
+        formatted_image_files[f"{rootdir}/"] = root_image_files
     return formatted_image_files
 
 


### PR DESCRIPTION
The Web UI's image file manager currently assumes that the image dir is called "images".
Also, it assumes that the images dir is located on the same file system as the python runtime for the purpose of calculating available disk space.

This change addresses both assumptions.