### PR TITLE
Remove limitation on the location of the images dir, #1172

### DIFF
--- a/cpp/piscsi/piscsi_image.cpp
+++ b/cpp/piscsi/piscsi_image.cpp
@@ -71,8 +71,8 @@ string PiscsiImage::SetDefaultFolder(const string& f)
 		folder = GetHomeDir() + "/" + folder;
 	}
 	else {
-		if (folder.find("/home/") != 0) {
-			return "Default image folder must be located in '/home/'";
+		if (folder == "/") {
+			return "Default image folder cannot be '/'";
 		}
 	}
 


### PR DESCRIPTION
Rather than allowing only subdirs of /home as default image dir, this change only disallows the file system root itself.

A user may want to use mountpoints in /mnt, for instance, as the images dir.