### PR TITLE
Improve invalid path error handling, and escape single quotes in javascript

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -341,17 +341,17 @@
                     <input type="submit" value="{{ _("Attach") }}" title="{{ _("Attach") }}">
                 {% endif %}
                 </form>
-                <form action="/files/rename" method="post" class="file-rename" onsubmit="var new_file_name = prompt('{{ _("Enter new file name for: %(file_name)s", file_name=file["name"]) }}', '{{ file['name'] }}'); if (new_file_name === null) event.preventDefault(); document.getElementById('new_file_name_{{ subdir }}_{{ loop.index }}').value = new_file_name;">
+                <form action="/files/rename" method="post" class="file-rename" onsubmit="var new_file_name = prompt('{{ _("Enter a new file name:") }}', '{{ file["name"]|replace("'", "\\'") }}'); if (new_file_name === null) event.preventDefault(); document.getElementById('new_file_name_{{ subdir }}_{{ loop.index }}').value = new_file_name;">
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
                     <input name="new_file_name" id="new_file_name_{{ subdir }}_{{ loop.index }}" type="hidden" value="">
                     <input type="submit" value="{{ _("Rename") }}" title="{{ _("Rename") }}">
                 </form>
-                <form action="/files/copy" method="post" class="file-copy" onsubmit="var copy_file_name = prompt('{{ _("Save copy of %(file_name)s as:", file_name=file["name"]) }}', '{{ file['name'] }}'); if (copy_file_name === null) event.preventDefault(); document.getElementById('copy_file_name_{{ subdir }}_{{ loop.index }}').value = copy_file_name;">
+                <form action="/files/copy" method="post" class="file-copy" onsubmit="var copy_file_name = prompt('{{ _("Enter a file name for the copy:") }}', '{{ file["name"]|replace("'", "\\'") }}'); if (copy_file_name === null) event.preventDefault(); document.getElementById('copy_file_name_{{ subdir }}_{{ loop.index }}').value = copy_file_name;">
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
                     <input name="copy_file_name" id="copy_file_name_{{ subdir }}_{{ loop.index }}" type="hidden" value="">
                     <input type="submit" value="{{ _("Copy") }}" title="{{ _("Copy") }}">
                 </form>
-                <form action="/files/delete" method="post" class="file-delete" onsubmit="return confirm('{{ _("Delete file: %(file_name)s?", file_name=file["name"]) }}')">
+                <form action="/files/delete" method="post" class="file-delete" onsubmit="return confirm('{{ _("Delete file: %(file_name)s?", file_name=file["name"]|replace("'", "\\'")) }}')">
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
                     <input type="submit" value="{{ _("Delete") }}" title="{{ _("Delete") }}">
                 </form>

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -297,11 +297,17 @@ def is_safe_path(file_name):
     Returns True if the path is safe
     Returns False if the path is either absolute, or tries to traverse the file system
     """
-    if file_name.is_absolute() or ".." in str(file_name) or str(file_name)[0] == "~":
-        return {
-            "status": False,
-            "msg": _("No permission to use path '%(file_name)s'", file_name=file_name),
-        }
+    error_message = ""
+    if file_name.is_absolute():
+        error_message = _("Path must not be absolute")
+    elif "../" in str(file_name):
+        error_message = _("Path must not traverse the file system")
+    elif str(file_name)[0] == "~":
+        error_message = _("Path must not start in the home directory")
+
+    if error_message:
+        logging.error("Not an allowed path: %s", str(file_name))
+        return {"status": False, "msg": error_message}
 
     return {"status": True, "msg": ""}
 


### PR DESCRIPTION
I attempted using jinja2's built in escape filters, notable `escape` and `tojson`, but neither did what I needed with the single quotes.  The current solution using the `replace` filter is a bit crude, but I needed to double escape the single quote to make the browser not interpret it "too early" to not break the javascript syntax. I think a better solution is to refactor the onsubmit event handler and put it in a script block rather than inline in the html element. I couldn't immediately think of how to do that for this dynamic table however.