### PR TITLE
easyinstall: Dynamically detect an available network i/f, and abort if none is found

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -568,7 +568,11 @@ function fetchHardDiskDrivers() {
 function setupWiredNetworking() {
     echo "Setting up wired network..."
 
-    LAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'eth\|enx' | head -n 1`
+    if [[ -z $HEADLESS ]]; then
+	LAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'eth\|enx' | head -n 1`
+    else
+	LAN_INTERFACE="eth0"
+    fi
 
     if [[ -z "$LAN_INTERFACE" ]]; then
 	echo "No usable wired network interfaces detected. Have you already enabled the bridge? Aborting..."
@@ -640,7 +644,12 @@ function setupWirelessNetworking() {
     CIDR="24"
     ROUTER_IP=$NETWORK.1
     ROUTING_ADDRESS=$NETWORK.0/$CIDR
-    WLAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'wlan\|wlx' | head -n 1`
+
+    if [[ -z $HEADLESS ]]; then
+	WLAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'wlan\|wlx' | head -n 1`
+    else
+	LAN_INTERFACE="wlan0"
+    fi
 
     if [[ -z "$WLAN_INTERFACE" ]]; then
 	echo "No usable wireless network interfaces detected. Have you already enabled the bridge? Aborting..."

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -568,9 +568,14 @@ function fetchHardDiskDrivers() {
 function setupWiredNetworking() {
     echo "Setting up wired network..."
 
-    LAN_INTERFACE=eth0
+    LAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'eth\|enx' | head -n 1`
 
-    echo "$LAN_INTERFACE will be configured for network forwarding with DHCP."
+    if [[ -z "$LAN_INTERFACE" ]]; then
+	echo "No usable wired network interfaces detected. Have you already enabled the bridge? Aborting..."
+	return 1
+    fi
+
+    echo "Network interface '$LAN_INTERFACE' will be configured for network forwarding with DHCP."
     echo ""
     echo "WARNING: If you continue, the IP address of your Pi may change upon reboot."
     echo "Please make sure you will not lose access to the Pi system."
@@ -582,7 +587,7 @@ function setupWiredNetworking() {
 
         if [ "$REPLY" == "N" ] || [ "$REPLY" == "n" ]; then
             echo "Available wired interfaces on this system:"
-            echo `ip -o addr show scope link | awk '{split($0, a); print $2}' | grep eth`
+            echo `ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'eth\|enx'`
             echo "Please type the wired interface you want to use and press Enter:"
             read SELECTED
             LAN_INTERFACE=$SELECTED
@@ -635,9 +640,14 @@ function setupWirelessNetworking() {
     CIDR="24"
     ROUTER_IP=$NETWORK.1
     ROUTING_ADDRESS=$NETWORK.0/$CIDR
-    WLAN_INTERFACE="wlan0"
+    WLAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'wlan\|wlx' | head -n 1`
 
-    echo "$WLAN_INTERFACE will be configured for network forwarding with static IP assignment."
+    if [[ -z "$WLAN_INTERFACE" ]]; then
+	echo "No usable wireless network interfaces detected. Have you already enabled the bridge? Aborting..."
+	return 1
+    fi
+
+    echo "Network interface '$WLAN_INTERFACE' will be configured for network forwarding with static IP assignment."
     echo "Configure your Macintosh or other device with the following:"
     echo "IP Address (static): $IP"
     echo "Router Address: $ROUTER_IP"
@@ -649,7 +659,7 @@ function setupWirelessNetworking() {
 
     if [ "$REPLY" == "N" ] || [ "$REPLY" == "n" ]; then
         echo "Available wireless interfaces on this system:"
-        echo `ip -o addr show scope link | awk '{split($0, a); print $2}' | grep wlan`
+        echo `ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'wlan\|wlx'`
         echo "Please type the wireless interface you want to use and press Enter:"
         read -r WLAN_INTERFACE
         echo "Base IP address (ex. 10.10.20):"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -189,8 +189,10 @@ function installPiscsi() {
 
     # install
     sudo make install CONNECT_TYPE="$CONNECT_TYPE" </dev/null
+}
 
-    # update launch parameters
+# Update the systemd configuration for piscsi
+function configurePiscsiService() {
     if [[ -f $SECRET_FILE ]]; then
         sudo sed -i "\@^ExecStart.*@ s@@& -F $VIRTUAL_DRIVER_PATH -P $SECRET_FILE@" "$SYSTEMD_PATH/piscsi.service"
         echo "Secret token file $SECRET_FILE detected. Using it to enable back-end authentication."
@@ -1182,6 +1184,7 @@ function runChoice() {
               compilePiscsi
               backupPiscsiService
               installPiscsi
+	      configurePiscsiService
               enablePiscsiService
               preparePythonCommon
               if [[ $(isPiscsiScreenInstalled) -eq 0 ]]; then
@@ -1224,6 +1227,7 @@ function runChoice() {
               backupPiscsiService
               preparePythonCommon
               installPiscsi
+	      configurePiscsiService
               enablePiscsiService
               if [[ $(isPiscsiScreenInstalled) -eq 0 ]]; then
                   echo "Detected piscsi oled service; will run the installation steps for the OLED monitor."
@@ -1401,6 +1405,7 @@ function runChoice() {
               fetchHardDiskDrivers
               compilePiscsi
               installPiscsi
+	      configurePiscsiService
               enablePiscsiService
               preparePythonCommon
               cachePipPackages

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -650,7 +650,7 @@ function setupWirelessNetworking() {
     if [[ -z $HEADLESS ]]; then
 	WLAN_INTERFACE=`ip -o addr show scope link | awk '{split($0, a); print $2}' | grep 'wlan\|wlx' | head -n 1`
     else
-	LAN_INTERFACE="wlan0"
+	WLAN_INTERFACE="wlan0"
     fi
 
     if [[ -z "$WLAN_INTERFACE" ]]; then


### PR DESCRIPTION
In the easyinstall.sh network bridge configuration:
- Dynamically pick the first available network interface as default
- Adds support for detecting predictable interface names
- Abort if no linked interfaces matching the pattern is found
- Fallback to the hardcoded eth0 and wlan0 when running in headless mode
- Bonus: Fixes https://github.com/PiSCSI/piscsi/issues/1150 by breaking out the piscsi systemd configuration into a separate step