### PR TITLE
Launch python client services only after network-online target

### DIFF
--- a/python/ctrlboard/service-infra/piscsi-ctrlboard.service
+++ b/python/ctrlboard/service-infra/piscsi-ctrlboard.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PiSCSI Control Board service
-After=network.target piscsi.service
+After=network-online.target piscsi.service
 
 [Service]
 Type=simple

--- a/python/oled/service-infra/piscsi-oled.service
+++ b/python/oled/service-infra/piscsi-oled.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PiSCSI-OLED Monitor service
-After=network.target piscsi.service
+After=network-online.target piscsi.service
 
 [Service]
 Type=simple

--- a/python/web/service-infra/piscsi-web.service
+++ b/python/web/service-infra/piscsi-web.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PiSCSI-Web service
-After=network.target
+After=network-online.target piscsi.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The python clients rely on pip packages to be fetched from remote repos to function. Therefore wait until the network-online target before launching them with systemd.