### PR TITLE
Disable the Timer Test #1227

### DIFF
--- a/cpp/scsiloop/scsiloop_core.cpp
+++ b/cpp/scsiloop/scsiloop_core.cpp
@@ -159,8 +159,8 @@ int ScsiLoop::run(const vector<char *> &args)
     // This must be executed before the timer test, since this initializes the timer
     ScsiLoop_GPIO gpio_test;
 
-    int result = ScsiLoop_Timer::RunTimerTest(error_list);
-    result += gpio_test.RunLoopbackTest(error_list);
+    // int result = ScsiLoop_Timer::RunTimerTest(error_list);
+    int result = gpio_test.RunLoopbackTest(error_list);
 
     if (result == 0) {
         // Only test the dat inputs/outputs if the loopback test passed.


### PR DESCRIPTION
The Timer test isn't reliable on all variants of the Raspberry Pi. This will temporarily comment it out.

When the RPi5 support is being added, this test should be made optional and only triggered when a CLI option is present.