### PR TITLE
Update Sonar Project Key

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -55,7 +55,7 @@ jobs:
       SONAR_SCANNER_VERSION: 5.0.1.3006
       SONAR_SERVER_URL: "https://sonarcloud.io"
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      SONAR_PROJECT_KEY: "akuker_PISCSI"
+      SONAR_PROJECT_KEY: "akuker-PISCSI"
       SONAR_ORGANIZATION: "piscsi"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Per SonarCloud's forum recommendations, SonarCloud was un-installed from the PiSCSI project, then re-installed. Also, a new project key was created. The SonarCloud web interface won't allow me to create a project key with an underscore, so maybe that's a problem for it?

