### PR TITLE
Lock werkzeug lib version to 2.3.7

### DIFF
--- a/python/web/requirements.txt
+++ b/python/web/requirements.txt
@@ -1,5 +1,5 @@
 bjoern==3.2.2
-Flask==2.3.2
+Flask==2.3.3
 Jinja2==3.1.2
 protobuf==3.20.2
 requests==2.31.0
@@ -7,3 +7,4 @@ simplepam==0.1.5
 flask_babel==2.0.0
 ua-parser==0.16.1
 vcgencmd==0.1.1
+werkzeug==2.3.7


### PR DESCRIPTION
Explicitly lock the werkzeug lib to v2.3.7 to avoid the issue where pip tries to pull a version that isn't compatible with Flask.
Also bumps Flask by one bugfix version.