### PR TITLE
Python 3.11 / Bookworm compliance

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -12,12 +12,31 @@ The policy in this project is to support the Python 3 interpreter that comes
 standard with the current stable, as well as previous stable release of Debian.
 
 At the time of writing they are:
-- Python 3.9.2 in [Debian Bullseye](https://packages.debian.org/bullseye/python3)
-- Python 3.7.3 in [Debian Buster](https://packages.debian.org/buster/python3)
+- Python 3.11 in [Debian Bookworm](https://packages.debian.org/bookworm/python3)
+- Python 3.9 in [Debian Bullseye](https://packages.debian.org/bullseye/python3)
 
-## Static analysis with pylint
+## Static analysis and formatting
 
-It is recommended to run pylint against new code to protect against bugs
+The CI workflow is set up to check code formatting with `black`,
+and linting with `flake8`. If non-conformant code is found, the CI job
+will fail.
+
+Before checking in new code, install the development packages and run
+these two tools locally.
+
+```
+pip install -r web/requirements-dev.txt
+```
+
+Note that `black` only works correctly if you run it in the root of the
+`python/` dir:
+
+```
+cd python
+black .
+```
+
+Optionally: It is recommended to run pylint against new code to protect against bugs
 and keep the code readable and maintainable.
 The local pylint configuration lives in .pylintrc.
 In order for pylint to recognize venv libraries, the pylint-venv package is required.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py39', 'py310', 'py311']
 extend-exclude = ".*_pb2.py"

--- a/python/web/requirements.txt
+++ b/python/web/requirements.txt
@@ -1,10 +1,10 @@
 bjoern==3.2.2
-Flask==2.3.3
+Flask==3.0.0
 Jinja2==3.1.2
 protobuf==3.20.2
 requests==2.31.0
 simplepam==0.1.5
-flask_babel==2.0.0
+flask_babel==4.0.0
 ua-parser==0.16.1
 vcgencmd==0.1.1
-werkzeug==2.3.7
+werkzeug==3.0.1

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -74,8 +74,25 @@ from settings import (
 )
 
 
+def get_locale():
+    """
+    Uses the session language, or tries to detect based on accept-languages header
+    """
+    session_locale = session.get("language")
+    if session_locale:
+        return session_locale
+
+    client_locale = request.accept_languages.best_match(LANGUAGES)
+    if client_locale:
+        return client_locale
+
+    logging.info("The default locale could not be detected. Falling back to English.")
+    return "en"
+
+
 APP = Flask(__name__)
 BABEL = Babel(APP)
+BABEL.init_app(APP, locale_selector=get_locale)
 
 
 def get_env_info():
@@ -183,23 +200,6 @@ def response(
     if redirect_url:
         return redirect(url_for(redirect_url))
     return redirect(url_for("index"))
-
-
-@BABEL.localeselector
-def get_locale():
-    """
-    Uses the session language, or tries to detect based on accept-languages header
-    """
-    session_locale = session.get("language")
-    if session_locale:
-        return session_locale
-
-    client_locale = request.accept_languages.best_match(LANGUAGES)
-    if client_locale:
-        return client_locale
-
-    logging.info("The default locale could not be detected. Falling back to English.")
-    return "en"
 
 
 def get_supported_locales():


### PR DESCRIPTION
- Bump to Flask 3.0.x / wekzeug 3.0.x / flask-babel 4.0.x (these library versions have python 3.7 deprecation in common)
- Rework the flask app init routine to use the new flask-babel API
- Update readmes and code scanning configs