### PR TITLE
 Remove unused duplicate code dealing with MODE SELECT (#1268)

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -703,18 +703,8 @@ void ScsiController::DataOutNonBlockOriented()
 		case scsi_command::eCmdWriteLong16:
 		case scsi_command::eCmdVerify10:
 		case scsi_command::eCmdVerify16:
-			break;
-
 		case scsi_command::eCmdModeSelect6:
-		case scsi_command::eCmdModeSelect10: {
-				if (auto device = dynamic_pointer_cast<ModePageDevice>(GetDeviceForLun(GetEffectiveLun()));
-					device != nullptr) {
-					device->ModeSelect(GetOpcode(), GetCmd(), GetBuffer(), GetOffset());
-				}
-				else {
-					throw scsi_exception(sense_key::illegal_request, asc::invalid_command_operation_code);
-				}
-			}
+		case scsi_command::eCmdModeSelect10:
 			break;
 
 		case scsi_command::eCmdSetMcastAddr:

--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -691,7 +691,7 @@ bool ScsiController::XferOut(bool cont)
 	return device != nullptr ? device->WriteByteSequence(span(GetBuffer().data(), count)) : false;
 }
 
-void ScsiController::DataOutNonBlockOriented()
+void ScsiController::DataOutNonBlockOriented() const
 {
 	assert(IsDataOut());
 

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -93,7 +93,7 @@ private:
 	bool XferOutBlockOriented(bool);
 	void ReceiveBytes();
 
-	void DataOutNonBlockOriented();
+	void DataOutNonBlockOriented() const;
 	void Receive();
 
 	// TODO Make non-virtual as soon as SysTimer calls do not segfault anymore on a regular PC, e.g. by using ifdef __arm__.


### PR DESCRIPTION
Test results:
```
[2023-10-25 19:29:11.246] [debug] (ID 5) - Controller is executing ModeSelect6, CDB $151100001c00
[2023-10-25 19:29:11.246] [debug] (ID:LUN 5:0) - Device is executing ModeSelect6 ($15)
[2023-10-25 19:29:11.246] [warning] In order to change the sector size use the -b option when launching piscsi
[2023-10-25 19:29:11.246] [debug] (ID 5) - Error status: Sense Key $5, ASC $26
```
After the code removal MODE SELECT is still working as expected.