### PR TITLE
Fix MESSAGE OUT handling for initiator mode (#1283)

### DIFF
--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -388,7 +388,6 @@ bool GPIOBUS::PollSelectEvent()
     return false;
 #else
     GPIO_FUNCTION_TRACE
-    spdlog::trace(__PRETTY_FUNCTION__);
     errno = 0;
 
     if (epoll_event epev; epoll_wait(epfd, &epev, 1, -1) <= 0) {

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -38,11 +38,10 @@ bool GPIOBUS::Init(mode_e mode)
 //---------------------------------------------------------------------------
 int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 {
-    GPIO_FUNCTION_TRACE
     // Only works in TARGET mode
-    if (actmode != mode_e::TARGET) {
-        return 0;
-    }
+	assert(actmode == mode_e::TARGET);
+
+	GPIO_FUNCTION_TRACE
 
     DisableIRQ();
 

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -321,12 +321,6 @@ int GPIOBUS::SendHandShake(uint8_t *buf, int count, int delay_after_bytes)
         phase_t phase = GetPhase();
 
         for (i = 0; i < count; i++) {
-            if (i == delay_after_bytes) {
-                spdlog::trace("DELAYING for " + to_string(SCSI_DELAY_SEND_DATA_DAYNAPORT_US) + " after " +
-                		to_string(delay_after_bytes) + " bytes");
-                SysTimer::SleepUsec(SCSI_DELAY_SEND_DATA_DAYNAPORT_US);
-            }
-
             // Set the DATA signals
             SetDAT(*buf);
 
@@ -336,6 +330,11 @@ int GPIOBUS::SendHandShake(uint8_t *buf, int count, int delay_after_bytes)
             // Check for timeout waiting for REQ to be asserted
             if (!ret) {
                 break;
+            }
+
+           	// Signal the last MESSAGE OUT byte
+            if (phase == phase_t::msgout && i == count - 1) {
+            	SetATN(false);
             }
 
             // Phase error


### PR DESCRIPTION
This PR can wait until right after the first bookworm release, because in this release MESSAGE OUT in initiator mode is not yet used.
It is going to be needed by the upcoming improved scsidump.