### PR TITLE
Remove explicit pull request event types from workflow

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,11 +11,6 @@ on:
       - 'cpp/**'
       - 'python/**'
       - '.github/workflows/cpp.yml'
-    types:
-      - assigned
-      - opened
-      - synchronize
-      - reopened
 
 env:
   APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -12,11 +12,6 @@ on:
       - 'python/common/**'
       - '.github/workflows/web.yml'
       - 'easyinstall.sh'
-    types:
-      - assigned
-      - opened
-      - synchronize
-      - reopened
 
 jobs:
   backend_checks:


### PR DESCRIPTION
According to [github docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), when not specifying pull request event type in the github workflow, the default events are "opened, synchronize, and reopened". However, the way we explicitly defined the event types caused the "synchronize" event (run the jobs when new commit is synchronized with the remote branch) to not trigger. Removing the explicitly defined events and using the default gets us the wanted behavior (e.g. triggering workflows on new commits to a PR branch.)