### PR TITLE
Web UI: Refactor file upload code to make it safer

### DIFF
--- a/python/common/src/piscsi/file_cmds.py
+++ b/python/common/src/piscsi/file_cmds.py
@@ -30,6 +30,8 @@ from util import unarchiver
 FILE_READ_ERROR = "Unhandled exception when reading file: %s"
 FILE_WRITE_ERROR = "Unhandled exception when writing to file: %s"
 URL_SAFE = "/:?&"
+# Common file sharing protocol meta data dirs to filter out from target upload dirs
+EXCLUDED_DIRS = ["Network Trash Folder", "Temporary Items", "TheVolumeSettingsFolder"]
 
 
 class FileCmds:
@@ -60,15 +62,14 @@ class FileCmds:
         Returns a (list) of (str) subdir_list.
         """
         subdir_list = []
-        # Filter out file sharing meta data dirs
-        excluded_dirs = ("Network Trash Folder", "Temporary Items", "TheVolumeSettingsFolder")
         for root, dirs, _files in walk(directory, topdown=True):
             # Strip out dirs that begin with .
             dirs[:] = [d for d in dirs if d[0] != "."]
             for dir in dirs:
-                if dir not in excluded_dirs:
+                if dir not in EXCLUDED_DIRS:
                     dirpath = path.join(root, dir)
-                    subdir_list.append(dirpath.replace(directory, "", 1))
+                    # Remove the section of the path up until the first subdir
+                    subdir_list.append(dirpath.replace(directory + "/", "", 1))
 
         subdir_list.sort()
         return subdir_list

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -401,7 +401,7 @@
     {% for dir in images_subdirs %}
     <option value="{{dir}}">{{dir}}</option>
     {% endfor %}
-    <option value="/" selected>/</option>
+    <option value="" selected>/</option>
     </select>
     {% if file_server_dir_exists %}
     <input type="radio" name="destination" id="shared_files" value="shared_files">
@@ -411,7 +411,7 @@
     {% for dir in shared_subdirs %}
     <option value="{{dir}}">{{dir}}</option>
     {% endfor %}
-    <option value="/" selected>/</option>
+    <option value="" selected>/</option>
     </select>
     {% endif %}
     <input type="submit" value="{{ _("Download") }}" onclick="processNotify('{{ _("Downloading File...") }}')">

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ua_parser import user_agent_parser
 from re import findall
 
-from flask import request, abort
+from flask import request, abort, make_response
 from flask_babel import _
 from werkzeug.utils import secure_filename
 
@@ -322,6 +322,16 @@ def is_safe_path(file_name):
         return {"status": False, "msg": error_message}
 
     return {"status": True, "msg": ""}
+
+
+def validate_target_dir(target_dir):
+    """
+    Takes (Path) target_dir on the host and validates that it is a valid dir for uploading.
+    """
+    safe_path = is_safe_path(Path(".") / target_dir)
+    if not safe_path["status"]:
+        return make_response(safe_path["msg"], 403)
+    return True
 
 
 def browser_supports_modern_themes():

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -208,7 +208,7 @@ def test_extract_file(
         "/files/download_url",
         data={
             "destination": "disk_images",
-            "images_subdir": "/",
+            "images_subdir": "",
             "url": url,
         },
     )
@@ -335,7 +335,7 @@ def test_download_properties(http_client, list_files, delete_file):
 def test_download_url_to_dir(env, httpserver, http_client, list_files, delete_file):
     file_name = str(uuid.uuid4())
     http_path = f"/images/{file_name}"
-    subdir = "/"
+    subdir = ""
     url = httpserver.url_for(http_path)
 
     with open("tests/assets/test_image.hds", mode="rb") as file:
@@ -362,7 +362,7 @@ def test_download_url_to_dir(env, httpserver, http_client, list_files, delete_fi
     assert file_name in list_files()
     assert (
         response_data["messages"][0]["message"]
-        == f"Downloaded file to {env['images_dir']}{subdir}{file_name}"
+        == f"Downloaded file to {env['images_dir']}/{subdir}{file_name}"
     )
 
     # Cleanup


### PR DESCRIPTION
- Use Path objects to construct file upload paths
- Utility function for dir path validation (reduce cognitive complexity and code duplication)
- Construct subdir paths without leading "/" (reducing the risk of uploading to file system root)
- Break out inline literal list and turn it into tuple constant (for readability)