### PR TITLE
Fix assertion when creating a removable media drive with an empty filename

### DIFF
--- a/cpp/piscsi/piscsi_executor.cpp
+++ b/cpp/piscsi/piscsi_executor.cpp
@@ -263,7 +263,7 @@ bool PiscsiExecutor::Attach(const CommandContext& context, const PbDeviceDefinit
 		return context.ReturnLocalizedError(LocalizationKey::ERROR_SCSI_CONTROLLER);
 	}
 
-	if (storage_device != nullptr) {
+	if (storage_device != nullptr && !storage_device->IsRemoved()) {
 		storage_device->ReserveFile();
 	}
 


### PR DESCRIPTION
Must have been a very old bug. Fixed:

```
>piscsi -id 0 -t SCRM ""
+----+-----+------+-------------------------------------
| ID | LUN | TYPE | IMAGE FILE
+----+-----+------+-------------------------------------
|  0 |   0 | SCRM | NO MEDIUM
+----+-----+------+-------------------------------------
```