### PR TITLE
Web UI: Notify when network bridge is missing, but allow attaching network device

### DIFF
--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -298,9 +298,8 @@ def is_bridge_configured(interface):
         return_msg = _(
             "Configure the network bridge for %(interface)s first: ", interface=interface
         )
-        return {"status": False, "msg": return_msg + ", ".join(to_configure)}
 
-    return {"status": True, "msg": return_msg}
+    return {"status": True, "msg": return_msg + ", ".join(to_configure)}
 
 
 def is_safe_path(file_name):


### PR DESCRIPTION
This will allow attaching a networking device even when the Web UI detects that the network bridge isn't configured. It will notify the user with the same message as before.