### PR TITLE
Reduce logging in controller

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -178,13 +178,15 @@ void ScsiController::Command()
 
 void ScsiController::Execute()
 {
-	stringstream s;
-	s << "Controller is executing " << command_mapping.find(GetOpcode())->second.second << ", CDB $"
-			<< setfill('0') << hex;
-	for (int i = 0; i < BUS::GetCommandByteCount(static_cast<uint8_t>(GetOpcode())); i++) {
-		s << setw(2) << GetCmdByte(i);
-	}
-	LogDebug(s.str());
+    if (spdlog::get_level() == spdlog::level::trace) {
+        stringstream s;
+        s << "Controller is executing " << command_mapping.find(GetOpcode())->second.second << ", CDB $"
+            << setfill('0') << hex;
+        for (int i = 0; i < BUS::GetCommandByteCount(static_cast<uint8_t>(GetOpcode())); i++) {
+            s << setw(2) << GetCmdByte(i);
+        }
+        LogTrace(s.str());
+    }
 
 	// Initialization for data transfer
 	ResetOffset();


### PR DESCRIPTION
@rdmark The daynaport drivers have to poll very often, which leads to a flood of log messages even on debug level. This ticket changes the log level for a particular message to trace, and also makes building this message (building the string to be logged is expensive) less expensive in case it is not needed, by checking the active log level first before building the string.
Please approve this PR for the upcoming release.