### PR TITLE
Correct upload dir path validation logic

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -395,8 +395,8 @@
     <label for="download_url">{{ _("Download file from URL:") }}</label>
     <input name="url" id="download_url" required="" type="url">
     <label for="disk_images" class="hidden">{{ _("Disk Images") }}</label>
+    <label for="images_subdir">{{ _("To directory:") }}</label>
     <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
-    <label for="images_subdir" class="hidden">{{ _("Directory") }}</label>
     <select name="images_subdir" id="images_subdir">
     {% for dir in images_subdirs %}
     <option value="{{dir}}">{{env['image_root_dir']}}/{{dir}}</option>
@@ -406,7 +406,7 @@
     {% if file_server_dir_exists %}
     <label for="shared_files" class="hidden">{{ _("Shared Files") }}</label>
     <input type="radio" name="destination" id="shared_files" value="shared_files">
-    <label for="shared_subdir" class="hidden">{{ _("Directory") }}</label>
+    <label for="shared_subdir" class="hidden">{{ _("To directory:") }}</label>
     <select name="shared_subdir" id="shared_subdir">
     {% for dir in shared_subdirs %}
     <option value="{{dir}}">{{env['shared_root_dir']}}/{{dir}}</option>

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -16,7 +16,7 @@
     <legend>{{ _("Destination") }}</legend>
     <label for="disk_images" class="hidden">{{ _("Disk Images") }}</label>
     <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
-    <label for="images_subdir" class="hidden">{{ _("Directory") }}</label>
+    <label for="images_subdir" class="hidden">{{ _("To directory:") }}</label>
     <select name="images_subdir" id="images_subdir">
     {% for dir in images_subdirs %}
     <option value="{{dir}}">{{ env['image_root_dir'] }}/{{dir}}</option>
@@ -26,7 +26,7 @@
     {% if file_server_dir_exists %}
     <label for="shared_files" class="hidden">{{ _("Shared Files") }}</label>
     <input type="radio" name="destination" id="shared_files" value="shared_files">
-    <label for="shared_subdir" class="hidden">{{ _("Directory") }}</label>
+    <label for="shared_subdir" class="hidden">{{ _("To directory:") }}</label>
     <select name="shared_subdir" id="shared_subdir">
     {% for dir in shared_subdirs %}
     <option value="{{dir}}">{{ env['shared_root_dir'] }}/{{dir}}</option>

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -58,7 +58,6 @@ from web_utils import (
     auth_active,
     is_bridge_configured,
     is_safe_path,
-    validate_target_dir,
     browser_supports_modern_themes,
 )
 from settings import (
@@ -996,14 +995,18 @@ def download_file():
     images_subdir = request.form.get("images_subdir")
     shared_subdir = request.form.get("shared_subdir")
     if destination == "disk_images":
+        safe_path = is_safe_path(Path(images_subdir))
+        if not safe_path["status"]:
+            return response(error=True, message=safe_path["msg"])
         server_info = piscsi_cmd.get_server_info()
         destination_dir = Path(server_info["image_dir"]) / images_subdir
     elif destination == "shared_files":
+        safe_path = is_safe_path(Path(shared_subdir))
+        if not safe_path["status"]:
+            return response(error=True, message=safe_path["msg"])
         destination_dir = Path(FILE_SERVER_DIR) / shared_subdir
     else:
         return response(error=True, message=_("Unknown destination"))
-
-    validate_target_dir(destination_dir)
 
     process = file_cmd.download_to_dir(url, Path(destination_dir) / Path(url).name)
     process = ReturnCodeMapper.add_msg(process)
@@ -1034,16 +1037,20 @@ def upload_file():
     images_subdir = request.form.get("images_subdir")
     shared_subdir = request.form.get("shared_subdir")
     if destination == "disk_images":
+        safe_path = is_safe_path(Path(images_subdir))
+        if not safe_path["status"]:
+            return make_response(safe_path["msg"], 403)
         server_info = piscsi_cmd.get_server_info()
         destination_dir = Path(server_info["image_dir"]) / images_subdir
     elif destination == "shared_files":
+        safe_path = is_safe_path(Path(shared_subdir))
+        if not safe_path["status"]:
+            return make_response(safe_path["msg"], 403)
         destination_dir = Path(FILE_SERVER_DIR) / shared_subdir
     elif destination == "piscsi_config":
         destination_dir = Path(CFG_DIR)
     else:
         return make_response(_("Unknown destination"), 403)
-
-    validate_target_dir(destination_dir)
 
     log = logging.getLogger("pydrop")
     file_object = request.files["file"]

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1066,6 +1066,10 @@ def upload_file():
     if path.exists(save_path) and current_chunk == 0:
         return make_response(_("The file already exists!"), 400)
 
+    if path.exists(tmp_save_path) and current_chunk == 0:
+        log.info("Deleting existing temporary file before uploading...")
+        file_cmd.delete_file(tmp_save_path)
+
     try:
         with open(tmp_save_path, "ab") as save:
             save.seek(int(request.form["dzchunkbyteoffset"]))

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ua_parser import user_agent_parser
 from re import findall
 
-from flask import request, abort, make_response
+from flask import request, abort
 from flask_babel import _
 from werkzeug.utils import secure_filename
 
@@ -302,35 +302,25 @@ def is_bridge_configured(interface):
     return {"status": True, "msg": return_msg + ", ".join(to_configure)}
 
 
-def is_safe_path(file_name):
+def is_safe_path(path_name):
     """
-    Takes (Path) file_name with the path to a file on the file system
-    Returns True if the path is safe
-    Returns False if the path is either absolute, or tries to traverse the file system
+    Takes (Path) path_name with the relative path to a file on the file system.
+    Returns False if the path is either absolute, or tries to traverse the file system.
+    Returns True if neither of the above criteria are met.
     """
     error_message = ""
-    if file_name.is_absolute():
+    if path_name.is_absolute():
         error_message = _("Path must not be absolute")
-    elif "../" in str(file_name):
+    elif "../" in str(path_name):
         error_message = _("Path must not traverse the file system")
-    elif str(file_name)[0] == "~":
+    elif str(path_name)[0] == "~":
         error_message = _("Path must not start in the home directory")
 
     if error_message:
-        logging.error("Not an allowed path: %s", str(file_name))
+        logging.error("Not an allowed path: %s", str(path_name))
         return {"status": False, "msg": error_message}
 
     return {"status": True, "msg": ""}
-
-
-def validate_target_dir(target_dir):
-    """
-    Takes (Path) target_dir on the host and validates that it is a valid dir for uploading.
-    """
-    safe_path = is_safe_path(Path(".") / target_dir)
-    if not safe_path["status"]:
-        return make_response(safe_path["msg"], 403)
-    return True
 
 
 def browser_supports_modern_themes():


### PR DESCRIPTION
The safe path validation for file uploads with dropzone.js wasn't actually working following a recent refactor meant to reduce code duplication and cognitive complexity. The error response was happening in the wrong flask context and the file transfer was allowed when it should have been stopped.

Additionally, the file downloads validation, which used the same refactored method, ended up using the wrong type of flask response, leading to the app being aborted with a 403 instead of a flash warning displayed in the flask app.

Therefore, this patch removes the refactored method and brings the is_safe_path() check and response into the respective flask endpoints.

Two peripheral fixes pushed while working on this:
- tweaked the labels of the file download form, to make it clear the purpose of the target dir dropdown.
- clean up existing tmp file before uploading (otherwise the file size validation fails in the end.)