### PR TITLE
Reset Python venv if RESET_VENV is set

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -40,10 +40,11 @@ The following environment variables are available when using Docker Compose:
 | `WEB_HTTP_PORT`      | 8080     |
 | `WEB_HTTPS_PORT`     | 8443     |
 | `WEB_LOG_LEVEL`      | info     |
-| `BACKEND_HOST`        | backend  |
-| `BACKEND_PORT`        | 6868     |
-| `BACKEND_PASSWORD`    | *[None]* |
-| `BACKEND_LOG_LEVEL`   | debug    |
+| `BACKEND_HOST`       | backend  |
+| `BACKEND_PORT`       | 6868     |
+| `BACKEND_PASSWORD`   | *[None]* |
+| `BACKEND_LOG_LEVEL`  | debug    |
+| `RESET_VENV`         | *[None]* |
 
 **Examples:**
 
@@ -55,6 +56,12 @@ OS_VERSION=bullseye docker compose up
 Start the web UI with the log level set to debug:
 ```
 WEB_LOG_LEVEL=debug docker compose up
+```
+
+Force resetting & reinstalling Python web `venv` directory:
+
+```
+RESET_VENV=1 docker compose up
 ```
 
 ## Volumes

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - "127.0.0.1:${WEB_HTTPS_PORT:-8443}:443"
     environment:
      - BACKEND_PASSWORD=${BACKEND_PASSWORD:-}
+     - RESET_VENV=${RESET_VENV:-}
     init: true
     command: [
       "--backend-host=${BACKEND_HOST:-backend}",

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -36,6 +36,12 @@ if [ $ERROR = 1 ] ; then
     exit 1
 fi
 
+# Force rebuild the venv if RESET_VENV is set to any non-empty value
+if [[ "$RESET_VENV" ]]; then
+    echo "Force-removing old venv"
+    sudo rm -rf venv
+fi 
+
 # Test for two known broken venv states
 if test -e venv; then
     GOOD_VENV=true


### PR DESCRIPTION
If the `$RESET_VENV` environment variable is set to a non-empty/non-null value then the `piscsi/python/web/start.sh` will force-delete the `venv` & rebuild it from scratch.  

This is particularly useful for the Docker environment as it can be used as follows to ensure a fresh & up-to-date `venv`:

```shell
RESET_VENV=1 docker compose up
```