### PR TITLE
Fix missing webmin install automation flags

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -967,9 +967,9 @@ function installWebmin() {
     echo "Installing packages..."
     sudo apt-get install curl libcgi-session-perl --no-install-recommends --assume-yes </dev/null
     curl -o setup-repos.sh https://raw.githubusercontent.com/webmin/webmin/master/setup-repos.sh
-    sudo sh setup-repos.sh
+    sudo sh setup-repos.sh -f
     rm setup-repos.sh
-    sudo apt-get install webmin --install-recommends </dev/null
+    sudo apt-get install webmin --install-recommends --assume-yes </dev/null
     echo
     echo "Downloading and installing Webmin module..."
     if [[ -f "$WEBMIN_MODULE_CONFIG" ]]; then


### PR DESCRIPTION
Adding a couple flags to automatically run commands without prompting for the Webmin `easyinstall.sh` setup.  These additions keep the script from prompting the user to continue:

- Add a `-f` to the `setup-repos.sh` script that adds the Webmin package repo
- Add an `--assume-yes` for installing the `webmin` package

