### PR TITLE
Use a standard timer for the DaynaPort delay work-around

### DIFF
--- a/cpp/hal/bus.h
+++ b/cpp/hal/bus.h
@@ -54,7 +54,7 @@ const static int SCSI_DELAY_FAST_NEGATION_PERIOD_NS      = 30;
 // The DaynaPort SCSI Link do a short delay in the middle of transfering
 // a packet. This is the number of uS that will be delayed between the
 // header and the actual data.
-const static int SCSI_DELAY_SEND_DATA_DAYNAPORT_US = 100;
+const static int SCSI_DELAY_SEND_DATA_DAYNAPORT_NS = 100'000;
 
 
 class bus_exception : public runtime_error

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -278,7 +278,9 @@ int GPIOBUS::SendHandShake(uint8_t *buf, int count, int delay_after_bytes)
             if (i == delay_after_bytes) {
                 spdlog::trace("DELAYING for " + to_string(SCSI_DELAY_SEND_DATA_DAYNAPORT_US) + " us after " +
                 		to_string(delay_after_bytes) + " bytes");
-                SysTimer::SleepUsec(SCSI_DELAY_SEND_DATA_DAYNAPORT_US);
+                EnableIRQ();
+                usleep(SCSI_DELAY_SEND_DATA_DAYNAPORT_US);
+                DisableIRQ();
             }
 
             // Set the DATA signals

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -14,7 +14,7 @@
 #include <spdlog/spdlog.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <sys/time.h>
+#include <time.h>
 #ifdef __linux__
 #include <sys/epoll.h>
 #endif
@@ -276,10 +276,11 @@ int GPIOBUS::SendHandShake(uint8_t *buf, int count, int delay_after_bytes)
     if (actmode == mode_e::TARGET) {
         for (i = 0; i < count; i++) {
             if (i == delay_after_bytes) {
-                spdlog::trace("DELAYING for " + to_string(SCSI_DELAY_SEND_DATA_DAYNAPORT_US) + " us after " +
+                spdlog::trace("DELAYING for " + to_string(SCSI_DELAY_SEND_DATA_DAYNAPORT_NS) + " ns after " +
                 		to_string(delay_after_bytes) + " bytes");
                 EnableIRQ();
-                usleep(SCSI_DELAY_SEND_DATA_DAYNAPORT_US);
+                const timespec ts = { .tv_sec = 0, .tv_nsec = SCSI_DELAY_SEND_DATA_DAYNAPORT_NS};
+                nanosleep(&ts, nullptr);
                 DisableIRQ();
             }
 


### PR DESCRIPTION
A seemingly small change, but important. Tested with a Mac SE, but the actual delay does not change anyway with this change.