### PR TITLE
Replace system timer by C++ standard timer for timeout of 3 s

### DIFF
--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -20,7 +20,6 @@
 #include "devices/storage_device.h"
 #include "hal/gpiobus_factory.h"
 #include "hal/gpiobus.h"
-#include "hal/systimer.h"
 #include "piscsi/piscsi_core.h"
 #include <spdlog/spdlog.h>
 #include <netinet/in.h>
@@ -29,6 +28,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <chrono>
 
 using namespace std;
 using namespace filesystem;
@@ -684,21 +684,19 @@ bool Piscsi::ShutDown(AbstractController::piscsi_shutdown_mode shutdown_mode)
 bool Piscsi::IsNotBusy() const
 {
     // Wait until BSY is released as there is a possibility for the
-	// initiator to assert it while setting the ID (for up to 3 seconds)
-	if (bus->GetBSY()) {
-		const uint32_t now = SysTimer::GetTimerLow();
+    // initiator to assert it while setting the ID (for up to 3 seconds)
+    if (bus->GetBSY()) {
+        const auto now = chrono::steady_clock::now();
+        while ((chrono::duration_cast<chrono::seconds>(chrono::steady_clock::now() - now).count()) < 3) {
+            bus->Acquire();
 
-		// Wait for 3s
-		while ((SysTimer::GetTimerLow() - now) < 3'000'000) {
-			bus->Acquire();
+            if (!bus->GetBSY()) {
+                return true;
+            }
+        }
 
-			if (!bus->GetBSY()) {
-				return true;
-			}
-		}
+        return false;
+    }
 
-		return false;
-	}
-
-	return true;
+    return true;
 }


### PR DESCRIPTION
There is no need for using a PI specific timer for a timeout of 3 s.