### PR TITLE
Use optimized SCSI compliant handshake

### DIFF
--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -76,8 +76,10 @@ public:
 
 private:
 
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
 	// Execution start time
 	uint32_t execstart = 0;
+#endif
 
 	// The initiator ID may be unavailable, e.g. with Atari ACSI and old host adapters
 	int initiator_id = UNKNOWN_INITIATOR_ID;
@@ -103,7 +105,9 @@ private:
 	void ParseMessage();
 	void ProcessMessage();
 
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
 	void Sleep();
+#endif
 
 	scsi_t scsi = {};
 };

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -40,7 +40,7 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 
     bool ack = WaitACK(true);
 
-#ifndef SCSI_COMPLIANT_HANDSHAKE
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
         SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 #endif
 
@@ -68,7 +68,7 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 
         ack = WaitACK(true);
 
-#ifndef SCSI_COMPLIANT_HANDSHAKE
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
         SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 #endif
 
@@ -102,7 +102,7 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 
         ack = WaitACK(true);
 
-#ifndef SCSI_COMPLIANT_HANDSHAKE
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
         SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 #endif
 
@@ -134,7 +134,7 @@ int GPIOBUS::ReceiveHandShake(uint8_t *buf, int count)
 
             const bool ack = WaitACK(true);
 
-#ifndef SCSI_COMPLIANT_HANDSHAKE
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
         SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 #endif
 
@@ -165,7 +165,7 @@ int GPIOBUS::ReceiveHandShake(uint8_t *buf, int count)
                 break;
             }
 
-#ifndef SCSI_COMPLIANT_HANDSHAKE
+#ifdef NO_SCSI_COMPLIANT_HANDSHAKE
         SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 #endif
 

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -40,6 +40,10 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 
     bool ack = WaitACK(true);
 
+#ifndef SCSI_COMPLIANT_HANDSHAKE
+        SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
+#endif
+
     buf[0] = GetDAT();
 
     SetREQ(false);
@@ -63,6 +67,10 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
         SetREQ(true);
 
         ack = WaitACK(true);
+
+#ifndef SCSI_COMPLIANT_HANDSHAKE
+        SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
+#endif
 
         // Get the actual SCSI command
         buf[0] = GetDAT();
@@ -94,6 +102,10 @@ int GPIOBUS::CommandHandShake(vector<uint8_t> &buf)
 
         ack = WaitACK(true);
 
+#ifndef SCSI_COMPLIANT_HANDSHAKE
+        SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
+#endif
+
         buf[offset] = GetDAT();
 
         SetREQ(false);
@@ -122,6 +134,10 @@ int GPIOBUS::ReceiveHandShake(uint8_t *buf, int count)
 
             const bool ack = WaitACK(true);
 
+#ifndef SCSI_COMPLIANT_HANDSHAKE
+        SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
+#endif
+
             *buf = GetDAT();
 
             SetREQ(false);
@@ -149,6 +165,9 @@ int GPIOBUS::ReceiveHandShake(uint8_t *buf, int count)
                 break;
             }
 
+#ifndef SCSI_COMPLIANT_HANDSHAKE
+        SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
+#endif
 
             *buf = GetDAT();
 

--- a/cpp/hal/gpiobus_virtual.cpp
+++ b/cpp/hal/gpiobus_virtual.cpp
@@ -10,7 +10,6 @@
 
 #include "hal/gpiobus_virtual.h"
 #include "hal/gpiobus.h"
-#include "hal/systimer.h"
 #include "hal/log.h"
 #include <cstddef>
 #include <map>

--- a/cpp/shared/config.h
+++ b/cpp/shared/config.h
@@ -21,3 +21,6 @@
 #if defined(__x86_64__) || defined(__X86__) || !defined(__linux__)
 #undef USE_SEL_EVENT_ENABLE
 #endif
+
+// Use improved SCSI compliant handshake which does not require the system timer and provides a small performance benefit
+#define SCSI_COMPLIANT_HANDSHAKE

--- a/cpp/shared/config.h
+++ b/cpp/shared/config.h
@@ -22,5 +22,6 @@
 #undef USE_SEL_EVENT_ENABLE
 #endif
 
-// Use improved SCSI compliant handshake which does not require the system timer and provides a small performance benefit
-#define SCSI_COMPLIANT_HANDSHAKE
+// Disable improved SCSI compliant handshake. The improved handshake does not require the system timer and
+// provides a small performance benefit.
+//#define NO_SCSI_COMPLIANT_HANDSHAKE


### PR DESCRIPTION
See item 2. in #1287 and the respective details in #1287 for details. I also renamed some booleans in order to be more descriptive.
Tested with a Mac SE and an Atari TT, with hard drive and daynaport emulation, and with two connected PiSCSI boards. Also tested with scsidump, a Quantum hard drive and a SCSI card reader.
Again about 1% more throughput with a Pi 4. Not much, but anyway ...