### PR TITLE
Revert moving webmin to sub-path

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -986,10 +986,6 @@ function installWebmin() {
         sudo sed -i 's@/usr/sbin@/usr/local/sbin@' "$WEBMIN_MODULE_CONFIG"
     fi
     rm netatalk2-wbm.tgz || true
-
-    # Configure Webmin to be accessible from a '/webmin' URL path
-    echo "webprefix=/webmin" | sudo tee -a /etc/webmin/config
-    echo "webprefixnoredir=1" | sudo tee -a /etc/webmin/config
 }
 
 # updates configuration files and installs packages needed for the OLED screen script

--- a/python/web/service-infra/nginx-default.conf
+++ b/python/web/service-infra/nginx-default.conf
@@ -18,12 +18,6 @@ server {
         proxy_pass http://127.0.0.1:8080;
     }
 
-    # Configure Webmin to be accessed via '/webmin' URL path
-    # NOTE: Use of 'https' here is required as is the trailing '/'
-    location /webmin {
-        proxy_pass https://127.0.0.1:10000/;
-    } 
-
     # Large files
     client_max_body_size 0;
     proxy_read_timeout 1000;

--- a/python/web/src/templates/admin.html
+++ b/python/web/src/templates/admin.html
@@ -129,7 +129,7 @@
     {% if webmin_configured %}
     <ul>
       <li class="service-item extlink">
-        <a href="../webmin/netatalk2/" target=\"_blank\">{{ _("Manage the AFP server") }}</a>
+        <a href="https://{{ env["ip_addr"] }}:10000/netatalk2/" target=\"_blank\">{{ _("Manage the AFP server") }}</a>
       </li>
     </ul>
     {% endif %}
@@ -144,7 +144,7 @@
     {% if webmin_configured %}
     <ul>
       <li class="service-item extlink">
-        <a href="../webmin/samba/" target=\"_blank\">{{ _("Manage the SMB server") }}</a>
+        <a href="https://{{ env["ip_addr"] }}:10000/webmin/samba/" target=\"_blank\">{{ _("Manage the SMB server") }}</a>
       </li>
     </ul>
     {% endif %}
@@ -166,7 +166,7 @@
     </li>
     {% if webmin_configured %}
     <li class="service-item extlink">
-	<a href="../webmin/" target=\"_blank\">{{ _("Manage PiSCSI services & Linux with Webmin") }}</a>
+      <a href="https://{{ env["ip_addr"] }}:10000/" target=\"_blank\">{{ _("Manage PiSCSI services & Linux with Webmin") }}</a>
     </li>
     {% endif %}
 </ul>


### PR DESCRIPTION
This reverts the parts of #1354 that moved Webmin to a URL sub-path `/webmin` which is breaking Webmin authentication.

Issue #1380 has been opened to re-address moving Webmin to a sub-path properly in a future change.  

This PR retains the Settings page UI tweaks to Webmin but just uses the direct URL to port `10000`.