### PR TITLE
Use standard C++ timer for long timeout in piscsi core

### DIFF
--- a/cpp/piscsi/piscsi_core.h
+++ b/cpp/piscsi/piscsi_core.h
@@ -46,7 +46,7 @@ private:
 	static void TerminationHandler(int);
 	string ParseArguments(span<char *>, PbCommand&, int&, string&);
 	void Process();
-	bool IsNotBusy() const;
+	bool WaitForNotBusy() const;
 
 	bool ShutDown(AbstractController::piscsi_shutdown_mode);
 	bool ShutDown(const CommandContext&, const string&);


### PR DESCRIPTION
Same as https://github.com/PiSCSI/piscsi/pull/1361, but different code location.