### PR TITLE
Web UI: Rework the Attach Device section to be universal

### DIFF
--- a/python/web/src/static/themes/classic/style.css
+++ b/python/web/src/static/themes/classic/style.css
@@ -58,6 +58,15 @@ div.footer div.theme-change-hint {
   margin-bottom: 15px;
 }
 
+div.login-status {
+  text-align: right;
+}
+
+div.login-status a {
+  color: white;
+  text-decoration: underline;
+}
+
 div.logged-in {
   background-color: green;
 }

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -763,6 +763,10 @@ section#files p {
   margin-top: 1rem;
 }
 
+section#files details.subdir {
+  padding-left: 2rem;
+}
+
 section#files details.subdir summary.dirname {
   text-decoration: underline;
   font-family: monospace;

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -858,7 +858,7 @@ section#upload a p {
 
 /*
  ------------------------------------------------------------------------------
- Index > Section: Attach peripheral devices
+ Index > Section: Attach devices
  ------------------------------------------------------------------------------
  */
 section#attach-devices table th:last-child,
@@ -868,6 +868,10 @@ section#attach-devices table td:last-child {
 
 section#attach-devices form {
   display: block;
+}
+
+section#attach-devices table form select.table-dropdown {
+  width: 16rem;
 }
 
 @media (max-width: 900px) {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -654,7 +654,7 @@ table#attached-devices td.parameters form {
 }
 
 table#attached-devices td.parameters form label {
-  display: none;
+  padding: 0 0.5rem 0 0;
 }
 
 table#attached-devices td.parameters form select {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -764,7 +764,8 @@ section#files p {
 }
 
 section#files details.subdir {
-  padding-left: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 section#files details.subdir summary.dirname {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -651,6 +651,7 @@ table#attached-devices td.actions {
 
 table#attached-devices td.parameters form {
   display: flex;
+  align-items: center;
 }
 
 table#attached-devices td.parameters form label {

--- a/python/web/src/static/themes/modern/style.css
+++ b/python/web/src/static/themes/modern/style.css
@@ -282,18 +282,6 @@ div.header div.login-form-title {
   display: none;
 }
 
-div.header div.authentication-disabled span.separator {
-  display: none;
-}
-
-div.header div.authentication-disabled span.wiki-help-text {
-  display: block;
-}
-
-div.header div.authentication-disabled a {
-  color: #fff;
-}
-
 @media (max-width: 900px) {
   div.header {
     flex-wrap: wrap;

--- a/python/web/src/templates/admin.html
+++ b/python/web/src/templates/admin.html
@@ -115,6 +115,8 @@
     <ul>
         <li>{{ _("If you want to add a service, run the easyinstall.sh script and choose the one to install.") }}</li>
         <li>{{ _("In order to manage the services in the Web UI, you may install Webmin as well.") }}</li>
+        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}
+        </li>
     </ul>
 </details>
 <ul class="service_status">

--- a/python/web/src/templates/base.html
+++ b/python/web/src/templates/base.html
@@ -27,37 +27,31 @@
 
 <body class="{{ body_classes|join(' ') }}">
     <div class="header">
-        {% if env["auth_active"] %}
+        {% if env["logged_in"] or not env["auth_active"] %}
+        <div align="center" class="login-status logged-in">
             {% if env["logged_in"] %}
-                <div align="center" class="login-status logged-in">
-                    <span class="logged-in-as-text">{{ _("Logged in as <em>%(username)s</em>", username=env["username"]) }}</span>
-                    <span class="separator">-</span>
-                    <span class="log-out-button"><a href="/logout">{{ _("Log Out") }}</a></span>
-                    <span class="separator">-</span>
-                    <span class="admin-button"><a href="/sys/admin">{{ _("Settings") }}</a></span>
-                </div>
-            {% else %}
-                <div align="center" class="login-status logged-out">
-                    <form method="POST" action="/login">
-                        <div class="login-form-title">{{ _("Log in to use Web Interface") }}</div>
-                        <span>
-                            <label for="username">{{ _("Username:") }}</label>
-                            <input type="text" name="username" id="username">
-                        </span>
-                        <span>
-                            <label for="password">{{ _("Password:") }}</label>
-                            <input type="password" name="password" id="password">
-                        </span>
-                        <input type="submit" value="Login">
-                    </form>
-                </div>
+            <span class="logged-in-as-text">{{ _("Logged in as <em>%(username)s</em>", username=env["username"]) }}</span>
+            <span class="separator">-</span>
+            <span class="log-out-button"><a href="/logout">{{ _("Log Out") }}</a></span>
+            <span class="separator">-</span>
             {% endif %}
+            <span class="admin-button"><a href="/sys/admin">{{ _("Settings") }}</a></span>
+        </div>
         {% else %}
-            <div align="center" class="login-status authentication-disabled">
-                <span class="authentication-disabled-text">{{ _("Web Interface Authentication Disabled") }}</span>
-                <span class="separator">-</span>
-                <span class="wiki-help-text">{{ _("See <a href=\"%(url)s\" target=\"_blank\">Wiki</a> for more information", url="https://github.com/PiSCSI/piscsi/wiki/Web-Interface#enable-authentication") }}</span>
-            </div>
+        <div align="center" class="login-status logged-out">
+            <form method="POST" action="/login">
+                <div class="login-form-title">{{ _("Log in to use Web Interface") }}</div>
+                <span>
+                    <label for="username">{{ _("Username:") }}</label>
+                    <input type="text" name="username" id="username">
+                </span>
+                <span>
+                    <label for="password">{{ _("Password:") }}</label>
+                    <input type="password" name="password" id="password">
+                </span>
+                <input type="submit" value="Login">
+            </form>
+        </div>
         {% endif %}
 
         <div align="center" class="title">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -193,143 +193,6 @@
 </section>
 
 <hr/>
-
-<section id="attach-devices">
-<details>
-    <summary class="heading">
-        {{ _("Attach Device") }}
-    </summary>
-    <ul>
-        </li>
-        {% if bridge_configured %}
-        <li>{{ _("The <tt>piscsi_bridge</tt> network bridge is active and ready to be used by an emulated network adapter!") }}</li>
-        {% else %}
-        <li>{{ _("Please configure the <tt>piscsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
-        {% endif %}
-        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}</li>
-        </li>
-        <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types") }}
-        </li>
-    </ul>
-</details>
-<table border="black" cellpadding="3" summary="List of peripheral devices">
-    <tr>
-        <th scope="col">{{ _("Device") }}</th>
-        <th scope="col">{{ _("Key") }}</th>
-        <th scope="col">{{ _("Parameters and Actions") }}</th>
-    </tr>
-    {% for type in device_types.keys() %}
-    <tr>
-        <td>
-            <div>{{ device_types[type]["name"] }}</div>
-        </td>
-        <td>
-            <div>{{ type }}</div>
-        </td>
-        <td>
-            <form action="/scsi/attach" method="post" class="device-attach">
-                <input name="type" type="hidden" value="{{ type }}">
-                {% for key, value in device_types[type]["params"] | dictsort %}
-                <label for="param_{{ type }}_{{ key }}">{{ key }}:</label>
-                {% if value.isnumeric() %}
-                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="number" value="{{ value }}">
-                {% elif key == "interface" %}
-                <select name="param_{{ key }}" id="param_{{ type }}_{{ key }}">
-                {% for if in netinfo["ifs"] %}
-                    <option value="{{ if }}">
-                        {{ if }}
-                    </option>
-                {% endfor %}
-                </select>
-                {% else %}
-                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="text" size="{{ value|length }}" placeholder="{{ value }}">
-                {% endif %}
-                {% endfor %}
-                {% if type in DISK_DEVICE_TYPES %}
-                <label for="{{ type }}_drive_name">{{ _("Masquerade as:") }}</label>
-                <select name="drive_name" id="{{ type }}_drive_name">
-                <option value="">
-                {{ _("None") }}
-                </option>
-                {% if type == "SCHD" %}
-                {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                {% if type == "SCCD" %}
-                {% for drive in drive_properties["cd_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                {% if type == "SCRM" %}
-                {% for drive in drive_properties["rm_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                {% if type == "SCMO" %}
-                {% for drive in drive_properties["mo_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                </select>
-                <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
-                <select name="file_name" id="{{ type }}_image_file_name">
-                {% if type != "SCHD" %}
-                <option value="">
-                {{ _("None") }}
-                </option>
-                {% endif %}
-                {% for f in files|sort(attribute='name') %}
-                {% if type == "SCHD" %}
-                {% if f["name"].lower().endswith(env['hd_suffixes']) %}
-                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
-                {% endif %}
-                {% elif type == "SCCD" %}
-                {% if f["name"].lower().endswith(env['cd_suffixes']) %}
-                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
-                {% endif %}
-                {% elif type == "SCRM" %}
-                {% if f["name"].lower().endswith(env['rm_suffixes']) %}
-                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
-                {% endif %}
-                {% elif type == "SCMO" %}
-                {% if f["name"].lower().endswith(env['mo_suffixes']) %}
-                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
-                {% endif %}
-                {% else %}
-                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
-                {% endif %}
-                {% endfor %}
-                </select>
-                {% endif %}
-                <label for="{{ type }}_scsi_id">{{ _("ID") }}</label>
-                <select name="scsi_id" id="{{ type }}_scsi_id">
-                {% for id in scsi_ids["valid_ids"] %}
-                    <option value="{{ id }}"{% if id == scsi_ids["recommended_id"] %} selected{% endif %}>
-                        {{ id }}
-                    </option>
-                {% endfor %}
-                </select>
-                <label for="{{ type }}_unit">{{ _("LUN") }}</label>
-                <input class="lun" name="unit" id="{{ type }}_unit" type="number" value="0" min="0" max="31" step="1" size="3">
-                <input type="submit" value="{{ _("Attach") }}" title="{{ _("Attach") }}">
-            </form>
-        </td>
-    </tr>
-    {% endfor %}
-</table>
-</section>
-
-<hr/>
-
 <section id="files">
 <details>
     <summary class="heading">
@@ -530,6 +393,142 @@
 
 <hr/>
 
+<section id="attach-devices">
+<details>
+    <summary class="heading">
+        {{ _("Attach Device") }}
+    </summary>
+    <ul>
+        </li>
+        {% if bridge_configured %}
+        <li>{{ _("The <tt>piscsi_bridge</tt> network bridge is active and ready to be used by an emulated network adapter!") }}</li>
+        {% else %}
+        <li>{{ _("Please configure the <tt>piscsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
+        {% endif %}
+        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}</li>
+        </li>
+        <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types") }}
+        </li>
+    </ul>
+</details>
+<table border="black" cellpadding="3" summary="List of peripheral devices">
+    <tr>
+        <th scope="col">{{ _("Device") }}</th>
+        <th scope="col">{{ _("Key") }}</th>
+        <th scope="col">{{ _("Parameters and Actions") }}</th>
+    </tr>
+    {% for type in device_types.keys() %}
+    <tr>
+        <td>
+            <div>{{ device_types[type]["name"] }}</div>
+        </td>
+        <td>
+            <div>{{ type }}</div>
+        </td>
+        <td>
+            <form action="/scsi/attach" method="post" class="device-attach">
+                <input name="type" type="hidden" value="{{ type }}">
+                {% for key, value in device_types[type]["params"] | dictsort %}
+                <label for="param_{{ type }}_{{ key }}">{{ key }}:</label>
+                {% if value.isnumeric() %}
+                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="number" value="{{ value }}">
+                {% elif key == "interface" %}
+                <select name="param_{{ key }}" id="param_{{ type }}_{{ key }}">
+                {% for if in netinfo["ifs"] %}
+                    <option value="{{ if }}">
+                        {{ if }}
+                    </option>
+                {% endfor %}
+                </select>
+                {% else %}
+                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="text" size="{{ value|length }}" placeholder="{{ value }}">
+                {% endif %}
+                {% endfor %}
+                {% if type in DISK_DEVICE_TYPES %}
+                <label for="{{ type }}_drive_name">{{ _("Masquerade as:") }}</label>
+                <select name="drive_name" id="{{ type }}_drive_name">
+                <option value="">
+                {{ _("None") }}
+                </option>
+                {% if type == "SCHD" %}
+                {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCCD" %}
+                {% for drive in drive_properties["cd_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCRM" %}
+                {% for drive in drive_properties["rm_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCMO" %}
+                {% for drive in drive_properties["mo_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                </select>
+                <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
+                <select name="file_name" id="{{ type }}_image_file_name">
+                {% if type != "SCHD" %}
+                <option value="">
+                {{ _("None") }}
+                </option>
+                {% endif %}
+                {% for f in files|sort(attribute='name') %}
+                {% if type == "SCHD" %}
+                {% if f["name"].lower().endswith(env['hd_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCCD" %}
+                {% if f["name"].lower().endswith(env['cd_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCRM" %}
+                {% if f["name"].lower().endswith(env['rm_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCMO" %}
+                {% if f["name"].lower().endswith(env['mo_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% else %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% endfor %}
+                </select>
+                {% endif %}
+                <label for="{{ type }}_scsi_id">{{ _("ID") }}</label>
+                <select name="scsi_id" id="{{ type }}_scsi_id">
+                {% for id in scsi_ids["valid_ids"] %}
+                    <option value="{{ id }}"{% if id == scsi_ids["recommended_id"] %} selected{% endif %}>
+                        {{ id }}
+                    </option>
+                {% endfor %}
+                </select>
+                <label for="{{ type }}_unit">{{ _("LUN") }}</label>
+                <input class="lun" name="unit" id="{{ type }}_unit" type="number" value="0" min="0" max="31" step="1" size="3">
+                <input type="submit" value="{{ _("Attach") }}" title="{{ _("Attach") }}">
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+</section>
+
+<hr/>
+
 <section id="download-url">
 <details>
     <summary class="heading">
@@ -583,6 +582,69 @@
         {{ _("The file uploading functionality requires JavaScript.") }}
     </div>
 </noscript>
+
+<hr/>
+
+<section id="create-image">
+<details>
+    <summary class="heading">
+        {{ _("Create Empty Disk Image") }}
+    </summary>
+    <ul>
+        <li>{{ _("Please refer to <a href=\"%(url)s\" target=\"_blank\">wiki documentation</a> to learn more about the supported image file types.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types#image-types") }}</li>
+        <li>{{ _("It is not recommended to use the Lido hard disk driver with the Macintosh Plus.") }}</li>
+    </ul>
+</details>
+
+<form action="/files/create" method="post">
+    <label for="image_create_file_name">{{ _("File Name:") }}</label>
+    <input name="file_name" id="image_create_file_name" required="" type="text">
+    <label for="image_create_type">{{ _("Type:") }}</label>
+    <select name="type" id="image_create_type">
+        {% for key, value in image_suffixes_to_create.items() %}
+        <option value="{{ key }}">
+        {{ value }} [.{{ key }}]
+        </option>
+        {% endfor %}
+    </select>
+    <label for="image_create_size">{{ _("Size:") }}</label>
+    <input name="size" id="image_create_size" type="number" placeholder="{{ _("MiB") }}" min="1" max="262144" required>
+    <label for="image_create_drive_name">{{ _("Masquerade as:") }}</label>
+    <select name="drive_name" id="image_create_drive_name">
+    <option value="">
+    {{ _("None") }}
+    </option>
+    {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
+    <option value="{{ drive.name }}">
+    {{ drive.name }}
+    </option>
+    {% endfor %}
+    </select>
+    <label for="drive_format">{{ _("Format as:") }}</label>
+    <select name="drive_format" id="drive_format">
+    <option value="">
+    {{ _("None") }}
+    </option>
+    <option value="Lido 7.56">
+    HFS + Lido
+    </option>
+    <option value="SpeedTools 3.6">
+    HFS + SpeedTools
+    </option>
+    <option value="FAT16">
+    FAT16
+    </option>
+    <option value="FAT32">
+    FAT32
+    </option>
+    </select>
+    <input type="submit" value="{{ _("Create") }}">
+</form>
+</section>
+
+<section id="create-drive">
+    <a href="/drive/list"><p>{{ _("Create Disk Image With Properties") }}</p></a>
+</section>
 
 <hr/>
 
@@ -661,66 +723,4 @@
 
 <hr/>
 
-<section id="create-image">
-<details>
-    <summary class="heading">
-        {{ _("Create Empty Disk Image") }}
-    </summary>
-    <ul>
-        <li>{{ _("Please refer to <a href=\"%(url)s\" target=\"_blank\">wiki documentation</a> to learn more about the supported image file types.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types#image-types") }}</li>
-        <li>{{ _("It is not recommended to use the Lido hard disk driver with the Macintosh Plus.") }}</li>
-    </ul>
-</details>
-
-<form action="/files/create" method="post">
-    <label for="image_create_file_name">{{ _("File Name:") }}</label>
-    <input name="file_name" id="image_create_file_name" required="" type="text">
-    <label for="image_create_type">{{ _("Type:") }}</label>
-    <select name="type" id="image_create_type">
-        {% for key, value in image_suffixes_to_create.items() %}
-        <option value="{{ key }}">
-        {{ value }} [.{{ key }}]
-        </option>
-        {% endfor %}
-    </select>
-    <label for="image_create_size">{{ _("Size:") }}</label>
-    <input name="size" id="image_create_size" type="number" placeholder="{{ _("MiB") }}" min="1" max="262144" required>
-    <label for="image_create_drive_name">{{ _("Masquerade as:") }}</label>
-    <select name="drive_name" id="image_create_drive_name">
-    <option value="">
-    {{ _("None") }}
-    </option>
-    {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
-    <option value="{{ drive.name }}">
-    {{ drive.name }}
-    </option>
-    {% endfor %}
-    </select>
-    <label for="drive_format">{{ _("Format as:") }}</label>
-    <select name="drive_format" id="drive_format">
-    <option value="">
-    {{ _("None") }}
-    </option>
-    <option value="Lido 7.56">
-    HFS + Lido
-    </option>
-    <option value="SpeedTools 3.6">
-    HFS + SpeedTools
-    </option>
-    <option value="FAT16">
-    FAT16
-    </option>
-    <option value="FAT32">
-    FAT32
-    </option>
-    </select>
-    <input type="submit" value="{{ _("Create") }}">
-</form>
-</section>
-
-<section id="create-drive">
-    <a href="/drive/list"><p>{{ _("Create Disk Image With Properties") }}</p></a>
-</section>
-
-<hr/>
 {% endblock content %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -90,12 +90,11 @@
             {% endif %}
             <td class="name" align="center">{{ device.device_name }}</td>
             <td class="parameters">
-                {% if "No Media" in device.status %}
+            {% if "No Media" in device.status %}
                 <form action="/scsi/attach" method="post">
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
                     <input name="type" type="hidden" value="{{ device.device_type }}">
-                    <label for="device_list_file_name_{{ device.id }}_{{ device.unit }}">{{ _("Image file:") }}</label>
                     <select type="select" name="file_name" id="device_list_file_name_{{ device.id }}_{{ device.unit }}">
                     {% for f in files|sort(attribute='name') %}
                     {% if device.device_type == "SCCD" %}
@@ -113,7 +112,7 @@
                     {% endif %}
                     {% endfor %}
                     </select>
-                    <input type="submit" value="{{ _("Attach") }}">
+                    <input type="submit" value="{{ _("Insert") }}">
                 </form>
             {% else %}
                 {% if device.params %}
@@ -127,7 +126,14 @@
                         {% endif %}
                     {% endfor %}
                 {% elif device.file %}
-                    <span class="filename">{{ device.file }}</span>
+                <form action="/scsi/eject" method="post" onsubmit="return confirm('{{ _("Eject Disk?  WARNING: On Mac OS, eject the Disk in the Finder instead!") }}')">
+                    <label>{{ device.file }}</label>
+                    {% if device.device_type in REMOVABLE_DEVICE_TYPES and "No Media" not in device.status %}
+                    <input name="scsi_id" type="hidden" value="{{ device.id }}">
+                    <input name="unit" type="hidden" value="{{ device.unit }}">
+                    <input type="submit" value="{{ _("Eject") }}">
+                    {% endif %}
+                </form>
                 {% endif %}
             {% endif %}
             </td>
@@ -142,13 +148,6 @@
             </td>
             <td class="actions" align="center">
                 {% if device.id in scsi_ids["occupied_ids"] %}
-                {% if device.device_type in REMOVABLE_DEVICE_TYPES and "No Media" not in device.status %}
-                <form action="/scsi/eject" method="post" onsubmit="return confirm('{{ _("Eject Disk?  WARNING: On Mac OS, eject the Disk in the Finder instead!") }}')">
-                    <input name="scsi_id" type="hidden" value="{{ device.id }}">
-                    <input name="unit" type="hidden" value="{{ device.unit }}">
-                    <input type="submit" value="{{ _("Eject") }}">
-                </form>
-                {% endif %}
                 <form action="/scsi/detach" method="post" onsubmit="return confirm('{{ _("Detach Device?") }}')">
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
@@ -414,7 +413,7 @@
     <tr>
         <th scope="col">{{ _("Device") }}</th>
         <th scope="col">{{ _("Key") }}</th>
-        <th scope="col">{{ _("Parameters and Actions") }}</th>
+        <th scope="col">{{ _("Actions") }}</th>
     </tr>
     {% for type in device_types.keys() %}
     <tr>
@@ -479,9 +478,13 @@
                 {% endif %}
                 </select>
                 <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
-                <select name="file_name" id="{{ type }}_image_file_name">
-                <option value="">
-                {{ _("Choose an image file...") }}
+                <select name="file_name" id="{{ type }}_image_file_name" {% if type not in REMOVABLE_DEVICE_TYPES %}required{% endif %}>
+                <option value="" selected {% if type not in REMOVABLE_DEVICE_TYPES %}disabled{% endif %}>
+                {% if type in REMOVABLE_DEVICE_TYPES %}
+                {{ _("None") }}
+                {% else %}
+                {{ _("Choose a file...") }}
+                {% endif %}
                 </option>
                 {% for f in files|sort(attribute='name') %}
                 {% if type == "SCHD" %}
@@ -606,10 +609,10 @@
     </select>
     <label for="image_create_size">{{ _("Size:") }}</label>
     <input name="size" id="image_create_size" type="number" placeholder="{{ _("MiB") }}" min="1" max="262144" required>
-    <label for="image_create_drive_name">{{ _("Masquerade as:") }}</label>
+    <label for="image_create_drive_name">{{ _("Identify as:") }}</label>
     <select name="drive_name" id="image_create_drive_name">
     <option value="">
-    {{ _("None") }}
+    {{ _("Generic device") }}
     </option>
     {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
     <option value="{{ drive.name }}">
@@ -620,7 +623,7 @@
     <label for="drive_format">{{ _("Format as:") }}</label>
     <select name="drive_format" id="drive_format">
     <option value="">
-    {{ _("None") }}
+    {{ _("Unformatted") }}
     </option>
     <option value="Lido 7.56">
     HFS + Lido

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -405,8 +405,6 @@
         {% else %}
         <li>{{ _("Please configure the <tt>piscsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
         {% endif %}
-        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}</li>
-        </li>
         <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types") }}
         </li>
     </ul>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -513,16 +513,18 @@
     {{ _("The images directory is currently empty.") }}
 </div>
 {% endif %}
-<p><small>{{ _("%(disk_space)s MiB disk space remaining for images", disk_space=env["free_disk_space"]) }}</small></p>
-</section>
+<p>
+    <small>{{ _("%(disk_space)s MiB disk space remaining for images", disk_space=env["free_disk_space"]) }}</small>
+</p>
 
 {% else %}
 
 <div class="notice">
-{{ _("Please create the PiSCSI images dir to work with disk images:")}} {{ env["image_dir"] }}
+    {{ _("Please create the PiSCSI images dir to work with disk images:")}} {{ env["image_dir"] }}
 </div>
 
 {% endif %}
+</section>
 
 <hr/>
 

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -304,6 +304,8 @@
                 {% if f["name"].lower().endswith(env['mo_suffixes']) %}
                 <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
                 {% endif %}
+                {% else %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
                 {% endif %}
                 {% endfor %}
                 </select>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -92,6 +92,7 @@
             <td class="parameters">
             {% if "No Media" in device.status %}
                 <form action="/scsi/attach" method="post">
+                    <label for="device_list_file_name_{{ device.id }}_{{ device.unit }}">{{ _("File:") }}</label>
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
                     <input name="type" type="hidden" value="{{ device.device_type }}">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -443,10 +443,10 @@
                 {% endif %}
                 {% endfor %}
                 {% if type in DISK_DEVICE_TYPES %}
-                <label for="{{ type }}_drive_name">{{ _("Masquerade as:") }}</label>
+                <label for="{{ type }}_drive_name">{{ _("Identify as:") }}</label>
                 <select name="drive_name" id="{{ type }}_drive_name">
                 <option value="">
-                {{ _("None") }}
+                {{ _("Generic device") }}
                 </option>
                 {% if type == "SCHD" %}
                 {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
@@ -480,7 +480,7 @@
                 <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
                 <select name="file_name" id="{{ type }}_image_file_name">
                 <option value="">
-                {{ _("None") }}
+                {{ _("Choose an image file...") }}
                 </option>
                 {% for f in files|sort(attribute='name') %}
                 {% if type == "SCHD" %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -91,7 +91,7 @@
             <td class="name" align="center">{{ device.device_name }}</td>
             <td class="parameters">
                 {% if "No Media" in device.status %}
-                <form action="/scsi/attach_device" method="post">
+                <form action="/scsi/attach" method="post">
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
                     <input name="type" type="hidden" value="{{ device.device_type }}">
@@ -227,7 +227,7 @@
             <div>{{ type }}</div>
         </td>
         <td>
-            <form action="/scsi/attach_device" method="post" class="device-attach">
+            <form action="/scsi/attach" method="post" class="device-attach">
                 <input name="type" type="hidden" value="{{ type }}">
                 {% for key, value in device_types[type]["params"] | dictsort %}
                 <label for="param_{{ type }}_{{ key }}">{{ key }}:</label>
@@ -444,7 +444,7 @@
                     <input type="submit" value="{{ _("Extract") }}" title="{{ _("Extract") }}" onclick="processNotify('{{ _("Extracting all files...") }}')">
                 </form>
                 {% else %}
-                <form action="/scsi/attach_device" method="post" class="file-attach">
+                <form action="/scsi/attach" method="post" class="file-attach">
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
                     <label for="image_list_scsi_id_{{ file["name"] }}">{{ _("ID") }}</label>
                     <select name="scsi_id" id="image_list_scsi_id_{{ file["name"] }}">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -418,7 +418,17 @@
     {% for type in device_types.keys() %}
     <tr>
         <td>
+            {% if device_types[type]["name"] == type %}
+            {% if type in REMOVABLE_DEVICE_TYPES %}
+            <div>{{ _("Unknown Removable Disk Drive") }}</div>
+            {% elif type in DISK_DEVICE_TYPES %}
+            <div>{{ _("Unknown Fixed Disk Drive") }}</div>
+            {% else %}
+            <div>{{ _("Unknown Device") }}</div>
+            {% endif %}
+            {% else %}
             <div>{{ device_types[type]["name"] }}</div>
+            {% endif %}
         </td>
         <td>
             <div>{{ type }}</div>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -455,7 +455,7 @@
                 {% endfor %}
                 {% if type in DISK_DEVICE_TYPES %}
                 <label for="{{ type }}_drive_name">{{ _("Identify as:") }}</label>
-                <select name="drive_name" id="{{ type }}_drive_name">
+                <select name="drive_name" id="{{ type }}_drive_name" class="table-dropdown">
                 <option value="">
                 {{ _("Generic device") }}
                 </option>
@@ -489,7 +489,7 @@
                 {% endif %}
                 </select>
                 <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
-                <select name="file_name" id="{{ type }}_image_file_name" {% if type not in REMOVABLE_DEVICE_TYPES %}required{% endif %}>
+                <select name="file_name" id="{{ type }}_image_file_name" class="table-dropdown" {% if type not in REMOVABLE_DEVICE_TYPES %}required{% endif %}>
                 <option value="" selected {% if type not in REMOVABLE_DEVICE_TYPES %}disabled{% endif %}>
                 {% if type in REMOVABLE_DEVICE_TYPES %}
                 {{ _("None") }}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -83,11 +83,10 @@
             <td class="name" align="center">{{ device.device_name }}</td>
             <td class="parameters">
                 {% if "No Media" in device.status %}
-                <form action="/scsi/attach" method="post">
+                <form action="/scsi/attach_device" method="post">
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
                     <input name="type" type="hidden" value="{{ device.device_type }}">
-                    <input name="file_size" type="hidden" value="{{ device.size }}">
                     <label for="device_list_file_name_{{ device.id }}_{{ device.unit }}">{{ _("File name") }}</label>
                     <select type="select" name="file_name" id="device_list_file_name_{{ device.id }}_{{ device.unit }}">
                     {% for f in files|sort(attribute='name') %}
@@ -187,6 +186,140 @@
 
 <hr/>
 
+<section id="attach-devices">
+<details>
+    <summary class="heading">
+        {{ _("Attach Device") }}
+    </summary>
+    <ul>
+        </li>
+        {% if bridge_configured %}
+        <li>{{ _("The <tt>piscsi_bridge</tt> network bridge is active and ready to be used by an emulated network adapter!") }}</li>
+        {% else %}
+        <li>{{ _("Please configure the <tt>piscsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
+        {% endif %}
+        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}</li>
+        </li>
+        <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types") }}
+        </li>
+    </ul>
+</details>
+<table border="black" cellpadding="3" summary="List of peripheral devices">
+    <tr>
+        <th scope="col">{{ _("Device") }}</th>
+        <th scope="col">{{ _("Key") }}</th>
+        <th scope="col">{{ _("Parameters and Actions") }}</th>
+    </tr>
+    {% for type in device_types.keys() %}
+    <tr>
+        <td>
+            <div>{{ device_types[type]["name"] }}</div>
+        </td>
+        <td>
+            <div>{{ type }}</div>
+        </td>
+        <td>
+            <form action="/scsi/attach_device" method="post" class="device-attach">
+                <input name="type" type="hidden" value="{{ type }}">
+                {% for key, value in device_types[type]["params"] | dictsort %}
+                <label for="param_{{ type }}_{{ key }}">{{ key }}:</label>
+                {% if value.isnumeric() %}
+                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="number" value="{{ value }}">
+                {% elif key == "interface" %}
+                <select name="param_{{ key }}" id="param_{{ type }}_{{ key }}">
+                {% for if in netinfo["ifs"] %}
+                    <option value="{{ if }}">
+                        {{ if }}
+                    </option>
+                {% endfor %}
+                </select>
+                {% else %}
+                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="text" size="{{ value|length }}" placeholder="{{ value }}">
+                {% endif %}
+                {% endfor %}
+                {% if type in DISK_DEVICE_TYPES %}
+                <label for="{{ type }}_drive_name">{{ _("Masquerade as:") }}</label>
+                <select name="drive_name" id="{{ type }}_drive_name">
+                <option value="">
+                {{ _("None") }}
+                </option>
+                {% if type == "SCHD" %}
+                {% for drive in drive_properties["hd_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCCD" %}
+                {% for drive in drive_properties["cd_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCRM" %}
+                {% for drive in drive_properties["rm_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                {% if type == "SCMO" %}
+                {% for drive in drive_properties["mo_conf"] | sort(attribute='name') %}
+                <option value="{{ drive.name }}">
+                {{ drive.name }}
+                </option>
+                {% endfor %}
+                {% endif %}
+                </select>
+                <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
+                <select name="file_name" id="{{ type }}_image_file_name">
+                {% if type != "SCHD" %}
+                <option value="">
+                {{ _("None") }}
+                </option>
+                {% endif %}
+                {% for f in files|sort(attribute='name') %}
+                {% if type == "SCHD" %}
+                {% if f["name"].lower().endswith(env['hd_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCCD" %}
+                {% if f["name"].lower().endswith(env['cd_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCRM" %}
+                {% if f["name"].lower().endswith(env['rm_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% elif type == "SCMO" %}
+                {% if f["name"].lower().endswith(env['mo_suffixes']) %}
+                <option value="{{ f["name"] }}">{{ f["name"].replace(env["image_dir"], '') }}</option>
+                {% endif %}
+                {% endif %}
+                {% endfor %}
+                </select>
+                {% endif %}
+                <label for="{{ type }}_scsi_id">{{ _("ID") }}</label>
+                <select name="scsi_id" id="{{ type }}_scsi_id">
+                {% for id in scsi_ids["valid_ids"] %}
+                    <option value="{{ id }}"{% if id == scsi_ids["recommended_id"] %} selected{% endif %}>
+                        {{ id }}
+                    </option>
+                {% endfor %}
+                </select>
+                <label for="{{ type }}_unit">{{ _("LUN") }}</label>
+                <input class="lun" name="unit" id="{{ type }}_unit" type="number" value="0" min="0" max="31" step="1" size="3">
+                <input type="submit" value="{{ _("Attach") }}" title="{{ _("Attach") }}">
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+</section>
+
+<hr/>
+
 <section id="files">
 <details>
     <summary class="heading">
@@ -218,7 +351,7 @@
 <div>
 {% for subdir, group in formatted_image_files.items() %}
 
-<details class="subdir"{% if subdir == env["image_root_dir"] + "/" %} open{% endif %}>
+<details class="subdir">
     <summary class="dirname">
         {{ subdir }}
     </summary>
@@ -307,9 +440,8 @@
                     <input type="submit" value="{{ _("Extract") }}" title="{{ _("Extract") }}" onclick="processNotify('{{ _("Extracting all files...") }}')">
                 </form>
                 {% else %}
-                <form action="/scsi/attach" method="post" class="file-attach">
+                <form action="/scsi/attach_device" method="post" class="file-attach">
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
-                    <input name="file_size" type="hidden" value="{{ file['size'] }}">
                     <label for="image_list_scsi_id_{{ file["name"] }}">{{ _("ID") }}</label>
                     <select name="scsi_id" id="image_list_scsi_id_{{ file["name"] }}">
                         {% for id in scsi_ids["valid_ids"] %}
@@ -566,106 +698,6 @@
 
 <section id="create-drive">
     <a href="/drive/list"><p>{{ _("Create Disk Image With Properties") }}</p></a>
-</section>
-
-<hr/>
-
-<section id="attach-devices">
-<details>
-    <summary class="heading">
-        {{ _("Attach Peripheral Device") }}
-    </summary>
-    <ul>
-        </li>
-        {% if bridge_configured %}
-        <li>{{ _("The <tt>piscsi_bridge</tt> network bridge is active and ready to be used by an emulated network adapter!") }}</li>
-        {% else %}
-        <li>{{ _("Please configure the <tt>piscsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
-        {% endif %}
-        <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/PiSCSI/piscsi/wiki/Vintage-Web-Proxy#macproxy") }}</li>
-        </li>
-        <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/PiSCSI/piscsi/wiki/Supported-Device-Types") }}
-        </li>
-    </ul>
-</details>
-<table border="black" cellpadding="3" summary="List of peripheral devices">
-    <tr>
-        <th scope="col">{{ _("Device") }}</th>
-        <th scope="col">{{ _("Key") }}</th>
-        <th scope="col">{{ _("Parameters and Actions") }}</th>
-    </tr>
-    {% for type in REMOVABLE_DEVICE_TYPES + PERIPHERAL_DEVICE_TYPES %}
-    <tr>
-        <td>
-            <div>{{ device_types[type]["name"] }}</div>
-        </td>
-        <td>
-            <div>{{ type }}</div>
-        </td>
-        <td>
-            <form action="/scsi/attach_device" method="post" class="device-attach">
-                <input name="type" type="hidden" value="{{ type }}">
-                {% for key, value in device_types[type]["params"] | dictsort %}
-                <label for="param_{{ type }}_{{ key }}">{{ key }}:</label>
-                {% if value.isnumeric() %}
-                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="number" value="{{ value }}">
-                {% elif key == "interface" %}
-                <select name="param_{{ key }}" id="param_{{ type }}_{{ key }}">
-                {% for if in netinfo["ifs"] %}
-                    <option value="{{ if }}">
-                        {{ if }}
-                    </option>
-                {% endfor %}
-                </select>
-                {% else %}
-                <input name="param_{{ key }}" id="param_{{ type }}_{{ key }}" type="text" size="{{ value|length }}" placeholder="{{ value }}">
-                {% endif %}
-                {% endfor %}
-                {% if type in REMOVABLE_DEVICE_TYPES %}
-                <label for="{{ type }}_drive_name">{{ _("Masquerade as:") }}</label>
-                <select name="drive_name" id="{{ type }}_drive_name">
-                <option value="">
-                {{ _("None") }}
-                </option>
-                {% if type == "SCCD" %}
-                {% for drive in drive_properties["cd_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                {% if type == "SCRM" %}
-                {% for drive in drive_properties["rm_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                {% if type == "SCMO" %}
-                {% for drive in drive_properties["mo_conf"] | sort(attribute='name') %}
-                <option value="{{ drive.name }}">
-                {{ drive.name }}
-                </option>
-                {% endfor %}
-                {% endif %}
-                </select>
-                {% endif %}
-                <label for="{{ type }}_scsi_id">{{ _("ID") }}</label>
-                <select name="scsi_id" id="{{ type }}_scsi_id">
-                {% for id in scsi_ids["valid_ids"] %}
-                    <option value="{{ id }}"{% if id == scsi_ids["recommended_id"] %} selected{% endif %}>
-                        {{ id }}
-                    </option>
-                {% endfor %}
-                </select>
-                <label for="{{ type }}_unit">{{ _("LUN") }}</label>
-                <input class="lun" name="unit" id="{{ type }}_unit" type="number" value="0" min="0" max="31" step="1" size="3">
-                <input type="submit" value="{{ _("Attach") }}" title="{{ _("Attach") }}">
-            </form>
-        </td>
-    </tr>
-    {% endfor %}
-</table>
 </section>
 
 <hr/>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -24,6 +24,7 @@
     </ul>
 </details>
 
+{% if env["cfg_dir_exists"] %}
 <p>
 <form action="/config/action" method="post" id="config-actions">
     <label for="config_load_name">{{ _("File Name:") }}</label>
@@ -54,6 +55,13 @@
     <input type="submit" value="{{ _("Save") }}">
 </form>
 </p>
+{% else %}
+
+<div class="notice">
+{{ _("Please create the PiSCSI configuration dir to use configurations:")}} {{ CFG_DIR }}
+</div>
+
+{% endif %}
 
 <table id="attached-devices" border="black" cellpadding="3" summary="List of attached devices">
     <tbody>
@@ -342,12 +350,8 @@
     </ul>
 </details>
 
-{% if not files|length: %}
-<div class="notice">
-    {{ _("The images directory is currently empty.") }}
-</div>
-{% else %}
-
+{% if not env["image_dir_exists"] %}
+{% if files|length %}
 <div>
 {% for subdir, group in formatted_image_files.items() %}
 
@@ -502,9 +506,23 @@
 </details>
 {% endfor %}
 </div>
+
+{% else %}
+
+<div class="notice">
+    {{ _("The images directory is currently empty.") }}
+</div>
 {% endif %}
 <p><small>{{ _("%(disk_space)s MiB disk space remaining for images", disk_space=env["free_disk_space"]) }}</small></p>
 </section>
+
+{% else %}
+
+<div class="notice">
+{{ _("Please create the PiSCSI images dir to work with disk images:")}} {{ env["image_dir"] }}
+</div>
+
+{% endif %}
 
 <hr/>
 

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -479,11 +479,9 @@
                 </select>
                 <label for="{{ type }}_image_file_name">{{ _("Image file:") }}</label>
                 <select name="file_name" id="{{ type }}_image_file_name">
-                {% if type != "SCHD" %}
                 <option value="">
                 {{ _("None") }}
                 </option>
-                {% endif %}
                 {% for f in files|sort(attribute='name') %}
                 {% if type == "SCHD" %}
                 {% if f["name"].lower().endswith(env['hd_suffixes']) %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -95,7 +95,7 @@
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
                     <input name="unit" type="hidden" value="{{ device.unit }}">
                     <input name="type" type="hidden" value="{{ device.device_type }}">
-                    <label for="device_list_file_name_{{ device.id }}_{{ device.unit }}">{{ _("File name") }}</label>
+                    <label for="device_list_file_name_{{ device.id }}_{{ device.unit }}">{{ _("Image file:") }}</label>
                     <select type="select" name="file_name" id="device_list_file_name_{{ device.id }}_{{ device.unit }}">
                     {% for f in files|sort(attribute='name') %}
                     {% if device.device_type == "SCCD" %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -350,7 +350,7 @@
     </ul>
 </details>
 
-{% if not env["image_dir_exists"] %}
+{% if env["image_dir_exists"] %}
 {% if files|length %}
 <div>
 {% for subdir, group in formatted_image_files.items() %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -193,6 +193,7 @@
 </section>
 
 <hr/>
+
 <section id="files">
 <details>
     <summary class="heading">
@@ -220,7 +221,7 @@
 <div>
 {% for subdir, group in formatted_image_files.items() %}
 
-<details class="subdir">
+<details class="subdir"{% if subdir == env["image_root_dir"] + "/" %} open{% endif %}>
     <summary class="dirname">
         {{ subdir }}
     </summary>

--- a/python/web/src/translations/de/LC_MESSAGES/messages.po
+++ b/python/web/src/translations/de/LC_MESSAGES/messages.po
@@ -1309,7 +1309,7 @@ msgstr ""
 
 #: src/templates/index.html:594
 msgid "Key"
-msgstr "Taste"
+msgstr "Kürzel"
 
 #: src/templates/index.html:595
 msgid "Parameters and Actions"

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -643,7 +643,7 @@ def log_level():
     return response(error=True, message=process["msg"])
 
 
-@APP.route("/scsi/attach_device", methods=["POST"])
+@APP.route("/scsi/attach", methods=["POST"])
 @login_required
 def attach_device():
     """

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -305,8 +305,6 @@ def drive_list():
     """
     Sets up the data structures and kicks off the rendering of the drive list page
     """
-    server_info = piscsi_cmd.get_server_info()
-
     return response(
         template="drives.html",
         page_title=_("PiSCSI Create Drive"),

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -46,7 +46,6 @@ from return_code_mapper import ReturnCodeMapper
 from socket_cmds_flask import SocketCmdsFlask
 
 from web_utils import (
-    working_dirs_exist,
     sort_and_format_devices,
     get_valid_scsi_ids,
     map_device_types_and_names,
@@ -125,6 +124,8 @@ def get_env_info():
         "image_dir": server_info["image_dir"],
         "image_root_dir": Path(server_info["image_dir"]).name,
         "shared_root_dir": Path(FILE_SERVER_DIR).name,
+        "image_dir_exists": Path(server_info["image_dir"]).exists(),
+        "cfg_dir_exists": Path(CFG_DIR).exists(),
         "hd_suffixes": tuple(server_info["schd"]),
         "cd_suffixes": tuple(server_info["sccd"]),
         "rm_suffixes": tuple(server_info["scrm"]),
@@ -220,7 +221,6 @@ def index():
     Sets up data structures for and renders the index page
     """
     server_info = piscsi_cmd.get_server_info()
-    working_dirs_exist((server_info["image_dir"], CFG_DIR))
 
     devices = piscsi_cmd.list_devices()
     device_types = map_device_types_and_names(piscsi_cmd.get_device_types()["device_types"])
@@ -306,7 +306,6 @@ def drive_list():
     Sets up the data structures and kicks off the rendering of the drive list page
     """
     server_info = piscsi_cmd.get_server_info()
-    working_dirs_exist((server_info["image_dir"], CFG_DIR))
 
     return response(
         template="drives.html",
@@ -343,7 +342,6 @@ def upload_page():
     Sets up the data structures and kicks off the rendering of the file uploading page
     """
     server_info = piscsi_cmd.get_server_info()
-    working_dirs_exist((server_info["image_dir"], CFG_DIR))
 
     return response(
         template="upload.html",
@@ -545,7 +543,6 @@ def show_diskinfo():
     if not safe_path["status"]:
         return response(error=True, message=safe_path["msg"])
     server_info = piscsi_cmd.get_server_info()
-    working_dirs_exist((server_info["image_dir"], CFG_DIR))
     returncode, diskinfo = sys_cmd.get_diskinfo(Path(server_info["image_dir"]) / file_name)
     if returncode == 0:
         return response(

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -8,24 +8,11 @@ from pathlib import Path
 from ua_parser import user_agent_parser
 from re import findall
 
-from flask import request, abort
+from flask import request
 from flask_babel import _
 from werkzeug.utils import secure_filename
 
 from piscsi.sys_cmds import SysCmds
-
-
-def working_dirs_exist(working_dirs):
-    """
-    Method for validating that working dirs exist.
-    Takes (tuple) of (str) working_dirs with paths to required dirs.
-    """
-    for dir_path in working_dirs:
-        if not Path(dir_path).exists():
-            abort(
-                503,
-                _(f"Please create directory: {dir_path}"),
-            )
 
 
 def get_valid_scsi_ids(devices, reserved_ids):

--- a/python/web/tests/api/conftest.py
+++ b/python/web/tests/api/conftest.py
@@ -8,6 +8,41 @@ FILE_SIZE_1_MIB = 1048576
 STATUS_SUCCESS = "success"
 STATUS_ERROR = "error"
 
+ENV_ENDPOINT = "/env"
+HEALTHCHECK_ENDPOINT = "/healthcheck"
+PWA_FAVICON_ENDPOINT = "/pwa/favicon.ico"
+LOGIN_ENDPOINT = "/login"
+LOGOUT_ENDPOINT = "/logout"
+ATTACH_ENDPOINT = "/scsi/attach"
+DETACH_ENDPOINT = "/scsi/detach"
+DETACH_ALL_ENDPOINT = "/scsi/detach_all"
+EJECT_ENDPOINT = "/scsi/eject"
+RESERVE_ENDPOINT = "/scsi/reserve"
+RELEASE_ENDPOINT = "/scsi/release"
+INFO_ENDPOINT = "/scsi/info"
+CREATE_ENDPOINT = "/files/create"
+RENAME_ENDPOINT = "/files/rename"
+COPY_ENDPOINT = "/files/copy"
+DELETE_ENDPOINT = "/files/delete"
+DOWNLOAD_URL_ENDPOINT = "/files/download_url"
+DOWNLOAD_IMAGE_ENDPOINT = "/files/download_image"
+DOWNLOAD_CONFIG_ENDPOINT = "/files/download_config"
+EXTRACT_IMAGE_ENDPOINT = "/files/extract_image"
+UPLOAD_ENDPOINT = "/files/upload"
+CREATE_ISO_ENDPOINT = "/files/create_iso"
+DISKINFO_ENDPOINT = "/files/diskinfo"
+DRIVE_LIST_ENDPOINT = "/drive/list"
+DRIVE_CREATE_ENDPOINT = "/drive/create"
+DRIVE_CDROM_ENDPOINT = "/drive/cdrom"
+MANPAGE_ENDPOINT = "/sys/manpage?app=piscsi"
+LANGUAGE_ENDPOINT = "/language"
+LOG_LEVEL_ENDPOINT = "/logs/level"
+LOG_SHOW_ENDPOINT = "/logs/show"
+CONFIG_SAVE_ENDPOINT = "/config/save"
+CONFIG_ACTION_ENDPOINT = "/config/action"
+THEME_ENDPOINT = "/theme"
+SYS_RENAME_ENDPOINT = "/sys/rename"
+
 
 @pytest.fixture(scope="function")
 def create_test_image(request, http_client):
@@ -18,7 +53,7 @@ def create_test_image(request, http_client):
         file_name = f"{file_prefix}.{image_type}"
 
         response = http_client.post(
-            "/files/create",
+            CREATE_ENDPOINT,
             data={
                 "file_name": file_prefix,
                 "type": image_type,
@@ -42,7 +77,7 @@ def create_test_image(request, http_client):
 
     def delete():
         for image in images:
-            response = http_client.post("/files/delete", data={"file_name": image["file_name"]})
+            response = http_client.post(DELETE_ENDPOINT, data={"file_name": image["file_name"]})
             if response.status_code != 200 or response.json()["status"] != STATUS_SUCCESS:
                 warnings.warn(
                     f"Failed to auto-delete file created with create_test_image fixture: {image}"
@@ -71,7 +106,7 @@ def list_attached_images(http_client):
 @pytest.fixture(scope="function")
 def delete_file(http_client):
     def delete(file_name):
-        response = http_client.post("/files/delete", data={"file_name": file_name})
+        response = http_client.post(DELETE_ENDPOINT, data={"file_name": file_name})
         if response.status_code != 200 or response.json()["status"] != STATUS_SUCCESS:
             warnings.warn(f"Failed to delete file via delete_file fixture: {file_name}")
 
@@ -81,7 +116,7 @@ def delete_file(http_client):
 @pytest.fixture(scope="function")
 def detach_devices(http_client):
     def detach():
-        response = http_client.post("/scsi/detach_all")
+        response = http_client.post(DETACH_ALL_ENDPOINT)
         if response.json()["status"] == STATUS_SUCCESS:
             return True
         raise Exception("Failed to detach SCSI devices")

--- a/python/web/tests/api/test_auth.py
+++ b/python/web/tests/api/test_auth.py
@@ -1,11 +1,10 @@
-from conftest import STATUS_SUCCESS, STATUS_ERROR
+from conftest import STATUS_SUCCESS, STATUS_ERROR, LOGIN_ENDPOINT, LOGOUT_ENDPOINT
 
 
-# route("/login", methods=["POST"])
 def test_login_with_valid_credentials(pytestconfig, http_client_unauthenticated):
     # Note: This test depends on the piscsi group existing and 'username' a member the group
     response = http_client_unauthenticated.post(
-        "/login",
+        LOGIN_ENDPOINT,
         data={
             "username": pytestconfig.getoption("piscsi_username"),
             "password": pytestconfig.getoption("piscsi_password"),
@@ -19,10 +18,9 @@ def test_login_with_valid_credentials(pytestconfig, http_client_unauthenticated)
     assert "env" in response_data["data"]
 
 
-# route("/login", methods=["POST"])
 def test_login_with_invalid_credentials(http_client_unauthenticated):
     response = http_client_unauthenticated.post(
-        "/login",
+        LOGIN_ENDPOINT,
         data={
             "username": "__INVALID_USER__",
             "password": "__INVALID_PASS__",
@@ -38,7 +36,6 @@ def test_login_with_invalid_credentials(http_client_unauthenticated):
     )
 
 
-# route("/logout")
 def test_logout(http_client):
-    response = http_client.get("/logout")
+    response = http_client.get(LOGOUT_ENDPOINT)
     assert response.status_code == 200

--- a/python/web/tests/api/test_devices.py
+++ b/python/web/tests/api/test_devices.py
@@ -3,15 +3,21 @@ import pytest
 from conftest import (
     SCSI_ID,
     STATUS_SUCCESS,
+    ATTACH_ENDPOINT,
+    DETACH_ENDPOINT,
+    DETACH_ALL_ENDPOINT,
+    EJECT_ENDPOINT,
+    RESERVE_ENDPOINT,
+    RELEASE_ENDPOINT,
+    INFO_ENDPOINT,
 )
 
 
-# route("/scsi/attach_device", methods=["POST"])
 def test_attach_device_with_image(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     response = http_client.post(
-        "/scsi/attach_device",
+        ATTACH_ENDPOINT,
         data={
             "file_name": test_image,
             "scsi_id": SCSI_ID,
@@ -31,7 +37,6 @@ def test_attach_device_with_image(http_client, create_test_image, detach_devices
     detach_devices()
 
 
-# route("/scsi/attach_device", methods=["POST"])
 @pytest.mark.parametrize(
     "device_name,device_config",
     [
@@ -87,7 +92,7 @@ def test_attach_device(env, http_client, detach_devices, device_name, device_con
     device_config["unit"] = 0
 
     response = http_client.post(
-        "/scsi/attach_device",
+        ATTACH_ENDPOINT,
         data=device_config,
     )
 
@@ -103,12 +108,11 @@ def test_attach_device(env, http_client, detach_devices, device_name, device_con
     detach_devices()
 
 
-# route("/scsi/detach", methods=["POST"])
 def test_detach_device(http_client, create_test_image):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach_device",
+        ATTACH_ENDPOINT,
         data={
             "file_name": test_image,
             "scsi_id": SCSI_ID,
@@ -118,7 +122,7 @@ def test_detach_device(http_client, create_test_image):
     )
 
     response = http_client.post(
-        "/scsi/detach",
+        DETACH_ENDPOINT,
         data={
             "scsi_id": SCSI_ID,
             "unit": 0,
@@ -132,7 +136,6 @@ def test_detach_device(http_client, create_test_image):
     assert response_data["messages"][0]["message"] == f"Detached SCSI ID {SCSI_ID} LUN 0"
 
 
-# route("/scsi/detach_all", methods=["POST"])
 def test_detach_all_devices(http_client, create_test_image, list_attached_images):
     test_images = []
     scsi_ids = [4, 5, 6]
@@ -142,7 +145,7 @@ def test_detach_all_devices(http_client, create_test_image, list_attached_images
         test_images.append(test_image)
 
         http_client.post(
-            "/scsi/attach_device",
+            ATTACH_ENDPOINT,
             data={
                 "file_name": test_image,
                 "scsi_id": scsi_id,
@@ -153,7 +156,7 @@ def test_detach_all_devices(http_client, create_test_image, list_attached_images
 
     assert list_attached_images() == test_images
 
-    response = http_client.post("/scsi/detach_all")
+    response = http_client.post(DETACH_ALL_ENDPOINT)
     response_data = response.json()
 
     assert response.status_code == 200
@@ -161,12 +164,11 @@ def test_detach_all_devices(http_client, create_test_image, list_attached_images
     assert list_attached_images() == []
 
 
-# route("/scsi/eject", methods=["POST"])
 def test_eject_device(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach_device",
+        ATTACH_ENDPOINT,
         data={
             "file_name": test_image,
             "scsi_id": SCSI_ID,
@@ -176,7 +178,7 @@ def test_eject_device(http_client, create_test_image, detach_devices):
     )
 
     response = http_client.post(
-        "/scsi/eject",
+        EJECT_ENDPOINT,
         data={
             "scsi_id": SCSI_ID,
             "unit": 0,
@@ -193,12 +195,11 @@ def test_eject_device(http_client, create_test_image, detach_devices):
     detach_devices()
 
 
-# route("/scsi/info", methods=["POST"])
 def test_show_device_info(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach_device",
+        ATTACH_ENDPOINT,
         data={
             "file_name": test_image,
             "scsi_id": SCSI_ID,
@@ -208,7 +209,7 @@ def test_show_device_info(http_client, create_test_image, detach_devices):
     )
 
     response = http_client.post(
-        "/scsi/info",
+        INFO_ENDPOINT,
     )
 
     response_data = response.json()
@@ -222,13 +223,11 @@ def test_show_device_info(http_client, create_test_image, detach_devices):
     detach_devices()
 
 
-# route("/scsi/reserve", methods=["POST"])
-# route("/scsi/release", methods=["POST"])
 def test_reserve_and_release_device(http_client):
     scsi_id = 0
 
     response = http_client.post(
-        "/scsi/reserve",
+        RESERVE_ENDPOINT,
         data={
             "scsi_id": scsi_id,
             "memo": "TEST",
@@ -242,7 +241,7 @@ def test_reserve_and_release_device(http_client):
     assert response_data["messages"][0]["message"] == f"Reserved SCSI ID {scsi_id}"
 
     response = http_client.post(
-        "/scsi/release",
+        RELEASE_ENDPOINT,
         data={
             "scsi_id": scsi_id,
         },

--- a/python/web/tests/api/test_devices.py
+++ b/python/web/tests/api/test_devices.py
@@ -2,20 +2,18 @@ import pytest
 
 from conftest import (
     SCSI_ID,
-    FILE_SIZE_1_MIB,
     STATUS_SUCCESS,
 )
 
 
-# route("/scsi/attach", methods=["POST"])
-def test_attach_image(http_client, create_test_image, detach_devices):
+# route("/scsi/attach_device", methods=["POST"])
+def test_attach_device_with_image(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     response = http_client.post(
-        "/scsi/attach",
+        "/scsi/attach_device",
         data={
             "file_name": test_image,
-            "file_size": FILE_SIZE_1_MIB,
             "scsi_id": SCSI_ID,
             "unit": 0,
             "type": "SCHD",
@@ -26,7 +24,7 @@ def test_attach_image(http_client, create_test_image, detach_devices):
     assert response.status_code == 200
     assert response_data["status"] == STATUS_SUCCESS
     assert response_data["messages"][0]["message"] == (
-        f"Attached {test_image} as Hard Disk Drive to SCSI ID {SCSI_ID} LUN 0"
+        f"Attached Hard Disk Drive to SCSI ID {SCSI_ID} LUN 0"
     )
 
     # Cleanup
@@ -110,10 +108,9 @@ def test_detach_device(http_client, create_test_image):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach",
+        "/scsi/attach_device",
         data={
             "file_name": test_image,
-            "file_size": FILE_SIZE_1_MIB,
             "scsi_id": SCSI_ID,
             "unit": 0,
             "type": "SCHD",
@@ -145,10 +142,9 @@ def test_detach_all_devices(http_client, create_test_image, list_attached_images
         test_images.append(test_image)
 
         http_client.post(
-            "/scsi/attach",
+            "/scsi/attach_device",
             data={
                 "file_name": test_image,
-                "file_size": FILE_SIZE_1_MIB,
                 "scsi_id": scsi_id,
                 "unit": 0,
                 "type": "SCHD",
@@ -170,10 +166,9 @@ def test_eject_device(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach",
+        "/scsi/attach_device",
         data={
             "file_name": test_image,
-            "file_size": FILE_SIZE_1_MIB,
             "scsi_id": SCSI_ID,
             "unit": 0,
             "type": "SCCD",  # CD-ROM
@@ -203,10 +198,9 @@ def test_show_device_info(http_client, create_test_image, detach_devices):
     test_image = create_test_image()
 
     http_client.post(
-        "/scsi/attach",
+        "/scsi/attach_device",
         data={
             "file_name": test_image,
-            "file_size": FILE_SIZE_1_MIB,
             "scsi_id": SCSI_ID,
             "unit": 0,
             "type": "SCHD",

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -5,16 +5,26 @@ import os
 from conftest import (
     FILE_SIZE_1_MIB,
     STATUS_SUCCESS,
+    CREATE_ENDPOINT,
+    RENAME_ENDPOINT,
+    COPY_ENDPOINT,
+    DELETE_ENDPOINT,
+    DOWNLOAD_URL_ENDPOINT,
+    DOWNLOAD_IMAGE_ENDPOINT,
+    DOWNLOAD_CONFIG_ENDPOINT,
+    EXTRACT_IMAGE_ENDPOINT,
+    UPLOAD_ENDPOINT,
+    CREATE_ISO_ENDPOINT,
+    DISKINFO_ENDPOINT,
 )
 
 
-# route("/files/create", methods=["POST"])
 def test_create_file(http_client, list_files, delete_file):
     file_prefix = str(uuid.uuid4())
     file_name = f"{file_prefix}.hds"
 
     response = http_client.post(
-        "/files/create",
+        CREATE_ENDPOINT,
         data={
             "file_name": file_prefix,
             "type": "hds",
@@ -34,13 +44,12 @@ def test_create_file(http_client, list_files, delete_file):
     delete_file(file_name)
 
 
-# route("/files/create", methods=["POST"])
 def test_create_file_with_properties(http_client, list_files, delete_file):
     file_prefix = str(uuid.uuid4())
     file_name = f"{file_prefix}.hds"
 
     response = http_client.post(
-        "/files/create",
+        CREATE_ENDPOINT,
         data={
             "file_name": file_prefix,
             "type": "hds",
@@ -64,13 +73,12 @@ def test_create_file_with_properties(http_client, list_files, delete_file):
     delete_file(file_name)
 
 
-# route("/files/create", methods=["POST"])
 def test_create_file_and_format_hfs(http_client, list_files, delete_file):
     file_prefix = str(uuid.uuid4())
     file_name = f"{file_prefix}.hda"
 
     response = http_client.post(
-        "/files/create",
+        CREATE_ENDPOINT,
         data={
             "file_name": file_prefix,
             "type": "hda",
@@ -91,7 +99,6 @@ def test_create_file_and_format_hfs(http_client, list_files, delete_file):
     delete_file(file_name)
 
 
-# route("/files/create", methods=["POST"])
 def test_create_file_and_format_fat(env, http_client, list_files, delete_file):
     if env["is_docker"]:
         pytest.skip("Test not supported in Docker environment.")
@@ -99,7 +106,7 @@ def test_create_file_and_format_fat(env, http_client, list_files, delete_file):
     file_name = f"{file_prefix}.hdr"
 
     response = http_client.post(
-        "/files/create",
+        CREATE_ENDPOINT,
         data={
             "file_name": file_prefix,
             "type": "hdr",
@@ -120,13 +127,12 @@ def test_create_file_and_format_fat(env, http_client, list_files, delete_file):
     delete_file(file_name)
 
 
-# route("/files/rename", methods=["POST"])
 def test_rename_file(http_client, create_test_image, list_files, delete_file):
     original_file = create_test_image(auto_delete=False)
     renamed_file = f"{uuid.uuid4()}.rename"
 
     response = http_client.post(
-        "/files/rename",
+        RENAME_ENDPOINT,
         data={"file_name": original_file, "new_file_name": renamed_file},
     )
 
@@ -141,13 +147,12 @@ def test_rename_file(http_client, create_test_image, list_files, delete_file):
     delete_file(renamed_file)
 
 
-# route("/files/copy", methods=["POST"])
 def test_copy_file(http_client, create_test_image, list_files, delete_file):
     original_file = create_test_image()
     copy_file = f"{uuid.uuid4()}.copy"
 
     response = http_client.post(
-        "/files/copy",
+        COPY_ENDPOINT,
         data={
             "file_name": original_file,
             "copy_file_name": copy_file,
@@ -167,11 +172,10 @@ def test_copy_file(http_client, create_test_image, list_files, delete_file):
     delete_file(copy_file)
 
 
-# route("/files/delete", methods=["POST"])
 def test_delete_file(http_client, create_test_image, list_files):
     file_name = create_test_image(auto_delete=False)
 
-    response = http_client.post("/files/delete", data={"file_name": file_name})
+    response = http_client.post(DELETE_ENDPOINT, data={"file_name": file_name})
 
     response_data = response.json()
 
@@ -181,7 +185,6 @@ def test_delete_file(http_client, create_test_image, list_files):
     assert file_name not in list_files()
 
 
-# route("/files/extract_image", methods=["POST"])
 @pytest.mark.parametrize(
     "archive_file_name,image_file_name",
     [
@@ -205,7 +208,7 @@ def test_extract_file(
     )
 
     http_client.post(
-        "/files/download_url",
+        DOWNLOAD_URL_ENDPOINT,
         data={
             "destination": "disk_images",
             "images_subdir": "",
@@ -214,7 +217,7 @@ def test_extract_file(
     )
 
     response = http_client.post(
-        "/files/extract_image",
+        EXTRACT_IMAGE_ENDPOINT,
         data={
             "archive_file": archive_file_name,
             "archive_members": image_file_name,
@@ -233,7 +236,6 @@ def test_extract_file(
     delete_file(image_file_name)
 
 
-# route("/files/upload", methods=["POST"])
 def test_upload_file(http_client, delete_file):
     file_name = f"{uuid.uuid4()}.test"
 
@@ -267,7 +269,7 @@ def test_upload_file(http_client, delete_file):
             file_data = {"file": (file_name, file.read(chunk_size))}
 
             response = http_client.post(
-                "/files/upload",
+                UPLOAD_ENDPOINT,
                 data=form_data,
                 files=file_data,
             )
@@ -283,11 +285,10 @@ def test_upload_file(http_client, delete_file):
     delete_file(file_name)
 
 
-# route("/files/download_image", methods=["POST"])
 def test_download_image(http_client, create_test_image):
     file_name = create_test_image()
 
-    response = http_client.post("/files/download_image", data={"file": file_name})
+    response = http_client.post(DOWNLOAD_IMAGE_ENDPOINT, data={"file": file_name})
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/octet-stream"
@@ -295,13 +296,12 @@ def test_download_image(http_client, create_test_image):
     assert response.headers["content-length"] == str(FILE_SIZE_1_MIB)
 
 
-# route("/files/download_config", methods=["POST"])
 def test_download_properties(http_client, list_files, delete_file):
     file_prefix = str(uuid.uuid4())
     file_name = f"{file_prefix}.hds"
 
     response = http_client.post(
-        "/files/create",
+        CREATE_ENDPOINT,
         data={
             "file_name": file_prefix,
             "type": "hds",
@@ -321,7 +321,7 @@ def test_download_properties(http_client, list_files, delete_file):
     )
     assert file_name in list_files()
 
-    response = http_client.post("/files/download_config", data={"file": f"{file_name}.properties"})
+    response = http_client.post(DOWNLOAD_CONFIG_ENDPOINT, data={"file": f"{file_name}.properties"})
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/octet-stream"
@@ -331,7 +331,6 @@ def test_download_properties(http_client, list_files, delete_file):
     delete_file(file_name)
 
 
-# route("/files/download_url", methods=["POST"])
 def test_download_url_to_dir(env, httpserver, http_client, list_files, delete_file):
     file_name = str(uuid.uuid4())
     http_path = f"/images/{file_name}"
@@ -347,7 +346,7 @@ def test_download_url_to_dir(env, httpserver, http_client, list_files, delete_fi
     )
 
     response = http_client.post(
-        "/files/download_url",
+        DOWNLOAD_URL_ENDPOINT,
         data={
             "destination": "disk_images",
             "images_subdir": subdir,
@@ -369,7 +368,6 @@ def test_download_url_to_dir(env, httpserver, http_client, list_files, delete_fi
     delete_file(file_name)
 
 
-# route("/files/create_iso", methods=["POST"])
 def test_create_iso_from_url(
     httpserver,
     http_client,
@@ -392,7 +390,7 @@ def test_create_iso_from_url(
     )
 
     response = http_client.post(
-        "/files/create_iso",
+        CREATE_ISO_ENDPOINT,
         data={
             "type": ISO_TYPE,
             "url": url,
@@ -414,7 +412,6 @@ def test_create_iso_from_url(
     delete_file(iso_file_name)
 
 
-# route("/files/create_iso", methods=["POST"])
 def test_create_iso_from_local_file(
     http_client,
     create_test_image,
@@ -427,7 +424,7 @@ def test_create_iso_from_local_file(
     ISO_TYPE = "HFS"
 
     response = http_client.post(
-        "/files/create_iso",
+        CREATE_ISO_ENDPOINT,
         data={
             "type": ISO_TYPE,
             "file": test_file_name,
@@ -449,12 +446,11 @@ def test_create_iso_from_local_file(
     delete_file(iso_file_name)
 
 
-# route("/files/diskinfo", methods=["POST"])
 def test_show_diskinfo(http_client, create_test_image):
     test_image = create_test_image()
 
     response = http_client.post(
-        "/files/diskinfo",
+        DISKINFO_ENDPOINT,
         data={
             "file_name": test_image,
         },

--- a/python/web/tests/api/test_misc.py
+++ b/python/web/tests/api/test_misc.py
@@ -3,10 +3,16 @@ import uuid
 from conftest import (
     FILE_SIZE_1_MIB,
     STATUS_SUCCESS,
+    ENV_ENDPOINT,
+    PWA_FAVICON_ENDPOINT,
+    HEALTHCHECK_ENDPOINT,
+    DRIVE_LIST_ENDPOINT,
+    DRIVE_CREATE_ENDPOINT,
+    DRIVE_CDROM_ENDPOINT,
+    MANPAGE_ENDPOINT,
 )
 
 
-# route("/")
 def test_index(http_client):
     response = http_client.get("/")
     response_data = response.json()
@@ -16,9 +22,8 @@ def test_index(http_client):
     assert "devices" in response_data["data"]
 
 
-# route("/env")
 def test_get_env_info(http_client):
-    response = http_client.get("/env")
+    response = http_client.get(ENV_ENDPOINT)
     response_data = response.json()
 
     assert response.status_code == 200
@@ -26,17 +31,15 @@ def test_get_env_info(http_client):
     assert "running_env" in response_data["data"]
 
 
-# route("/pwa/<path:pwa_path>")
 def test_pwa_route(http_client):
-    response = http_client.get("/pwa/favicon.ico")
+    response = http_client.get(PWA_FAVICON_ENDPOINT)
 
     assert response.status_code == 200
     assert response.headers["content-disposition"] == "inline; filename=favicon.ico"
 
 
-# route("/drive/list", methods=["GET"])
 def test_show_named_drive_presets(http_client):
-    response = http_client.get("/drive/list")
+    response = http_client.get(DRIVE_LIST_ENDPOINT)
     response_data = response.json()
 
     prev_drive = {"name": ""}
@@ -57,12 +60,11 @@ def test_show_named_drive_presets(http_client):
     assert "files" in response_data["data"]
 
 
-# route("/drive/cdrom", methods=["POST"])
 def test_create_cdrom_properties_file(env, http_client):
     file_name = f"{uuid.uuid4()}.iso"
 
     response = http_client.post(
-        "/drive/cdrom",
+        DRIVE_CDROM_ENDPOINT,
         data={
             "drive_name": "Sony CDU-8012",
             "file_name": file_name,
@@ -78,13 +80,12 @@ def test_create_cdrom_properties_file(env, http_client):
     )
 
 
-# route("/drive/create", methods=["POST"])
 def test_create_image_with_properties_file(http_client, delete_file):
     file_prefix = str(uuid.uuid4())
     file_name = f"{file_prefix}.hds"
 
     response = http_client.post(
-        "/drive/create",
+        DRIVE_CREATE_ENDPOINT,
         data={
             "drive_name": "Miniscribe M8425",
             "size": FILE_SIZE_1_MIB,
@@ -105,16 +106,14 @@ def test_create_image_with_properties_file(http_client, delete_file):
     delete_file(file_name)
 
 
-# route("/sys/manpage", methods=["POST"])
 def test_show_manpage(http_client):
-    response = http_client.get("/sys/manpage?app=piscsi")
+    response = http_client.get(MANPAGE_ENDPOINT)
     response_data = response.json()
 
     assert response.status_code == 200
     assert "piscsi" in response_data["data"]["manpage"]
 
 
-# route("/healthcheck", methods=["GET"])
 def test_healthcheck(http_client):
-    response = http_client.get("/healthcheck")
+    response = http_client.get(HEALTHCHECK_ENDPOINT)
     assert response.status_code == 200


### PR DESCRIPTION
What was known as the "Attach Peripheral Device" has been reworked as "Attach Device" and now lists all devices that the piscsi backend can support. As part of this change, Attach Device has been reimagined as the primary way one would attach a disk image as well, and moved up above the Image Management section.

- Add "image file" dropdown for each "supports_file" device type under Attach Device
- Under the hood, merge the two attach endpoints to reduce code duplication
- Move Attach Device further up on the page
- Collapse the list of images by default
- Remove the logic that checked for overflowing bytes in images (complexity for little payoff)
- Don't abort the Web UI when working dirs don't exist, but rather hide sections and show a warning message
- Correct the German translation for Key
- Refactor the integration tests to use globally defined endpoint constants