### PR TITLE
Freeze Python requirements for the Control Board client

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1111,7 +1111,7 @@ function installPiscsiCtrlBoard() {
     if [[ $SKIP_PACKAGES ]]; then
         echo "Skipping package installation"
     else
-        sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config --assume-yes --no-install-recommends </dev/null
+        sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config python3-rpi.gpio --assume-yes --no-install-recommends </dev/null
         # install python packages through apt that need compilation
         sudo apt-get install python3-cbor2 --assume-yes --no-install-recommends </dev/null
     fi

--- a/python/ctrlboard/requirements.txt
+++ b/python/ctrlboard/requirements.txt
@@ -1,10 +1,10 @@
-#adafruit-circuitpython-busdevice==5.1.1
-#adafruit-circuitpython-framebuf==1.4.8
-#adafruit-circuitpython-ssd1306==2.12.3
-luma-oled==3.8.1
+luma.core==2.4.1
+luma.oled==3.8.1
 Pillow==10.0.1
-RPi.GPIO==0.7.0
 protobuf==3.19.5
-unidecode==1.3.2
+pyftdi==0.55.0
+pyserial==3.5
+pyusb==1.2.1
 smbus==1.1.post2
-
+smbus2==0.4.3
+Unidecode==1.3.2


### PR DESCRIPTION
- Capture the local python dependencies with `pip freeze -l`
- Explicitly install the python3-rpi.gpio deb (although it seems to be installed by default in Raspbian Bullseye)