### PR TITLE
Honor sector size change via ModeSelect6 in scsicd

### DIFF
--- a/cpp/devices/disk.cpp
+++ b/cpp/devices/disk.cpp
@@ -696,11 +696,17 @@ uint32_t Disk::GetSectorSizeInBytes() const
 void Disk::SetSectorSizeInBytes(uint32_t size_in_bytes)
 {
 	if (!GetSupportedSectorSizes().contains(size_in_bytes)) {
-    	throw io_exception("Invalid sector size of " + to_string(size_in_bytes) + " byte(s)");
+		throw io_exception("Invalid sector size of " + to_string(size_in_bytes) + " byte(s)");
 	}
+	uint64_t current_blocks = GetBlockCount();
+	uint32_t current_size_shift_count = size_shift_count;
+	uint64_t current_size = current_blocks << current_size_shift_count;
 
 	size_shift_count = CalculateShiftCount(size_in_bytes);
 	assert(size_shift_count);
+	if ((current_blocks > 0) && (current_size_shift_count > 0)) {
+		SetBlockCount(current_size >> size_shift_count);
+	}
 }
 
 uint32_t Disk::GetConfiguredSectorSize() const
@@ -714,7 +720,7 @@ bool Disk::SetConfiguredSectorSize(uint32_t configured_size)
 		return false;
 	}
 
-    configured_sector_size = configured_size;
+	configured_sector_size = configured_size;
 
 	return true;
 }

--- a/cpp/devices/disk.h
+++ b/cpp/devices/disk.h
@@ -112,7 +112,7 @@ protected:
 
 	void SetUpCache(off_t, bool = false);
 	void ResizeCache(const string&, bool);
-
+        bool GetRawMode() { return (cache?cache->GetRawMode():false); }
 	void SetUpModePages(map<int, vector<byte>>&, int, bool) const override;
 	void AddErrorPage(map<int, vector<byte>>&, bool) const;
 	virtual void AddFormatPage(map<int, vector<byte>>&, bool) const;

--- a/cpp/devices/disk.h
+++ b/cpp/devices/disk.h
@@ -112,7 +112,7 @@ protected:
 
 	void SetUpCache(off_t, bool = false);
 	void ResizeCache(const string&, bool);
-        bool GetRawMode() { return (cache?cache->GetRawMode():false); }
+        bool GetRawMode() const { return (cache?cache->GetRawMode():false); }
 	void SetUpModePages(map<int, vector<byte>>&, int, bool) const override;
 	void AddErrorPage(map<int, vector<byte>>&, bool) const;
 	virtual void AddFormatPage(map<int, vector<byte>>&, bool) const;

--- a/cpp/devices/disk_cache.h
+++ b/cpp/devices/disk_cache.h
@@ -51,7 +51,7 @@ public:
 	~DiskCache() = default;
 
 	void SetRawMode(bool b) { cd_raw = b; }		// CD-ROM raw mode setting
-	bool GetRawMode() { return cd_raw; }
+	bool GetRawMode() const { return cd_raw; }
 
 	bool Save();							// Save and release all
 	bool ReadSector(span<uint8_t>, uint32_t);			// Sector Read

--- a/cpp/devices/disk_cache.h
+++ b/cpp/devices/disk_cache.h
@@ -51,6 +51,7 @@ public:
 	~DiskCache() = default;
 
 	void SetRawMode(bool b) { cd_raw = b; }		// CD-ROM raw mode setting
+	bool GetRawMode() { return cd_raw; }
 
 	bool Save();							// Save and release all
 	bool ReadSector(span<uint8_t>, uint32_t);			// Sector Read

--- a/cpp/devices/mode_page_device.cpp
+++ b/cpp/devices/mode_page_device.cpp
@@ -114,7 +114,7 @@ void ModePageDevice::ModeSense10() const
 	EnterDataInPhase();
 }
 
-void ModePageDevice::ModeSelect(scsi_command, cdb_t, span<const uint8_t>, int) const
+void ModePageDevice::ModeSelect(scsi_command, cdb_t, span<const uint8_t>, int)
 {
 	// There is no default implementation of MODE SELECT
 	throw scsi_exception(sense_key::illegal_request, asc::invalid_command_operation_code);

--- a/cpp/devices/mode_page_device.h
+++ b/cpp/devices/mode_page_device.h
@@ -23,7 +23,7 @@ public:
 
 	bool Init(const param_map&) override;
 
-	virtual void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) const;
+	virtual void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int);
 
 protected:
 

--- a/cpp/devices/scsicd.cpp
+++ b/cpp/devices/scsicd.cpp
@@ -165,6 +165,25 @@ vector<uint8_t> SCSICD::InquiryInternal() const
 	return HandleInquiry(device_type::cd_rom, scsi_level, true);
 }
 
+void SCSICD::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, int length)
+{
+	int sector_size = 1 << GetSectorSizeShiftCount();
+	int wanted_sector_size;
+	// skip Block Descriptor
+	int offset = 4;
+	// evaluate Mode Parameter Block Descriptor, sector size
+	wanted_sector_size = scsi_command_util::GetInt16(buf, offset + 6);
+	if (wanted_sector_size != sector_size) {
+		LogDebug("Changing sector size from " + to_string(sector_size) + " to " + to_string(wanted_sector_size));
+		SetSectorSizeInBytes(wanted_sector_size);
+	}
+
+	if (const string result = scsi_command_util::ModeSelect(cmd, cdb, buf, length, sector_size);
+		!result.empty()) {
+		LogWarn(result);
+	}
+}
+
 void SCSICD::SetUpModePages(map<int, vector<byte>>& pages, int page, bool changeable) const
 {
 	Disk::SetUpModePages(pages, page, changeable);

--- a/cpp/devices/scsicd.cpp
+++ b/cpp/devices/scsicd.cpp
@@ -176,6 +176,8 @@ void SCSICD::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, in
 	if (wanted_sector_size != sector_size) {
 		LogDebug("Changing sector size from " + to_string(sector_size) + " to " + to_string(wanted_sector_size));
 		SetSectorSizeInBytes(wanted_sector_size);
+		ClearTrack();
+		CreateDataTrack();
 	}
 
 	if (const string result = scsi_command_util::ModeSelect(cmd, cdb, buf, length, sector_size);

--- a/cpp/devices/scsicd.cpp
+++ b/cpp/devices/scsicd.cpp
@@ -178,6 +178,8 @@ void SCSICD::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, in
 		SetSectorSizeInBytes(wanted_sector_size);
 		ClearTrack();
 		CreateDataTrack();
+		FlushCache();
+		ResizeCache(GetFilename(), GetRawMode());
 	}
 
 	if (const string result = scsi_command_util::ModeSelect(cmd, cdb, buf, length, sector_size);

--- a/cpp/devices/scsicd.h
+++ b/cpp/devices/scsicd.h
@@ -34,6 +34,7 @@ public:
 
 	vector<uint8_t> InquiryInternal() const override;
 	int Read(span<uint8_t>, uint64_t) override;
+	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) override;
 
 protected:
 

--- a/cpp/devices/scsihd.cpp
+++ b/cpp/devices/scsihd.cpp
@@ -82,7 +82,7 @@ vector<uint8_t> SCSIHD::InquiryInternal() const
 	return HandleInquiry(device_type::direct_access, scsi_level, IsRemovable());
 }
 
-void SCSIHD::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, int length) const
+void SCSIHD::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, int length)
 {
 	if (const string result = scsi_command_util::ModeSelect(cmd, cdb, buf, length, 1 << GetSectorSizeShiftCount());
 		!result.empty()) {

--- a/cpp/devices/scsihd.h
+++ b/cpp/devices/scsihd.h
@@ -37,7 +37,7 @@ public:
 
 	// Commands
 	vector<uint8_t> InquiryInternal() const override;
-	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) const override;
+	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) override;
 
 	void AddFormatPage(map<int, vector<byte>>&, bool) const override;
 	void AddVendorPage(map<int, vector<byte>>&, int, bool) const override;

--- a/cpp/devices/scsimo.cpp
+++ b/cpp/devices/scsimo.cpp
@@ -88,7 +88,7 @@ void SCSIMO::AddOptionPage(map<int, vector<byte>>& pages, bool) const
 	// Do not report update blocks
 }
 
-void SCSIMO::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, int length) const
+void SCSIMO::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uint8_t> buf, int length)
 {
 	if (const string result = scsi_command_util::ModeSelect(cmd, cdb, buf, length, 1 << GetSectorSizeShiftCount());
 		!result.empty()) {

--- a/cpp/devices/scsimo.h
+++ b/cpp/devices/scsimo.h
@@ -32,7 +32,7 @@ public:
 	void Open() override;
 
 	vector<uint8_t> InquiryInternal() const override;
-	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) const override;
+	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) override;
 
 protected:
 

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -387,6 +387,7 @@ class MockSCSICD : public SCSICD //NOSONAR Ignore inheritance hierarchy depth in
 	FRIEND_TEST(ScsiCdTest, GetSectorSizes);
 	FRIEND_TEST(ScsiCdTest, SetUpModePages);
 	FRIEND_TEST(ScsiCdTest, ReadToc);
+	FRIEND_TEST(ScsiCdTest, ModeSelect);
 
 	using SCSICD::SCSICD;
 };

--- a/cpp/test/scsicd_test.cpp
+++ b/cpp/test/scsicd_test.cpp
@@ -133,3 +133,26 @@ TEST(ScsiCdTest, ReadToc)
 
 	// Further testing requires filesystem access
 }
+
+TEST(ScsiCdTest, ModeSelect)
+{
+	MockSCSICD cd(0);
+	vector<int> cmd(6);
+	vector<uint8_t> buf(255);
+
+	cd.SetSectorSizeInBytes(2048);
+
+	// PF
+	cmd[1] = 0x10;
+	// Length
+	buf[3] = 0x08;
+	// 2048 bytes per sector
+	buf[10] = 0x08;
+	// Page 3 (Device Format Page)
+	buf[12] = 0x01;
+	EXPECT_NO_THROW(cd.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) with sector size 2048 is supported";
+
+	// 512 bytes per sector
+	buf[10] = 0x02;
+	EXPECT_NO_THROW(cd.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) with sector size 512 is supported";
+}


### PR DESCRIPTION
DEC's VMS can't handle 2k sector sizes.

Fixes #1397 