### PR TITLE
Add ModeSense page 0x25 (DEC special function control page)

### DIFF
--- a/cpp/devices/scsihd.cpp
+++ b/cpp/devices/scsihd.cpp
@@ -97,9 +97,9 @@ void SCSIHD::AddFormatPage(map<int, vector<byte>>& pages, bool changeable) const
 	EnrichFormatPage(pages, changeable, 1 << GetSectorSizeShiftCount());
 }
 
-// Page code 37 (25h) - DEC Unique Page
+// Page code 37 (25h) - DEC Special Function Control page
 
-void SCSIHD::AddDECUniquePage(map<int, vector<byte>>& pages, bool changeable) const
+void SCSIHD::AddDECSpecialFunctionControlPage(map<int, vector<byte>>& pages, bool changeable) const
 {
 	vector<byte> buf(25);
 
@@ -119,9 +119,9 @@ void SCSIHD::AddDECUniquePage(map<int, vector<byte>>& pages, bool changeable) co
 
 void SCSIHD::AddVendorPage(map<int, vector<byte>>& pages, int page, bool changeable) const
 {
-	// Page code 0x25: DEC unique
+	// Page code 0x25: DEC Special Function Control page
 	if (page == 0x25 || page == 0x3f) {
-		AddDECUniquePage(pages, changeable);
+		AddDECSpecialFunctionControlPage(pages, changeable);
 	}
 	// Page code 48
 	if (page == 0x30 || page == 0x3f) {

--- a/cpp/devices/scsihd.cpp
+++ b/cpp/devices/scsihd.cpp
@@ -97,8 +97,32 @@ void SCSIHD::AddFormatPage(map<int, vector<byte>>& pages, bool changeable) const
 	EnrichFormatPage(pages, changeable, 1 << GetSectorSizeShiftCount());
 }
 
+// Page code 37 (25h) - DEC Unique Page
+
+void SCSIHD::AddDECUniquePage(map<int, vector<byte>>& pages, bool changeable) const
+{
+	vector<byte> buf(25);
+
+	// No changeable area
+	if (changeable) {
+		pages[0x25] = buf;
+
+		return;
+	}
+
+	buf[0] = static_cast<byte> (0x25 | 0x80); // page code, high bit set
+	buf[1] = static_cast<byte> (sizeof(buf) - 1);
+	buf[2] = static_cast<byte> (0x01); // drive does not auto-start
+
+	pages[0x25] = buf;
+}
+
 void SCSIHD::AddVendorPage(map<int, vector<byte>>& pages, int page, bool changeable) const
 {
+	// Page code 0x25: DEC unique
+	if (page == 0x25 || page == 0x3f) {
+		AddDECUniquePage(pages, changeable);
+	}
 	// Page code 48
 	if (page == 0x30 || page == 0x3f) {
 		AddAppleVendorModePage(pages, changeable);

--- a/cpp/devices/scsihd.h
+++ b/cpp/devices/scsihd.h
@@ -40,7 +40,7 @@ public:
 	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) override;
 
 	void AddFormatPage(map<int, vector<byte>>&, bool) const override;
-	void AddDECUniquePage(map<int, vector<byte>>&, bool) const;
+	void AddDECSpecialFunctionControlPage(map<int, vector<byte>>&, bool) const;
 	void AddVendorPage(map<int, vector<byte>>&, int, bool) const override;
 
 private:

--- a/cpp/devices/scsihd.h
+++ b/cpp/devices/scsihd.h
@@ -40,6 +40,7 @@ public:
 	void ModeSelect(scsi_defs::scsi_command, cdb_t, span<const uint8_t>, int) override;
 
 	void AddFormatPage(map<int, vector<byte>>&, bool) const override;
+	void AddDECUniquePage(map<int, vector<byte>>&, bool) const;
 	void AddVendorPage(map<int, vector<byte>>&, int, bool) const override;
 
 private:

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -360,6 +360,7 @@ class MockSCSIHD : public SCSIHD //NOSONAR Ignore inheritance hierarchy depth in
 	FRIEND_TEST(ScsiHdTest, FinalizeSetup);
 	FRIEND_TEST(ScsiHdTest, GetProductData);
 	FRIEND_TEST(ScsiHdTest, SetUpModePages);
+	FRIEND_TEST(ScsiHdTest, DECUniquePage);
 	FRIEND_TEST(ScsiHdTest, GetSectorSizes);
 	FRIEND_TEST(ScsiHdTest, ModeSelect);
 	FRIEND_TEST(PiscsiExecutorTest, SetSectorSize);

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -360,7 +360,7 @@ class MockSCSIHD : public SCSIHD //NOSONAR Ignore inheritance hierarchy depth in
 	FRIEND_TEST(ScsiHdTest, FinalizeSetup);
 	FRIEND_TEST(ScsiHdTest, GetProductData);
 	FRIEND_TEST(ScsiHdTest, SetUpModePages);
-	FRIEND_TEST(ScsiHdTest, DECUniquePage);
+	FRIEND_TEST(ScsiHdTest, DECSpecialFunctionControlPage);
 	FRIEND_TEST(ScsiHdTest, GetSectorSizes);
 	FRIEND_TEST(ScsiHdTest, ModeSelect);
 	FRIEND_TEST(PiscsiExecutorTest, SetSectorSize);

--- a/cpp/test/scsihd_nec_test.cpp
+++ b/cpp/test/scsihd_nec_test.cpp
@@ -18,11 +18,12 @@ using namespace filesystem;
 
 void ScsiHdNecTest_SetUpModePages(map<int, vector<byte>>& pages)
 {
-	EXPECT_EQ(5, pages.size()) << "Unexpected number of mode pages";
+	EXPECT_EQ(6, pages.size()) << "Unexpected number of mode pages";
 	EXPECT_EQ(12, pages[1].size());
 	EXPECT_EQ(24, pages[3].size());
 	EXPECT_EQ(20, pages[4].size());
 	EXPECT_EQ(12, pages[8].size());
+	EXPECT_EQ(25, pages[37].size());
 	EXPECT_EQ(30, pages[48].size());
 }
 

--- a/cpp/test/scsihd_test.cpp
+++ b/cpp/test/scsihd_test.cpp
@@ -102,7 +102,7 @@ TEST(ScsiHdTest, SetUpModePages)
 	ScsiHdTest_SetUpModePages(pages);
 }
 
-TEST(ScsiHdTest, DECUniquePage)
+TEST(ScsiHdTest, DECSpecialFunctionControlPage)
 {
 	map<int, vector<byte>> pages;
 	vector<byte> buf;

--- a/cpp/test/scsihd_test.cpp
+++ b/cpp/test/scsihd_test.cpp
@@ -13,11 +13,12 @@
 
 void ScsiHdTest_SetUpModePages(map<int, vector<byte>>& pages)
 {
-	EXPECT_EQ(5, pages.size()) << "Unexpected number of mode pages";
+	EXPECT_EQ(6, pages.size()) << "Unexpected number of mode pages";
 	EXPECT_EQ(12, pages[1].size());
 	EXPECT_EQ(24, pages[3].size());
 	EXPECT_EQ(24, pages[4].size());
 	EXPECT_EQ(12, pages[8].size());
+	EXPECT_EQ(25, pages[37].size());
 	EXPECT_EQ(30, pages[48].size());
 }
 
@@ -99,6 +100,20 @@ TEST(ScsiHdTest, SetUpModePages)
 	pages.clear();
 	hd.SetUpModePages(pages, 0x3f, true);
 	ScsiHdTest_SetUpModePages(pages);
+}
+
+TEST(ScsiHdTest, DECUniquePage)
+{
+	map<int, vector<byte>> pages;
+	vector<byte> buf;
+	MockSCSIHD hd(0, false);
+
+	EXPECT_NO_THROW(hd.SetUpModePages(pages, 0x25, false)) << "MODE SENSE(6) DEC unique page is supported";
+	EXPECT_NE(pages.end(), pages.find(0x25));
+	buf = pages[0x25];
+	EXPECT_EQ(static_cast<byte> (0x25 | 0x80), buf[0]);
+	EXPECT_EQ(static_cast<byte> (0x17), buf[1]);
+	EXPECT_EQ(static_cast<byte> (0x01), buf[2]);
 }
 
 TEST(ScsiHdTest, ModeSelect)


### PR DESCRIPTION
VAXServer 3100 (CPU KA41-E) console firmware issues ModeSense(6) page 0x25
when probing for disks. A disk won't be recognized if this returns an error.

The DEC SCSI specification[1], section 8.5 documents this page.

[1] https://manx-docs.org/collections/antonio/dec/dec-scsi.pdf

Fixes #1410