### PR TITLE
Recognize .cdr and .toast as CD-ROM image file endings

### DIFF
--- a/cpp/devices/device_factory.h
+++ b/cpp/devices/device_factory.h
@@ -44,7 +44,9 @@ private:
 			{ "hdr", SCRM },
 			{ "mos", SCMO },
 			{ "is1", SCCD },
-			{ "iso", SCCD }
+			{ "iso", SCCD },
+			{ "cdr", SCCD },
+			{ "toast", SCCD }
 	};
 
 	const inline static unordered_map<string, PbDeviceType, piscsi_util::StringHash, equal_to<>> DEVICE_MAPPING = {

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -30,6 +30,8 @@ TEST(DeviceFactoryTest, GetTypeForFile)
 	EXPECT_EQ(device_factory.GetTypeForFile("test.mos"), SCMO);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.iso"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.is1"), SCCD);
+	EXPECT_EQ(device_factory.GetTypeForFile("test.cdr"), SCCD);
+	EXPECT_EQ(device_factory.GetTypeForFile("test.toast"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.suffix.iso"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("bridge"), SCBR);
 	EXPECT_EQ(device_factory.GetTypeForFile("daynaport"), SCDP);

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -46,7 +46,7 @@ TEST(DeviceFactoryTest, GetExtensionMapping)
 	DeviceFactory device_factory;
 
 	auto mapping = device_factory.GetExtensionMapping();
-	EXPECT_EQ(10, mapping.size());
+	EXPECT_EQ(12, mapping.size());
 	EXPECT_EQ(SCHD, mapping["hd1"]);
 	EXPECT_EQ(SCHD, mapping["hds"]);
 	EXPECT_EQ(SCHD, mapping["hda"]);
@@ -57,6 +57,8 @@ TEST(DeviceFactoryTest, GetExtensionMapping)
 	EXPECT_EQ(SCMO, mapping["mos"]);
 	EXPECT_EQ(SCCD, mapping["iso"]);
 	EXPECT_EQ(SCCD, mapping["is1"]);
+	EXPECT_EQ(SCCD, mapping["cdr"]);
+	EXPECT_EQ(SCCD, mapping["toast"]);
 }
 
 TEST(DeviceFactoryTest, UnknownDeviceType)

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -254,5 +254,5 @@ TEST(PiscsiResponseTest, GetMappingInfo)
 
 	PbMappingInfo info;
 	response.GetMappingInfo(info);
-	EXPECT_EQ(10, info.mapping().size());
+	EXPECT_EQ(12, info.mapping().size());
 }


### PR DESCRIPTION
Proposing the addition of these two unambiguous file endings as recognized CD-ROM file endings (in addition to .iso and .is1)