### PR TITLE
CI workflow: Build unit tests in debug mode

### DIFF
--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -7,6 +7,20 @@ on:
       - 'cpp/**'
       - '.github/workflows/build_code.yml'
       - '.github/workflows/arm_cross_compile.yml'
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - '.github/workflows/build_code.yml'
+      - '.github/workflows/arm_cross_compile.yml'
+    types:
+      - opened
+      - synchronize
+    branches:
+      - 'develop'
+      - 'main'
 
 jobs:
   fullspec:

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -7,19 +7,6 @@ on:
       - 'cpp/**'
       - '.github/workflows/build_code.yml'
       - '.github/workflows/arm_cross_compile.yml'
-  pull_request:
-    paths:
-      - 'cpp/**'
-      - '.github/workflows/build_code.yml'
-      - '.github/workflows/arm_cross_compile.yml'
-    types:
-      - assigned
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - 'develop'
-      - 'main'
 
 jobs:
   fullspec:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get install ${{ env.APT_PACKAGES }}
 
       - name: Build unit tests
-        run: make -j $(nproc) test
+        run: DEBUG=1 make -j $(nproc) test
 
       - name: Run unit tests
         run: (set -o pipefail && bin/piscsi_test | tee piscsi_test_log.txt)

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -7,6 +7,20 @@ on:
       - 'cpp/**'
       - 'python/**'
       - '.github/workflows/cpp.yml'
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'python/**'
+      - '.github/workflows/cpp.yml'
+    types:
+      - opened
+      - synchronize
+    branches:
+      - 'develop'
+      - 'main'
 
 env:
   APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -7,14 +7,6 @@ on:
       - 'cpp/**'
       - 'python/**'
       - '.github/workflows/cpp.yml'
-  pull_request:
-    paths:
-      - 'cpp/**'
-      - 'python/**'
-      - '.github/workflows/cpp.yml'
-    branches:
-      - 'develop'
-      - 'main'
 
 env:
   APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,15 +8,6 @@ on:
       - 'python/common/**'
       - '.github/workflows/web.yml'
       - 'easyinstall.sh'
-  pull_request:
-    paths:
-      - 'python/web/**'
-      - 'python/common/**'
-      - '.github/workflows/web.yml'
-      - 'easyinstall.sh'
-    branches:
-      - 'develop'
-      - 'main'
 
 jobs:
   backend_checks:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,6 +8,18 @@ on:
       - 'python/common/**'
       - '.github/workflows/web.yml'
       - 'easyinstall.sh'
+  pull_request:
+    paths:
+      - 'python/web/**'
+      - 'python/common/**'
+      - '.github/workflows/web.yml'
+      - 'easyinstall.sh'
+    types:
+      - opened
+      - synchronize
+    branches:
+      - 'develop'
+      - 'main'
 
 jobs:
   backend_checks:

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -41,7 +41,7 @@ using namespace scsi_defs;
 void Piscsi::Banner(span<char *> args) const
 {
 	cout << piscsi_util::Banner("(Backend Service)");
-	cout << "Connection ttype: " << CONNECT_DESC << '\n' << flush;
+	cout << "Connection type: " << CONNECT_DESC << '\n' << flush;
 
 	if ((args.size() > 1 && strcmp(args[1], "-h") == 0) || (args.size() > 1 && strcmp(args[1], "--help") == 0)){
 		cout << "\nUsage: " << args[0] << " [-idID[:LUN] FILE] ...\n\n";

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -41,7 +41,7 @@ using namespace scsi_defs;
 void Piscsi::Banner(span<char *> args) const
 {
 	cout << piscsi_util::Banner("(Backend Service)");
-	cout << "Connection type: " << CONNECT_DESC << '\n' << flush;
+	cout << "Connection ttype: " << CONNECT_DESC << '\n' << flush;
 
 	if ((args.size() > 1 && strcmp(args[1], "-h") == 0) || (args.size() > 1 && strcmp(args[1], "--help") == 0)){
 		cout << "\nUsage: " << args[0] << " [-idID[:LUN] FILE] ...\n\n";


### PR DESCRIPTION
Also, only run CI jobs for pushes when merged to main or develop. 

Since Uwe has resigned as active contributor, I prioritize saving on GitHub actions minutes. It is arguably more important that code from non-members get the workflow treatment to catch bugs in their code early. 

Project members are now encouraged to open a PR in order to get the workflow to execute. The PR can be kept in draft state during active development. 