### PR TITLE
fix typo in piscsi documentation

### DIFF
--- a/doc/piscsi.1
+++ b/doc/piscsi.1
@@ -76,7 +76,7 @@ Show a help page.
 .It Fl L Ar LOG_LEVEL Ns Oo : Ar ID Ns Oo : Ar LUN Oc Oc
 The piscsi log level (trace, debug, info, warning, error, off). The default log level is 'info' for all devices unless a particular device ID and an optional LUN was provided.
 .It Fl n Ar VENDOR:PRODUCT:REVISION
-Set the vendor, product and revision for the device, to be returned with the INQUIRY data. A complete set of name components must be provided. VENDOR may have up to 8, PRODUCT up to 16, REVISION up to 4 characters. Padding with blanks to the maxium length is automatically applied. Once set the name of a device cannot be changed.
+Set the vendor, product and revision for the device, to be returned with the INQUIRY data. A complete set of name components must be provided. VENDOR may have up to 8, PRODUCT up to 16, REVISION up to 4 characters. Padding with blanks to the maximum length is automatically applied. Once set the name of a device cannot be changed.
 .It Fl P Ar ACCESS_TOKEN_FILE
 Enable authentication and read the access token from the specified file. The access token file must be owned by root and must be readable by root only.
 .It Fl p Ar PORT


### PR DESCRIPTION
Corrected the spelling of 'maximum' in the documentation.