### PR TITLE
piscsi-web: add support for MiniSCSI driver for HFS image creation

### DIFF
--- a/go/piscsi-web/README.md
+++ b/go/piscsi-web/README.md
@@ -201,16 +201,20 @@ and enables the web service.
 
 ### Optional Macintosh driver injection
 
-Macintosh driver injection when creating `Lido 7.56` or `SpeedTools 3.6` HFS
-images is optional. The installer does not provide driver images. If you have
-the corresponding `Lido-7.56.img` and `SpeedTools-3.6.img` files, install them
-manually in the default driver directory:
+Macintosh driver injection when creating HFS images is optional. The installer
+does not provide driver images. Place regular `.bin` or `.img` driver files in
+the default driver directory; the web interface lists them as HFS formatting
+options:
 
 ```shell
 sudo install -d -o root -g root -m 0755 /var/lib/piscsi/data/mac-hard-disk-drivers
-sudo install -o root -g root -m 0644 /path/to/Lido-7.56.img /path/to/SpeedTools-3.6.img \
+sudo install -o root -g root -m 0644 /path/to/driver.bin /path/to/driver.img \
   /var/lib/piscsi/data/mac-hard-disk-drivers/
 ```
+
+Files whose names start with `miniscsi` are created with an `Apple_Driver43`
+partition and MiniSCSI-specific boot metadata. Other driver files use the legacy
+16 KiB `Apple_Driver` format.
 
 Alternatively, set `DRIVER_DIR` to an existing, readable directory containing
 those files. Without the driver images, the web service remains available but

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -8,6 +8,8 @@ package server
 import (
 	"archive/zip"
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -194,6 +196,9 @@ func (s *Server) handleIndex(c *gin.Context) {
 	data["BridgeConfigured"] = bridgeConfigured
 	data["CreatableImageSuffixes"] = creatableImageSuffixes(imageFileTypeMapping)
 	data["HardDiskDriveProfiles"] = s.hardDiskDriveProfiles()
+	if drivers, err := s.hardDiskDriverImages(); err == nil {
+		data["HardDiskDriverImages"] = drivers
+	}
 
 	c.HTML(http.StatusOK, "index.html", data)
 }
@@ -2129,7 +2134,7 @@ func (s *Server) handleFilesCreate(c *gin.Context) {
 
 	// Validate formatting before creating anything, so a malformed request
 	// cannot leave an unformatted image behind.
-	if !isSupportedDriveFormat(driveFormat) {
+	if !s.isSupportedDriveFormat(driveFormat) {
 		s.respond(c, ResponseOptions{
 			Error:   true,
 			Message: fmt.Sprintf("%s is not a valid hard disk format", driveFormat),
@@ -2264,13 +2269,53 @@ func (s *Server) imageFileTypeMapping(c *gin.Context) map[string]pb.PbDeviceType
 	return result.GetServerInfo().GetMappingInfo().GetMapping()
 }
 
-func isSupportedDriveFormat(format string) bool {
+// hardDiskDriverImages returns the regular driver-image files immediately in
+// DRIVER_DIR. Driver files are deliberately not searched recursively: the
+// selected filename is later used to open a file in this directory.
+func (s *Server) hardDiskDriverImages() ([]string, error) {
+	entries, err := os.ReadDir(s.config.DriverDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	drivers := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if isHardDiskDriverImage(entry.Name()) {
+			drivers = append(drivers, entry.Name())
+		}
+	}
+	sort.Strings(drivers)
+	return drivers, nil
+}
+
+func (s *Server) isSupportedDriveFormat(format string) bool {
 	switch format {
-	case "", "Lido 7.56", "SpeedTools 3.6", "FAT16", "FAT32":
+	case "", "FAT16", "FAT32":
 		return true
-	default:
+	}
+
+	drivers, err := s.hardDiskDriverImages()
+	if err != nil {
 		return false
 	}
+	for _, driver := range drivers {
+		if format == driver {
+			return true
+		}
+	}
+	return false
+}
+
+func isHardDiskDriverImage(name string) bool {
+	extension := strings.ToLower(filepath.Ext(name))
+	return extension == ".bin" || extension == ".img"
 }
 
 func mappedImageType(mapping map[string]pb.PbDeviceType, suffix string) pb.PbDeviceType {
@@ -2302,20 +2347,32 @@ func (s *Server) formatNewImage(fullPath string, sizeMB int64, format string) er
 			"mkfs.fat", "", "-v", "-F", fatSize, "-n",
 			volumeName[:min(len(volumeName), 11)], "--offset=2048", fullPath,
 		)
-	case "Lido 7.56", "SpeedTools 3.6":
+	default:
+		if !isHardDiskDriverImage(format) {
+			return fmt.Errorf("unsupported hard disk format %q", format)
+		}
+		driverPartitionType := "Apple_Driver"
+		if isMiniSCSIDriver(format) {
+			driverPartitionType = "Apple_Driver43"
+		}
 		if err := runFormatterCommand("hfdisk", strings.Join([]string{
-			"i", "", "C", "", "32", "Driver_Partition", "Apple_Driver",
+			"i", "", "C", "", "32", "Driver_Partition", driverPartitionType,
 			"C", "", "", volumeName, "Apple_HFS", "w", "y", "p", "",
 		}, "\n"), fullPath); err != nil {
 			return err
 		}
-		driverPath := filepath.Join(s.config.DriverDir, strings.ReplaceAll(format, " ", "-")+".img")
+		driverPath := filepath.Join(s.config.DriverDir, format)
+		if isMiniSCSIDriver(format) {
+			if err := injectMiniSCSIDriver(fullPath, driverPath); err != nil {
+				return err
+			}
+			return runHFSFormatterCommand("-l", volumeName, fullPath, "1")
+		}
 		if err := injectHFSDriver(fullPath, driverPath); err != nil {
 			return err
 		}
 		return runHFSFormatterCommand("-l", volumeName, fullPath, "1")
 	}
-	return nil
 }
 
 func runHFSFormatterCommand(args ...string) error {
@@ -2392,6 +2449,123 @@ func injectHFSDriver(imagePath, driverPath string) error {
 		return fmt.Errorf("inject hard disk driver: %w", err)
 	}
 	return image.Sync()
+}
+
+const (
+	diskBlockSize                 = 512
+	miniSCSIDriverPartitionBlock  = 64
+	miniSCSIDriverPartitionBlocks = 32
+	partitionMapEntrySize         = 512
+	partitionMapSignature         = 0x504d
+	partitionTypeOffset           = 0x30
+	partitionStatusOffset         = 0x58
+	partitionBootStartOffset      = 0x5c
+	partitionBootSizeOffset       = 0x60
+	partitionBootAddressOffset    = 0x64
+	partitionBootEntryOffset      = 0x6c
+	partitionBootChecksumOffset   = 0x74
+	partitionProcessorOffset      = 0x78
+	partitionStatusInUse          = 1 << 2
+	partitionStatusHasBootInfo    = 1 << 3
+	partitionStatusBootCodePIC    = 1 << 6
+)
+
+// isMiniSCSIDriver identifies MiniSCSI driver blobs by the documented filename
+// convention. Unlike legacy 16 KiB driver images, MiniSCSI is a variable-size
+// Apple_Driver43 boot-code blob with partition-map boot metadata.
+func isMiniSCSIDriver(name string) bool {
+	return strings.HasPrefix(strings.ToLower(filepath.Base(name)), "miniscsi")
+}
+
+func injectMiniSCSIDriver(imagePath, driverPath string) error {
+	driver, err := os.ReadFile(driverPath)
+	if err != nil {
+		return fmt.Errorf("read MiniSCSI driver %q: %w", driverPath, err)
+	}
+	if len(driver) == 0 || len(driver) > miniSCSIDriverPartitionBlocks*diskBlockSize {
+		return fmt.Errorf("MiniSCSI driver size %d is outside the supported range 1-%d bytes", len(driver), miniSCSIDriverPartitionBlocks*diskBlockSize)
+	}
+
+	image, err := os.OpenFile(imagePath, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer image.Close()
+	if _, err := image.Seek(miniSCSIDriverPartitionBlock*diskBlockSize, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := image.Write(driver); err != nil {
+		return fmt.Errorf("inject MiniSCSI driver: %w", err)
+	}
+	if err := updateMiniSCSIPartitionMap(image, len(driver), miniSCSIChecksum(driver)); err != nil {
+		return err
+	}
+	return image.Sync()
+}
+
+func updateMiniSCSIPartitionMap(image *os.File, driverSize int, checksum uint16) error {
+	entry := make([]byte, partitionMapEntrySize)
+	if _, err := image.ReadAt(entry, diskBlockSize); err != nil {
+		return fmt.Errorf("read Apple partition map: %w", err)
+	}
+	if binary.BigEndian.Uint16(entry) != partitionMapSignature {
+		return errors.New("invalid Apple partition map signature")
+	}
+	entryCount := binary.BigEndian.Uint32(entry[4:])
+	if entryCount == 0 {
+		return errors.New("Apple partition map has no entries")
+	}
+
+	for block := uint32(1); block <= entryCount; block++ {
+		if _, err := image.ReadAt(entry, int64(block)*diskBlockSize); err != nil {
+			return fmt.Errorf("read Apple partition map entry %d: %w", block, err)
+		}
+		if binary.BigEndian.Uint16(entry) != partitionMapSignature {
+			return fmt.Errorf("invalid Apple partition map signature in entry %d", block)
+		}
+		partitionType := string(entry[partitionTypeOffset : partitionTypeOffset+32])
+		if strings.TrimRight(partitionType, "\x00") != "Apple_Driver43" {
+			continue
+		}
+		if binary.BigEndian.Uint32(entry[12:]) < uint32((driverSize+diskBlockSize-1)/diskBlockSize) {
+			return errors.New("MiniSCSI driver does not fit in its partition")
+		}
+
+		status := binary.BigEndian.Uint32(entry[partitionStatusOffset:])
+		binary.BigEndian.PutUint32(entry[partitionStatusOffset:], status|partitionStatusInUse|partitionStatusHasBootInfo|partitionStatusBootCodePIC)
+		// Keep hfdisk's "Driver_Partition" name. The Start Manager verifies
+		// pmBootCksum only when the name starts with "Maci". MiniSCSI's
+		// documented checksum description was insufficient to reproduce the
+		// expected value, and verification prevented the driver from loading on
+		// an SE/30. Leave verification disabled until its checksum algorithm is
+		// specified or a known-good reference partition map is available.
+		binary.BigEndian.PutUint32(entry[partitionBootStartOffset:], 0)
+		binary.BigEndian.PutUint32(entry[partitionBootSizeOffset:], uint32(driverSize))
+		binary.BigEndian.PutUint32(entry[partitionBootAddressOffset:], 0)
+		binary.BigEndian.PutUint32(entry[partitionBootEntryOffset:], 0)
+		// Retain the calculated value for diagnostics and future compatibility,
+		// even though the partition name above intentionally disables validation.
+		binary.BigEndian.PutUint32(entry[partitionBootChecksumOffset:], uint32(checksum))
+		clear(entry[partitionProcessorOffset : partitionProcessorOffset+16])
+		copy(entry[partitionProcessorOffset:partitionProcessorOffset+16], "68000")
+		if _, err := image.WriteAt(entry, int64(block)*diskBlockSize); err != nil {
+			return fmt.Errorf("write MiniSCSI partition map entry: %w", err)
+		}
+		return nil
+	}
+	return errors.New("Apple_Driver43 partition not found")
+}
+
+func miniSCSIChecksum(driver []byte) uint16 {
+	var checksum uint32
+	for len(driver) >= 2 {
+		checksum += uint32(binary.BigEndian.Uint16(driver))
+		driver = driver[2:]
+	}
+	if len(driver) == 1 {
+		checksum += uint32(driver[0]) << 8
+	}
+	return uint16(checksum)
 }
 
 // creates an image and properties file pair

--- a/go/piscsi-web/internal/server/handlers_image_test.go
+++ b/go/piscsi-web/internal/server/handlers_image_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -702,6 +703,46 @@ func TestHandleFilesCreateRejectsFormatBeforeCreatingImage(t *testing.T) {
 	}
 }
 
+func TestHardDiskDriverImages(t *testing.T) {
+	driverDir := t.TempDir()
+	for _, name := range []string{"SpeedTools.IMG", "Lido.bin", "readme.txt", "no-extension"} {
+		if err := os.WriteFile(filepath.Join(driverDir, name), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(driverDir, "nested.img"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{config: &config.Config{DriverDir: driverDir}}
+	got, err := server.hardDiskDriverImages()
+	if err != nil {
+		t.Fatalf("hardDiskDriverImages() error = %v", err)
+	}
+	want := []string{"Lido.bin", "SpeedTools.IMG"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("hardDiskDriverImages() = %v, want %v", got, want)
+	}
+	if !server.isSupportedDriveFormat("Lido.bin") {
+		t.Error("listed driver was not accepted as a drive format")
+	}
+	if server.isSupportedDriveFormat("readme.txt") {
+		t.Error("non-driver file was accepted as a drive format")
+	}
+}
+
+func TestHardDiskDriverImagesAllowsMissingDirectory(t *testing.T) {
+	driverDir := filepath.Join(t.TempDir(), "missing")
+	server := &Server{config: &config.Config{DriverDir: driverDir}}
+	drivers, err := server.hardDiskDriverImages()
+	if err != nil {
+		t.Fatalf("hardDiskDriverImages() error = %v", err)
+	}
+	if len(drivers) != 0 {
+		t.Errorf("hardDiskDriverImages() = %v, want no drivers", drivers)
+	}
+}
+
 func TestHandleFilesCreateRemovesImageWhenFormattingFails(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	root := t.TempDir()
@@ -765,7 +806,7 @@ func TestFormatNewImageInjectsHFSDriver(t *testing.T) {
 	for i := range driverData {
 		driverData[i] = byte(i)
 	}
-	driverPath := filepath.Join(driverDir, "Lido-7.56.img")
+	driverPath := filepath.Join(driverDir, "Custom Driver.bin")
 	if err := os.WriteFile(driverPath, driverData, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +816,7 @@ func TestFormatNewImageInjectsHFSDriver(t *testing.T) {
 	}
 
 	server := &Server{config: &config.Config{DriverDir: driverDir}}
-	if err := server.formatNewImage(imagePath, 1, "Lido 7.56"); err != nil {
+	if err := server.formatNewImage(imagePath, 1, filepath.Base(driverPath)); err != nil {
 		t.Fatalf("formatNewImage() error = %v", err)
 	}
 	imageData, err := os.ReadFile(imagePath)
@@ -785,6 +826,85 @@ func TestFormatNewImageInjectsHFSDriver(t *testing.T) {
 	if !reflect.DeepEqual(imageData[64*512:96*512], driverData) {
 		t.Fatal("HFS driver was not injected at blocks 64-95")
 	}
+}
+
+func TestInjectMiniSCSIDriver(t *testing.T) {
+	root := t.TempDir()
+	driverData := make([]byte, 1862)
+	for i := range driverData {
+		driverData[i] = byte(i)
+	}
+	driverPath := filepath.Join(root, "miniscsi-1.0.bin")
+	if err := os.WriteFile(driverPath, driverData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(root, "disk.hds")
+	imageData := make([]byte, 1024*1024)
+	writeApplePartitionMapEntry(imageData[512:1024], 3, "Apple_partition_map", 1, 63)
+	writeApplePartitionMapEntry(imageData[1024:1536], 3, "Apple_Driver43", 64, 32)
+	copy(imageData[2*diskBlockSize+0x10:], "Driver_Partition")
+	writeApplePartitionMapEntry(imageData[1536:2048], 3, "Apple_HFS", 96, 1952)
+	if err := os.WriteFile(imagePath, imageData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := injectMiniSCSIDriver(imagePath, driverPath); err != nil {
+		t.Fatalf("injectMiniSCSIDriver() error = %v", err)
+	}
+	imageData, err := os.ReadFile(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driverOffset := miniSCSIDriverPartitionBlock * diskBlockSize
+	if !reflect.DeepEqual(imageData[driverOffset:driverOffset+len(driverData)], driverData) {
+		t.Fatal("MiniSCSI driver data was not injected")
+	}
+	entry := imageData[2*diskBlockSize : 3*diskBlockSize]
+	if got := binary.BigEndian.Uint32(entry[partitionStatusOffset:]); got != 0x7f {
+		t.Errorf("partition status = %#x, want %#x", got, uint32(0x7f))
+	}
+	if got := binary.BigEndian.Uint32(entry[partitionBootSizeOffset:]); got != uint32(len(driverData)) {
+		t.Errorf("boot size = %d, want %d", got, len(driverData))
+	}
+	if got := string(entry[0x10 : 0x10+16]); got != "Driver_Partition" {
+		t.Errorf("partition name = %q, want %q", got, "Driver_Partition")
+	}
+	if got, want := binary.BigEndian.Uint32(entry[partitionBootChecksumOffset:]), uint32(miniSCSIChecksum(driverData)); got != want {
+		t.Errorf("boot checksum = %#x, want %#x", got, want)
+	}
+	if got := string(entry[partitionProcessorOffset : partitionProcessorOffset+5]); got != "68000" {
+		t.Errorf("processor = %q, want %q", got, "68000")
+	}
+}
+
+func TestMiniSCSIChecksum(t *testing.T) {
+	if got, want := miniSCSIChecksum([]byte{0x12, 0x34, 0x56, 0x78}), uint16(0x68ac); got != want {
+		t.Errorf("miniSCSIChecksum() = %#x, want %#x", got, want)
+	}
+}
+
+func TestIsMiniSCSIDriver(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want bool
+	}{
+		{name: "miniscsi-1.0.bin", want: true},
+		{name: "MiniSCSI-1.0.bin", want: true},
+		{name: "SpeedTools-3.6.img", want: false},
+	} {
+		if got := isMiniSCSIDriver(test.name); got != test.want {
+			t.Errorf("isMiniSCSIDriver(%q) = %t, want %t", test.name, got, test.want)
+		}
+	}
+}
+
+func writeApplePartitionMapEntry(entry []byte, entryCount uint32, partitionType string, start, blocks uint32) {
+	binary.BigEndian.PutUint16(entry, partitionMapSignature)
+	binary.BigEndian.PutUint32(entry[4:], entryCount)
+	binary.BigEndian.PutUint32(entry[8:], start)
+	binary.BigEndian.PutUint32(entry[12:], blocks)
+	copy(entry[partitionTypeOffset:partitionTypeOffset+32], partitionType)
+	binary.BigEndian.PutUint32(entry[partitionStatusOffset:], 0x33)
 }
 
 func TestFormatNewImageSupportsFAT16AndFAT32(t *testing.T) {

--- a/go/piscsi-web/web/templates/index.html
+++ b/go/piscsi-web/web/templates/index.html
@@ -540,8 +540,9 @@ Please create the PiSCSI configuration dir to use configurations: {{.ConfigDir}}
     <label for="drive_format">Format as:</label>
     <select name="drive_format" id="drive_format">
         <option value="">Unformatted</option>
-        <option value="Lido 7.56">HFS + Lido</option>
-        <option value="SpeedTools 3.6">HFS + SpeedTools</option>
+        {{range .HardDiskDriverImages}}
+        <option value="{{.}}">HFS + {{.}}</option>
+        {{end}}
         <option value="FAT16">FAT16</option>
         <option value="FAT32">FAT32</option>
     </select>


### PR DESCRIPTION
when placed in the Mac drivers dir and renamed to 'miniscsi.bin' the Web UI can create a working HFS disk image to be mounted on a classic Mac

MiniSCSI is a free and open source alternative to historical Mac drivers:

https://github.com/ingpaschke/miniscsi

currently, only a m68k driver is available so PPC Macs are not supported

additionally, the Web UI will scan the Mac drivers dir for any file ending in .bin or .img and will enumerate them for the disk image creation form; before, only a few named images were offered as options