### PR TITLE
restore support for SASI disk drive device

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -169,7 +169,11 @@ $(OBJDIR) $(BINDIR):
 	@echo "-- Creating directory $@"
 	mkdir -p $@
 
-$(OBJDIR)/%.o: %.cpp | $(OBJDIR)
+# All regular C++ sources may include headers that transitively depend on the
+# protobuf interface. Make its generation complete before starting any of them;
+# otherwise a parallel clean build can compile a consumer before the header has
+# been created.
+$(OBJDIR)/%.o: %.cpp $(SRC_GENERATED) | $(OBJDIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(SRC_GENERATED) : $(SRC_PROTOC)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -50,6 +50,7 @@ endif
 PISCSI = piscsi
 SCSICTL = scsictl
 SCSIDUMP = scsidump
+SASIDUMP = sasidump
 SCSIMON = scsimon
 PISCSI_TEST = piscsi_test
 SCSILOOP = scsiloop
@@ -77,6 +78,7 @@ BIN_ALL = \
 # scsidump requires initiator support
 ifeq ($(CONNECT_TYPE), FULLSPEC)
 	BIN_ALL += $(BINDIR)/$(SCSIDUMP)
+	BIN_ALL += $(BINDIR)/$(SASIDUMP)
 endif
 
 SRC_PROTOC = ../proto/piscsi_interface.proto
@@ -110,6 +112,10 @@ SRC_SCSIDUMP = scsidump/scsidump.cpp
 SRC_SCSIDUMP += $(shell find ./scsidump -name '*.cpp' | grep -v scsidump.cpp)
 SRC_SCSIDUMP += $(shell find ./hal -name '*.cpp')
 
+SRC_SASIDUMP = sasidump/sasidump.cpp
+SRC_SASIDUMP += $(shell find ./sasidump -name '*.cpp' | grep -v sasidump.cpp)
+SRC_SASIDUMP += $(shell find ./hal -name '*.cpp')
+
 SRC_PISCSI_TEST = $(shell find ./test -name '*.cpp')
 SRC_PISCSI_TEST += $(shell find ./scsidump -name '*.cpp' | grep -v scsidump.cpp)
 
@@ -118,9 +124,9 @@ SRC_SCSILOOP += $(shell find ./scsiloop -name '*.cpp' | grep -v scsiloop.cpp)
 SRC_SCSILOOP += $(shell find ./hal -name '*.cpp')
 
 vpath %.h ./shared ./controllers ./devices ./scsimon ./hal \
-	./hal/pi_defs ./piscsi ./scsictl ./scsidump ./scsiloop
+	./hal/pi_defs ./piscsi ./scsictl ./scsidump ./sasidump ./scsiloop
 vpath %.cpp ./shared ./controllers ./devices ./scsimon ./hal \
-	./hal/pi_defs ./piscsi ./scsictl ./scsidump ./scsiloop ./test
+	./hal/pi_defs ./piscsi ./scsictl ./scsidump ./sasidump ./scsiloop ./test
 vpath %.o ./$(OBJDIR)
 vpath ./$(BINDIR)
 
@@ -130,6 +136,7 @@ OBJ_PISCSI := $(addprefix $(OBJDIR)/,$(notdir $(SRC_PISCSI:%.cpp=%.o)))
 OBJ_SCSICTL_CORE := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SCSICTL_CORE:%.cpp=%.o)))
 OBJ_SCSICTL := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SCSICTL:%.cpp=%.o)))
 OBJ_SCSIDUMP := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SCSIDUMP:%.cpp=%.o)))
+OBJ_SASIDUMP := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SASIDUMP:%.cpp=%.o)))
 OBJ_SCSIMON := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SCSIMON:%.cpp=%.o)))
 OBJ_PISCSI_TEST := $(addprefix $(OBJDIR)/,$(notdir $(SRC_PISCSI_TEST:%.cpp=%.o)))
 OBJ_SCSILOOP  := $(addprefix $(OBJDIR)/,$(notdir $(SRC_SCSILOOP:%.cpp=%.o)))
@@ -143,6 +150,7 @@ BINARIES = $(USR_LOCAL_BIN)/$(SCSICTL) \
 	$(USR_LOCAL_BIN)/$(SCSILOOP)
 ifeq ($(CONNECT_TYPE), FULLSPEC)
 	BINARIES += $(USR_LOCAL_BIN)/$(SCSIDUMP)
+	BINARIES += $(USR_LOCAL_BIN)/$(SASIDUMP)
 endif
 
 MAN_PAGES = $(MAN_PAGE_DIR)/piscsi.1 \
@@ -151,6 +159,7 @@ MAN_PAGES = $(MAN_PAGE_DIR)/piscsi.1 \
 	$(MAN_PAGE_DIR)/scsiloop.1
 ifeq ($(CONNECT_TYPE), FULLSPEC)
 	MAN_PAGES += $(MAN_PAGE_DIR)/scsidump.1
+	MAN_PAGES += $(MAN_PAGE_DIR)/sasidump.1
 endif
 
 GENERATED_DIR := generated
@@ -162,7 +171,7 @@ TEST_WRAPS = -Wl,--wrap=fopen64
 
 # The following will include all of the auto-generated dependency files (*.d)
 # if they exist. This will trigger a rebuild of a source file if a header changes
-ALL_DEPS := $(patsubst %.o,%.d,$(OBJ_PISCSI_CORE) $(OBJ_SCSICTL_CORE) $(OBJ_PISCSI) $(OBJ_SCSICTL) $(OBJ_SCSIDUMP) $(OBJ_SCSIMON) $(OBJ_SHARED) $(OBJ_PROTOBUF) $(OBJ_PISCSI_TEST) $(OBJ_SCSILOOP))
+ALL_DEPS := $(patsubst %.o,%.d,$(OBJ_PISCSI_CORE) $(OBJ_SCSICTL_CORE) $(OBJ_PISCSI) $(OBJ_SCSICTL) $(OBJ_SCSIDUMP) $(OBJ_SASIDUMP) $(OBJ_SCSIMON) $(OBJ_SHARED) $(OBJ_PROTOBUF) $(OBJ_PISCSI_TEST) $(OBJ_SCSILOOP))
 -include $(ALL_DEPS)
 
 $(OBJDIR) $(BINDIR):
@@ -220,6 +229,9 @@ $(BINDIR)/$(SCSICTL): $(OBJ_GENERATED) $(OBJ_SCSICTL_CORE) $(OBJ_SCSICTL) $(OBJ_
 $(BINDIR)/$(SCSIDUMP): $(OBJ_SCSIDUMP) $(OBJ_SHARED) | $(BINDIR)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJ_SCSIDUMP) $(OBJ_SHARED)
 
+$(BINDIR)/$(SASIDUMP): $(OBJ_SASIDUMP) $(OBJ_SHARED) | $(BINDIR)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJ_SASIDUMP) $(OBJ_SHARED)
+
 $(BINDIR)/$(SCSIMON): $(OBJ_SCSIMON) $(OBJ_SHARED) | $(BINDIR)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJ_SCSIMON) $(OBJ_SHARED)
 
@@ -230,10 +242,12 @@ $(BINDIR)/$(PISCSI_TEST): $(OBJ_GENERATED) $(OBJ_PISCSI_CORE) $(OBJ_SCSICTL_CORE
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(TEST_WRAPS) -o $@ $(OBJ_PISCSI_CORE) $(OBJ_SCSICTL_CORE) $(OBJ_PISCSI_TEST) $(OBJ_SHARED) $(OBJ_PROTOBUF) $(OBJ_GENERATED) -lpthread -lpcap -lprotobuf -lgmock -lgtest
 
 # Phony rules for building individual utilities
-.PHONY: $(PISCSI) $(SCSICTL) $(SCSIDUMP) $(SCSIMON) $(PISCSI_TEST) $(SCSILOOP)
+.PHONY: $(PISCSI) $(SCSICTL) $(SCSIDUMP) $(SASIDUMP) $(SCSIMON) $(PISCSI_TEST) $(SCSILOOP)
 $(PISCSI) : $(BINDIR)/$(PISCSI) 
 $(SCSICTL) : $(BINDIR)/$(SCSICTL) 
 $(SCSIDUMP) : $(BINDIR)/$(SCSIDUMP) 
+
+$(SASIDUMP) : $(BINDIR)/$(SASIDUMP)
 $(SCSIMON) : $(BINDIR)/$(SCSIMON)
 $(PISCSI_TEST): $(BINDIR)/$(PISCSI_TEST)
 $(SCSILOOP) : $(BINDIR)/$(SCSILOOP)

--- a/cpp/controllers/abstract_controller.h
+++ b/cpp/controllers/abstract_controller.h
@@ -46,6 +46,7 @@ public:
 			scsi_defs::status = scsi_defs::status::check_condition) = 0;
 	virtual void Reset();
 	virtual int GetInitiatorId() const = 0;
+	virtual bool IsSasi() const { return false; }
 
 	// Get requested LUN based on IDENTIFY message, with LUN from the CDB as fallback
 	virtual int GetEffectiveLun() const = 0;

--- a/cpp/controllers/controller_manager.cpp
+++ b/cpp/controllers/controller_manager.cpp
@@ -8,6 +8,7 @@
 //---------------------------------------------------------------------------
 
 #include "devices/primary_device.h"
+#include "sasi_controller.h"
 #include "scsi_controller.h"
 #include "controller_manager.h"
 
@@ -21,9 +22,22 @@ shared_ptr<ScsiController> ControllerManager::CreateScsiController(BUS& bus, int
 	return controller;
 }
 
+shared_ptr<SasiController> ControllerManager::CreateSasiController(BUS& bus, int id) const
+{
+	auto controller = make_shared<SasiController>(bus, id);
+	controller->Init();
+
+	return controller;
+}
+
 bool ControllerManager::AttachToController(BUS& bus, int id, shared_ptr<PrimaryDevice> device)
 {
 	if (auto controller = FindController(id); controller != nullptr) {
+		// SCSI and SASI use different bus phase semantics and cannot share a target ID.
+		if (controller->IsSasi() != (device->GetType() == SAHD)) {
+			return false;
+		}
+
 		if (controller->HasDeviceForLun(device->GetLun())) {
 			return false;
 		}
@@ -33,7 +47,10 @@ bool ControllerManager::AttachToController(BUS& bus, int id, shared_ptr<PrimaryD
 
 	// If this is LUN 0 create a new controller
 	if (!device->GetLun()) {
-		if (auto controller = CreateScsiController(bus, id); controller->AddDevice(device)) {
+		auto controller = device->GetType() == SAHD ?
+			static_pointer_cast<AbstractController>(CreateSasiController(bus, id)) :
+			static_pointer_cast<AbstractController>(CreateScsiController(bus, id));
+		if (controller->AddDevice(device)) {
 			controllers[id] = controller;
 
 			return true;

--- a/cpp/controllers/controller_manager.h
+++ b/cpp/controllers/controller_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "generated/piscsi_interface.pb.h"
 #include "hal/bus.h"
 #include "controllers/abstract_controller.h"
 #include <unordered_map>
@@ -20,6 +21,7 @@
 using namespace std;
 
 class ScsiController;
+class SasiController;
 class PrimaryDevice;
 
 class ControllerManager
@@ -41,10 +43,14 @@ public:
 
 	static int GetScsiIdMax() { return 8; }
 	static int GetScsiLunMax() { return 32; }
+	static int GetSasiLunMax() { return 2; }
+	static int GetLunMax(piscsi_interface::PbDeviceType type)
+		{ return type == piscsi_interface::SAHD ? GetSasiLunMax() : GetScsiLunMax(); }
 
 private:
 
 	shared_ptr<ScsiController> CreateScsiController(BUS&, int) const;
+	shared_ptr<SasiController> CreateSasiController(BUS&, int) const;
 
 	// Controllers mapped to their device IDs
 	unordered_map<int, shared_ptr<AbstractController>> controllers;

--- a/cpp/controllers/sasi_controller.cpp
+++ b/cpp/controllers/sasi_controller.cpp
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#include "controllers/controller_manager.h"
+#include "sasi_controller.h"
+
+SasiController::SasiController(BUS& bus, int target_id)
+	: ScsiController(bus, target_id, ControllerManager::GetSasiLunMax())
+{
+}
+
+int SasiController::GetEffectiveLun() const
+{
+	return GetLun();
+}
+
+void SasiController::MsgOut()
+{
+	// SASI does not define a message out phase.
+	Command();
+}

--- a/cpp/controllers/sasi_controller.cpp
+++ b/cpp/controllers/sasi_controller.cpp
@@ -17,11 +17,18 @@ SasiController::SasiController(BUS& bus, int target_id)
 
 int SasiController::GetEffectiveLun() const
 {
+	// The X68000 probes for a SASI disk with the non-standard CDB 00 28.
+	// Treat it as a LUN 0 command so that the device can return the expected
+	// CHECK CONDITION instead of rejecting the encoded LUN as unsupported.
+	if (GetOpcode() == scsi_defs::scsi_command::eCmdTestUnitReady && GetCmdByte(1) == 0x28) {
+		return 0;
+	}
+
 	return GetLun();
 }
 
 void SasiController::MsgOut()
 {
-	// SASI does not define a message out phase.
+	// SASI does not define a message-out phase.
 	Command();
 }

--- a/cpp/controllers/sasi_controller.h
+++ b/cpp/controllers/sasi_controller.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#pragma once
+
+#include <algorithm>
+
+#include "scsi_controller.h"
+
+class SasiController final : public ScsiController
+{
+public:
+	SasiController(BUS&, int);
+	~SasiController() override = default;
+
+	bool IsSasi() const override { return true; }
+	int GetEffectiveLun() const override;
+	void MsgOut() override;
+
+protected:
+	// Use a 100 us baseline for SASI commands rather than the SCSI default
+    // of 50 us, needed for timing-sensitive initiators such as the X68000.
+	unsigned int GetMinimumExecutionTime() const override { return std::max(100U, MIN_EXEC_TIME); }
+};

--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -29,7 +29,11 @@
 
 using namespace scsi_defs;
 
-ScsiController::ScsiController(BUS& bus, int target_id) : AbstractController(bus, target_id, ControllerManager::GetScsiLunMax())
+ScsiController::ScsiController(BUS& bus, int target_id) : ScsiController(bus, target_id, ControllerManager::GetScsiLunMax())
+{
+}
+
+ScsiController::ScsiController(BUS& bus, int target_id, int max_luns) : AbstractController(bus, target_id, max_luns)
 {
 	// The initial buffer size will default to either the default buffer size OR
 	// the size of an Ethernet message, whichever is larger.
@@ -122,8 +126,8 @@ void ScsiController::Selection()
 	if (!GetBus().GetSEL() && GetBus().GetBSY()) {
 		LogTrace("Selection completed");
 
-		// Message out phase if ATN=1, otherwise command phase
-		if (GetBus().GetATN()) {
+		// SASI has no message phases. SCSI enters message out if ATN is asserted.
+		if (!IsSasi() && GetBus().GetATN()) {
 			MsgOut();
 		} else {
 			Command();
@@ -266,7 +270,7 @@ void ScsiController::Status()
 		ResetOffset();
 		SetLength(1);
 		SetBlocks(1);
-		GetBuffer()[0] = (uint8_t)GetStatus();
+		GetBuffer()[0] = static_cast<uint8_t>(GetStatus()) | (IsSasi() ? GetEffectiveLun() << 5 : 0);
 
 		return;
 	}
@@ -490,6 +494,10 @@ void ScsiController::Send()
 			break;
 
 		case phase_t::status:
+			if (IsSasi()) {
+				BusFree();
+				break;
+			}
 			SetLength(1);
 			SetBlocks(1);
 			GetBuffer()[0] = (uint8_t)GetMessage();
@@ -979,8 +987,8 @@ int ScsiController::GetEffectiveLun() const
 
 void ScsiController::Sleep()
 {
-	if (const uint32_t time = SysTimer::GetTimerLow() - execstart; time < MIN_EXEC_TIME) {
-		SysTimer::SleepUsec(MIN_EXEC_TIME - time);
+	if (const uint32_t time = SysTimer::GetTimerLow() - execstart; time < GetMinimumExecutionTime()) {
+		SysTimer::SleepUsec(GetMinimumExecutionTime() - time);
 	}
 	execstart = 0;
 }

--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -126,7 +126,7 @@ void ScsiController::Selection()
 	if (!GetBus().GetSEL() && GetBus().GetBSY()) {
 		LogTrace("Selection completed");
 
-		// SASI has no message phases. SCSI enters message out if ATN is asserted.
+		// SASI omits message out. SCSI enters message out if ATN is asserted.
 		if (!IsSasi() && GetBus().GetATN()) {
 			MsgOut();
 		} else {
@@ -494,10 +494,6 @@ void ScsiController::Send()
 			break;
 
 		case phase_t::status:
-			if (IsSasi()) {
-				BusFree();
-				break;
-			}
 			SetLength(1);
 			SetBlocks(1);
 			GetBuffer()[0] = (uint8_t)GetMessage();

--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -251,9 +251,9 @@ void ScsiController::Status()
 		// Minimum execution time
 		// TODO Why is a delay needed? Is this covered by the SCSI specification?
 		if (execstart > 0) {
-			Sleep();
+			Sleep(GetMinimumExecutionTime());
 		} else {
-			SysTimer::SleepUsec(5);
+			SysTimer::SleepUsec(GetMinimumStatusPhaseTime());
 		}
 
 		stringstream s;
@@ -328,7 +328,7 @@ void ScsiController::DataIn()
 	if (!IsDataIn()) {
 		// Minimum execution time
 		if (execstart > 0) {
-			Sleep();
+			Sleep(GetMinimumDataPhaseTime());
 		}
 
 		// If the length is 0, go to the status phase
@@ -357,7 +357,7 @@ void ScsiController::DataOut()
 	if (!IsDataOut()) {
 		// Minimum execution time
 		if (execstart > 0) {
-			Sleep();
+			Sleep(GetMinimumDataPhaseTime());
 		}
 
 		// If the length is 0, go to the status phase
@@ -981,10 +981,10 @@ int ScsiController::GetEffectiveLun() const
 	return identified_lun != -1 ? identified_lun : GetLun();
 }
 
-void ScsiController::Sleep()
+void ScsiController::Sleep(unsigned int minimum_time)
 {
-	if (const uint32_t time = SysTimer::GetTimerLow() - execstart; time < GetMinimumExecutionTime()) {
-		SysTimer::SleepUsec(GetMinimumExecutionTime() - time);
+	if (const uint32_t time = SysTimer::GetTimerLow() - execstart; time < minimum_time) {
+		SysTimer::SleepUsec(minimum_time - time);
 	}
 	execstart = 0;
 }

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -77,6 +77,8 @@ public:
 protected:
 	ScsiController(BUS&, int, int);
 	virtual unsigned int GetMinimumExecutionTime() const { return MIN_EXEC_TIME; }
+	virtual unsigned int GetMinimumDataPhaseTime() const { return GetMinimumExecutionTime(); }
+	virtual unsigned int GetMinimumStatusPhaseTime() const { return 5; }
 
 	// SCSI controllers process an IDENTIFY message before using the CDB LUN.
 	// SASI controllers override this because SASI has no message-out phase.
@@ -111,7 +113,7 @@ private:
 	void ParseMessage();
 	void ProcessMessage();
 
-	void Sleep();
+	void Sleep(unsigned int);
 
 	scsi_t scsi = {};
 };

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -59,8 +59,6 @@ public:
 
 	bool Process(int) override;
 
-	int GetEffectiveLun() const override;
-
 	void Error(scsi_defs::sense_key sense_key, scsi_defs::asc asc = scsi_defs::asc::no_additional_sense_information,
 			scsi_defs::status status = scsi_defs::status::check_condition) override;
 
@@ -75,6 +73,14 @@ public:
 	void Status() override;
 	void DataIn() override;
 	void DataOut() override;
+
+protected:
+	ScsiController(BUS&, int, int);
+	virtual unsigned int GetMinimumExecutionTime() const { return MIN_EXEC_TIME; }
+
+	// SCSI controllers process an IDENTIFY message before using the CDB LUN.
+	// SASI controllers override this because SASI has no message phases.
+	int GetEffectiveLun() const override;
 
 private:
 
@@ -109,4 +115,3 @@ private:
 
 	scsi_t scsi = {};
 };
-

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -79,7 +79,7 @@ protected:
 	virtual unsigned int GetMinimumExecutionTime() const { return MIN_EXEC_TIME; }
 
 	// SCSI controllers process an IDENTIFY message before using the CDB LUN.
-	// SASI controllers override this because SASI has no message phases.
+	// SASI controllers override this because SASI has no message-out phase.
 	int GetEffectiveLun() const override;
 
 private:

--- a/cpp/devices/device_factory.cpp
+++ b/cpp/devices/device_factory.cpp
@@ -10,6 +10,7 @@
 #include "shared/piscsi_util.h"
 #include "scsihd.h"
 #include "scsihd_nec.h"
+#include "sasi_hd.h"
 #include "scsimo.h"
 #include "scsicd.h"
 #include "scsi_printer.h"
@@ -46,6 +47,10 @@ shared_ptr<PrimaryDevice> DeviceFactory::CreateDevice(PbDeviceType type, int lun
 
 	shared_ptr<PrimaryDevice> device;
 	switch (type) {
+	case SAHD:
+		device = make_shared<SasiHd>(lun);
+		break;
+
 	case SCHD: {
 		if (const string ext = GetExtensionLowerCase(filename); ext == "hdn" || ext == "hdi" || ext == "nhd") {
 			device = make_shared<SCSIHD_NEC>(lun);

--- a/cpp/devices/device_factory.h
+++ b/cpp/devices/device_factory.h
@@ -35,6 +35,7 @@ public:
 private:
 
 	const inline static unordered_map<string, PbDeviceType, piscsi_util::StringHash, equal_to<>> EXTENSION_MAPPING = {
+			{ "hdf", SAHD },
 			{ "hd1", SCHD },
 			{ "hds", SCHD },
 			{ "hda", SCHD },

--- a/cpp/devices/sasi_hd.cpp
+++ b/cpp/devices/sasi_hd.cpp
@@ -25,8 +25,40 @@ bool SasiHd::Init(const param_map& params)
 	// SASI uses opcode 0x05 for READ CAPACITY and has a legacy FORMAT opcode at 0x06.
 	AddCommand(scsi_command::eCmdReadBlockLimits, [this] { ReadCapacity(); });
 	AddCommand(scsi_command::eCmdFormatLegacy, [this] { Dispatch(scsi_command::eCmdFormatUnit); });
+	AddCommand(scsi_command::eCmdTestUnitReady, [this] { TestUnitReady(); });
+	AddCommand(scsi_command::eCmdAssignDiskParameters, [this] { AssignDiskParameters(); });
 
 	return true;
+}
+
+void SasiHd::TestUnitReady()
+{
+	// X68000 SASI firmware probes a target with 00 28 and requires CHECK
+	// CONDITION (with no sense data). 00 03 is the corresponding ready probe.
+	if (GetController()->GetCmdByte(1) == 0x28) {
+		GetController()->SetStatus(status::check_condition);
+		EnterStatusPhase();
+		return;
+	}
+	if (GetController()->GetCmdByte(1) == 0x03) {
+		GetController()->SetStatus(status::good);
+		EnterStatusPhase();
+		return;
+	}
+
+	CheckReady();
+	EnterStatusPhase();
+}
+
+void SasiHd::AssignDiskParameters()
+{
+	CheckReady();
+
+	// SASI initiators such as the X68000 configure geometry with this
+	// six-byte command followed by ten parameter bytes. Geometry is derived
+	// from the image, so consume and ignore the parameter list.
+	GetController()->SetLength(10);
+	EnterDataOutPhase();
 }
 
 void SasiHd::Open()

--- a/cpp/devices/sasi_hd.cpp
+++ b/cpp/devices/sasi_hd.cpp
@@ -1,0 +1,83 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#include "controllers/abstract_controller.h"
+#include "sasi_hd.h"
+
+using namespace scsi_defs;
+
+SasiHd::SasiHd(int lun, const unordered_set<uint32_t>& sector_sizes) : Disk(SAHD, lun, sector_sizes)
+{
+	SetProduct("SASI HD");
+	SetProtectable(true);
+}
+
+bool SasiHd::Init(const param_map& params)
+{
+	Disk::Init(params);
+
+	// SASI uses opcode 0x05 for READ CAPACITY and has a legacy FORMAT opcode at 0x06.
+	AddCommand(scsi_command::eCmdReadBlockLimits, [this] { ReadCapacity(); });
+	AddCommand(scsi_command::eCmdFormatLegacy, [this] { Dispatch(scsi_command::eCmdFormatUnit); });
+
+	return true;
+}
+
+void SasiHd::Open()
+{
+	assert(!IsReady());
+
+	SetSectorSizeInBytes(GetConfiguredSectorSize() ? GetConfiguredSectorSize() : 256);
+	SetBlockCount(GetFileSize() >> GetSectorSizeShiftCount());
+
+	// READ/WRITE(6) encodes a 21-bit block address.
+	if (GetBlockCount() > 2'097'152) {
+		throw io_exception("SASI drives are limited to 2097152 blocks");
+	}
+
+	ValidateFile();
+	SetUpCache(0);
+}
+
+void SasiHd::Inquiry()
+{
+	// SASI INQUIRY consists of two bytes; byte 0 denotes a direct-access device.
+	GetController()->GetBuffer()[0] = 0;
+	GetController()->GetBuffer()[1] = 0;
+	GetController()->SetLength(2);
+	EnterDataInPhase();
+}
+
+void SasiHd::RequestSense()
+{
+	// SASI uses the non-extended format and transfers four bytes when ALLOCATION LENGTH is zero.
+	const int allocation_length = GetController()->GetCmdByte(4) ? GetController()->GetCmdByte(4) : 4;
+	auto& buffer = GetController()->GetBuffer();
+	fill_n(buffer.begin(), allocation_length, 0);
+	buffer[0] = static_cast<uint8_t>(GetStatusCode() >> 16);
+	buffer[1] = static_cast<uint8_t>(GetLun() << 5);
+	GetController()->SetLength(allocation_length);
+	EnterDataInPhase();
+}
+
+void SasiHd::ReadCapacity()
+{
+	CheckReady();
+
+	const uint32_t capacity = static_cast<uint32_t>(GetBlockCount() - 1);
+	auto& buffer = GetController()->GetBuffer();
+	buffer[0] = static_cast<uint8_t>(capacity >> 24);
+	buffer[1] = static_cast<uint8_t>(capacity >> 16);
+	buffer[2] = static_cast<uint8_t>(capacity >> 8);
+	buffer[3] = static_cast<uint8_t>(capacity);
+	buffer[4] = static_cast<uint8_t>(GetSectorSizeInBytes() >> 8);
+	buffer[5] = static_cast<uint8_t>(GetSectorSizeInBytes());
+	GetController()->SetLength(6);
+	EnterDataInPhase();
+}

--- a/cpp/devices/sasi_hd.h
+++ b/cpp/devices/sasi_hd.h
@@ -25,5 +25,7 @@ public:
 
 private:
 	vector<uint8_t> InquiryInternal() const override { return {}; }
+	void TestUnitReady() override;
+	void AssignDiskParameters();
 	void ReadCapacity();
 };

--- a/cpp/devices/sasi_hd.h
+++ b/cpp/devices/sasi_hd.h
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#pragma once
+
+#include "disk.h"
+
+class SasiHd final : public Disk
+{
+public:
+	explicit SasiHd(int, const unordered_set<uint32_t>& = { 256, 512, 1024 });
+	~SasiHd() override = default;
+
+	bool Init(const param_map&) override;
+	void Open() override;
+
+	void Inquiry() override;
+	void RequestSense() override;
+
+private:
+	vector<uint8_t> InquiryInternal() const override { return {}; }
+	void ReadCapacity();
+};

--- a/cpp/devices/storage_device.h
+++ b/cpp/devices/storage_device.h
@@ -75,13 +75,13 @@ protected:
 	off_t GetFileSize() const;
 
 protected:
-	// Sector size shift count (9=512, 10=1024, 11=2048, 12=4096)
+	// Sector size shift count (8=256, 9=512, 10=1024, 11=2048, 12=4096)
 	uint32_t size_shift_count = 0;
 
 	unordered_set<uint32_t> supported_sector_sizes;
 
 	static inline const unordered_map<uint32_t, uint32_t> shift_counts =
-	{ { 512, 9 }, { 1024, 10 }, { 2048, 11 }, { 4096, 12 } };
+	{ { 256, 8 }, { 512, 9 }, { 1024, 10 }, { 2048, 11 }, { 4096, 12 } };
 
 	uint32_t configured_sector_size = 0;
 

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -2,6 +2,7 @@ controllers_src = [
     'controllers/abstract_controller.cpp',
     'controllers/controller_manager.cpp',
     'controllers/phase_handler.cpp',
+    'controllers/sasi_controller.cpp',
     'controllers/scsi_controller.cpp',
 ]
 devices_src = [
@@ -17,6 +18,7 @@ devices_src = [
     'devices/mode_page_device.cpp',
     'devices/primary_device.cpp',
     'devices/scsi_command_util.cpp',
+    'devices/sasi_hd.cpp',
     'devices/scsi_daynaport.cpp',
     'devices/scsi_printer.cpp',
     'devices/scsi_streamer.cpp',
@@ -109,6 +111,7 @@ test_src = [
     'test/primary_device_test.cpp',
     'test/protobuf_util_test.cpp',
     'test/scsi_command_util_test.cpp',
+    'test/sasi_hd_test.cpp',
     'test/scsi_controller_test.cpp',
     'test/scsi_daynaport_test.cpp',
     'test/scsi_printer_test.cpp',

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -66,6 +66,12 @@ scsidump_core_src = [
 scsidump_src = [
     'scsidump/scsidump.cpp',
 ] + scsidump_core_src + hal_src
+sasidump_core_src = [
+    'sasidump/sasidump_core.cpp',
+]
+sasidump_src = [
+    'sasidump/sasidump.cpp',
+] + sasidump_core_src + hal_src
 scsiloop_src = [
     'scsiloop/scsiloop.cpp',
     'scsiloop/scsiloop_core.cpp',
@@ -179,6 +185,14 @@ if connect_type == 'FULLSPEC' and target.contains('scsidump')
     scsidump_bin = executable('scsidump',
         scsidump_src + shared_src,
         dependencies : common_deps,
+        install : true,
+    )
+endif
+
+if connect_type == 'FULLSPEC' and target.contains('sasidump')
+    sasidump_bin = executable('sasidump',
+        sasidump_src + shared_src,
+        dependencies : common_deps + [protobuf_dep],
         install : true,
     )
 endif

--- a/cpp/piscsi/piscsi_executor.cpp
+++ b/cpp/piscsi/piscsi_executor.cpp
@@ -196,9 +196,9 @@ bool PiscsiExecutor::Attach(const CommandContext& context, const PbDeviceDefinit
 	const int lun = pb_device.unit();
 	const PbDeviceType type = pb_device.type();
 
-	if (lun >= ControllerManager::GetScsiLunMax()) {
+	if (lun >= ControllerManager::GetLunMax(type)) {
 		return context.ReturnLocalizedError(LocalizationKey::ERROR_INVALID_LUN, to_string(lun),
-				to_string(ControllerManager::GetScsiLunMax()));
+				to_string(ControllerManager::GetLunMax(type) - 1));
 	}
 
 	if (controller_manager.HasDeviceForIdAndLun(id, lun)) {

--- a/cpp/piscsi/piscsi_response.cpp
+++ b/cpp/piscsi/piscsi_response.cpp
@@ -26,7 +26,7 @@ using namespace protobuf_util;
 
 void PiscsiResponse::GetDeviceProperties(shared_ptr<Device> device, PbDeviceProperties& properties) const
 {
-	properties.set_luns(ControllerManager::GetScsiLunMax());
+	properties.set_luns(ControllerManager::GetLunMax(device->GetType()));
 	properties.set_read_only(device->IsReadOnly());
 	properties.set_protectable(device->IsProtectable());
 	properties.set_stoppable(device->IsStoppable());

--- a/cpp/sasidump/sasidump.cpp
+++ b/cpp/sasidump/sasidump.cpp
@@ -1,0 +1,21 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Powered by XM6 TypeG Technology.
+// Copyright (C) 2016-2020 GIMONS
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#include "sasidump/sasidump_core.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+    vector<char*> args(argv, argv + argc);
+
+    return SasiDump().run(args);
+}

--- a/cpp/sasidump/sasidump_core.cpp
+++ b/cpp/sasidump/sasidump_core.cpp
@@ -1,0 +1,422 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Powered by XM6 TypeG Technology.
+// Copyright (C) 2016-2020 GIMONS
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//	HDD dump utility (Initiator mode/SASI Version)
+//
+//	SASI IMAGE EXAMPLE
+//		X68000
+//			10MB(10441728 BS=256 C=40788)
+//			20MB(20748288 BS=256 C=81048)
+//			40MB(41496576 BS=256 C=162096)
+//
+//		MZ-2500/MZ-2800 MZ-1F23
+//			20MB(22437888 BS=1024 C=21912)
+//
+//---------------------------------------------------------------------------
+
+#include "sasidump/sasidump_core.h"
+#include "hal/gpiobus_factory.h"
+#include "hal/systimer.h"
+#include "shared/piscsi_exceptions.h"
+#include "shared/piscsi_util.h"
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <csignal>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <thread>
+#include <unistd.h>
+
+using namespace std;
+using namespace piscsi_util;
+
+namespace
+{
+constexpr uint8_t TEST_UNIT_READY   = 0x00;
+constexpr uint8_t REQUEST_SENSE     = 0x03;
+constexpr uint8_t READ_6            = 0x08;
+constexpr uint8_t WRITE_6           = 0x0a;
+constexpr uint32_t PHASE_TIMEOUT_US = 3'000'000;
+
+class sasi_dump_exception : public runtime_error
+{
+    using runtime_error::runtime_error;
+};
+} // namespace
+
+bool SasiDump::Banner(span<char*> args) const
+{
+    cout << piscsi_util::Banner("(SASI Hard Disk Dump/Restore Utility)");
+
+    if (args.size() < 2 || string(args[1]) == "-h" || string(args[1]) == "--help") {
+        cout << "Usage: " << args[0] << " -i ID [-u UNIT] [-b BLOCK_SIZE] -c COUNT -f FILE [-r]\n"
+             << "See the sasidump man page for all supported parameters\n";
+        return false;
+    }
+
+    return true;
+}
+
+void SasiDump::ParseArguments(span<char*> args)
+{
+    int option;
+
+    opterr = 0;
+    while ((option = getopt(static_cast<int>(args.size()), args.data(), "i:u:b:c:f:r")) != -1) {
+        switch (option) {
+        case 'i':
+            if (!GetAsUnsignedInt(optarg, target_id) || target_id > 7) {
+                throw parser_exception("Invalid target ID (0-7)");
+            }
+            break;
+
+        case 'u':
+            if (!GetAsUnsignedInt(optarg, unit_id) || unit_id > 1) {
+                throw parser_exception("Invalid unit ID (0-1)");
+            }
+            break;
+
+        case 'b': {
+            int value;
+            if (!GetAsUnsignedInt(optarg, value) || (value != 256 && value != 512 && value != 1024)) {
+                throw parser_exception("Invalid block size (256, 512, or 1024)");
+            }
+            block_size = static_cast<uint32_t>(value);
+        } break;
+
+        case 'c': {
+            int value;
+            if (!GetAsUnsignedInt(optarg, value) || value == 0 || value > static_cast<int>(MAX_BLOCK_ADDRESS + 1)) {
+                throw parser_exception("Invalid block count (1-" + to_string(MAX_BLOCK_ADDRESS + 1) + ")");
+            }
+            block_count = static_cast<uint32_t>(value);
+        } break;
+
+        case 'f':
+            filename = optarg;
+            break;
+
+        case 'r':
+            restore = true;
+            break;
+
+        default:
+            throw parser_exception("Invalid option");
+        }
+    }
+
+    if (target_id == -1) {
+        throw parser_exception("Missing target ID");
+    }
+    if (block_count == 0) {
+        throw parser_exception("Missing block count");
+    }
+    if (filename.empty()) {
+        throw parser_exception("Missing filename");
+    }
+}
+
+bool SasiDump::Init() const
+{
+    struct sigaction termination_handler{};
+    termination_handler.sa_handler = TerminationHandler;
+    sigemptyset(&termination_handler.sa_mask);
+    sigaction(SIGINT, &termination_handler, nullptr);
+    sigaction(SIGHUP, &termination_handler, nullptr);
+    sigaction(SIGTERM, &termination_handler, nullptr);
+    signal(SIGPIPE, SIG_IGN);
+
+    bus = GPIOBUS_Factory::Create(BUS::mode_e::INITIATOR);
+    return bus != nullptr;
+}
+
+void SasiDump::CleanUp()
+{
+    if (bus != nullptr) {
+        bus->Cleanup();
+    }
+}
+
+void SasiDump::TerminationHandler(int)
+{
+    CleanUp();
+}
+
+void SasiDump::ResetBus() const
+{
+    bus->SetRST(true);
+    this_thread::sleep_for(chrono::milliseconds(1));
+    bus->SetRST(false);
+}
+
+void SasiDump::WaitForPhase(phase_t phase) const
+{
+    const uint32_t start = SysTimer::GetTimerLow();
+    while (SysTimer::GetTimerLow() - start < PHASE_TIMEOUT_US) {
+        bus->Acquire();
+        if (bus->GetREQ() && bus->GetPhase() == phase) {
+            return;
+        }
+    }
+
+    throw sasi_dump_exception("Expected " + string(BUS::GetPhaseStrRaw(phase)) + " phase, actual phase is " +
+                              string(BUS::GetPhaseStrRaw(bus->GetPhase())));
+}
+
+void SasiDump::WaitForBusy() const
+{
+    for (int attempts = 0; attempts < 10'000; attempts++) {
+        this_thread::sleep_for(chrono::microseconds(20));
+        bus->Acquire();
+        if (bus->GetBSY()) {
+            return;
+        }
+    }
+
+    throw sasi_dump_exception("Selection failed");
+}
+
+void SasiDump::SelectTarget() const
+{
+    // Unlike SCSI, SASI selection puts only the target ID on the data bus.
+    bus->SetDAT(static_cast<uint8_t>(1U << target_id));
+    bus->SetSEL(true);
+    WaitForBusy();
+    bus->SetSEL(false);
+}
+
+void SasiDump::SendCommand(vector<uint8_t>& command) const
+{
+    SelectTarget();
+    WaitForPhase(phase_t::command);
+
+    if (bus->SendHandShake(command.data(), static_cast<int>(command.size()), BUS::SEND_NO_DELAY) !=
+        static_cast<int>(command.size())) {
+        BusFree();
+        throw sasi_dump_exception("Command transfer failed");
+    }
+}
+
+void SasiDump::ReadData(int length)
+{
+    WaitForPhase(phase_t::datain);
+    if (bus->ReceiveHandShake(buffer.data(), length) != length) {
+        throw sasi_dump_exception("DATA IN transfer failed");
+    }
+}
+
+void SasiDump::WriteData(int length)
+{
+    WaitForPhase(phase_t::dataout);
+    if (bus->SendHandShake(buffer.data(), length, BUS::SEND_NO_DELAY) != length) {
+        throw sasi_dump_exception("DATA OUT transfer failed");
+    }
+}
+
+uint8_t SasiDump::ReceiveStatus() const
+{
+    array<uint8_t, 1> status = {};
+    WaitForPhase(phase_t::status);
+    if (bus->ReceiveHandShake(status.data(), static_cast<int>(status.size())) != static_cast<int>(status.size())) {
+        throw sasi_dump_exception("STATUS transfer failed");
+    }
+    return status[0];
+}
+
+void SasiDump::ReceiveMessageIn() const
+{
+    array<uint8_t, 1> message = {};
+    WaitForPhase(phase_t::msgin);
+    if (bus->ReceiveHandShake(message.data(), static_cast<int>(message.size())) != static_cast<int>(message.size())) {
+        throw sasi_dump_exception("MESSAGE IN transfer failed");
+    }
+}
+
+void SasiDump::BusFree() const
+{
+    bus->Reset();
+}
+
+void SasiDump::TestUnitReady()
+{
+    try {
+        vector<uint8_t> command(6, 0);
+        command[0] = TEST_UNIT_READY;
+        command[1] = static_cast<uint8_t>(unit_id << 5);
+        SendCommand(command);
+        ReceiveStatus();
+        ReceiveMessageIn();
+    } catch (...) {
+        BusFree();
+        throw;
+    }
+    BusFree();
+}
+
+void SasiDump::RequestSense()
+{
+    vector<uint8_t> command(6, 0);
+    command[0] = REQUEST_SENSE;
+    command[1] = static_cast<uint8_t>(unit_id << 5);
+    command[4] = 4;
+
+    try {
+        SendCommand(command);
+        ReadData(4);
+        ReceiveStatus();
+        ReceiveMessageIn();
+    } catch (...) {
+        BusFree();
+        throw;
+    }
+    BusFree();
+}
+
+void SasiDump::Read6(uint32_t start_block, uint32_t blocks)
+{
+    vector<uint8_t> command(6, 0);
+    command[0] = READ_6;
+    command[1] = static_cast<uint8_t>((unit_id << 5) | ((start_block >> 16) & 0x1f));
+    command[2] = static_cast<uint8_t>(start_block >> 8);
+    command[3] = static_cast<uint8_t>(start_block);
+    command[4] = static_cast<uint8_t>(blocks);
+
+    try {
+        SendCommand(command);
+        ReadData(static_cast<int>(blocks * block_size));
+        ReceiveStatus();
+        ReceiveMessageIn();
+    } catch (...) {
+        BusFree();
+        throw;
+    }
+    BusFree();
+}
+
+void SasiDump::Write6(uint32_t start_block, uint32_t blocks)
+{
+    vector<uint8_t> command(6, 0);
+    command[0] = WRITE_6;
+    command[1] = static_cast<uint8_t>((unit_id << 5) | ((start_block >> 16) & 0x1f));
+    command[2] = static_cast<uint8_t>(start_block >> 8);
+    command[3] = static_cast<uint8_t>(start_block);
+    command[4] = static_cast<uint8_t>(blocks);
+
+    try {
+        SendCommand(command);
+        WriteData(static_cast<int>(blocks * block_size));
+        ReceiveStatus();
+        ReceiveMessageIn();
+    } catch (...) {
+        BusFree();
+        throw;
+    }
+    BusFree();
+}
+
+void SasiDump::DumpRestore()
+{
+    const uint32_t blocks_per_transfer = static_cast<uint32_t>(buffer.size() / block_size);
+    const uint64_t transfer_size       = static_cast<uint64_t>(block_count) * block_size;
+
+    cout << "Target ID:       " << target_id << "\n"
+         << "Unit ID:         " << unit_id << "\n"
+         << "Number of blocks: " << block_count << "\n"
+         << "Block length:    " << block_size << " bytes\n"
+         << "Total length:    " << transfer_size << " bytes (" << transfer_size / 1024 / 1024 << " MiB)\n";
+
+    ifstream input;
+    ofstream output;
+    if (restore) {
+        input.open(filename, ios::binary);
+        if (!input) {
+            throw io_exception("Can't open image file '" + filename + "'");
+        }
+
+        const auto file_size = filesystem::file_size(filename);
+        cout << "Restore file size: " << file_size << " bytes\n";
+        if (file_size < transfer_size) {
+            throw io_exception("Restore file is smaller than the specified disk size");
+        }
+        if (file_size > transfer_size) {
+            cout << "Warning: Restore file is larger than the specified disk size\n";
+        }
+    } else {
+        output.open(filename, ios::binary | ios::trunc);
+        if (!output) {
+            throw io_exception("Can't open image file '" + filename + "'");
+        }
+    }
+
+    ResetBus();
+    TestUnitReady();
+    RequestSense();
+
+    cout << (restore ? "Restore progress: " : "Dump progress: ") << flush;
+    for (uint32_t start_block = 0; start_block < block_count;) {
+        const uint32_t blocks = min(blocks_per_transfer, block_count - start_block);
+        const auto bytes      = static_cast<streamsize>(blocks * block_size);
+
+        if (restore) {
+            input.read(reinterpret_cast<char*>(buffer.data()), bytes);
+            if (input.gcount() != bytes) {
+                throw io_exception("Failed to read image file");
+            }
+            Write6(start_block, blocks);
+        } else {
+            Read6(start_block, blocks);
+            output.write(reinterpret_cast<const char*>(buffer.data()), bytes);
+            if (!output) {
+                throw io_exception("Failed to write image file");
+            }
+        }
+
+        start_block += blocks;
+        cout << '\r' << (start_block * 100 / block_count) << "% (" << start_block << '/' << block_count << ')' << flush;
+    }
+    cout << '\n';
+}
+
+int SasiDump::run(span<char*> args)
+{
+    if (!Banner(args)) {
+        return EXIT_SUCCESS;
+    }
+
+    try {
+        ParseArguments(args);
+    } catch (const parser_exception& e) {
+        cerr << "Error: " << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
+
+#ifndef USE_SEL_EVENT_ENABLE
+    cerr << "Error: No PiSCSI hardware support\n";
+    return EXIT_FAILURE;
+#endif
+
+    if (!Init()) {
+        cerr << "Error: Can't initialize bus\n";
+        return EXIT_FAILURE;
+    }
+
+    try {
+        DumpRestore();
+    } catch (const exception& e) {
+        cerr << "Error: " << e.what() << '\n';
+        CleanUp();
+        return EXIT_FAILURE;
+    }
+
+    CleanUp();
+    return EXIT_SUCCESS;
+}

--- a/cpp/sasidump/sasidump_core.h
+++ b/cpp/sasidump/sasidump_core.h
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+// Powered by XM6 TypeG Technology.
+// Copyright (C) 2016-2020 GIMONS
+// Copyright (C) 2026 Daniel Markstedt <daniel@mindani.net>
+//
+//---------------------------------------------------------------------------
+
+#pragma once
+
+#include "hal/bus.h"
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+class SasiDump
+{
+  public:
+    int run(span<char*>);
+
+  private:
+    static constexpr size_t BUFFER_SIZE         = 64 * 1024;
+    static constexpr uint32_t MAX_BLOCK_ADDRESS = 0x1fffff;
+
+    bool Banner(span<char*>) const;
+    void ParseArguments(span<char*>);
+    bool Init() const;
+    void DumpRestore();
+    void ResetBus() const;
+    void SelectTarget() const;
+    void SendCommand(vector<uint8_t>&) const;
+    void Read6(uint32_t, uint32_t);
+    void Write6(uint32_t, uint32_t);
+    void TestUnitReady();
+    void RequestSense();
+    void ReadData(int);
+    void WriteData(int);
+    uint8_t ReceiveStatus() const;
+    void ReceiveMessageIn() const;
+    void WaitForPhase(phase_t) const;
+    void WaitForBusy() const;
+    void BusFree() const;
+
+    static void CleanUp();
+    static void TerminationHandler(int);
+
+    static inline unique_ptr<BUS> bus;
+
+    vector<uint8_t> buffer = vector<uint8_t>(BUFFER_SIZE);
+    int target_id          = -1;
+    int unit_id            = 0;
+    uint32_t block_size    = 256;
+    uint32_t block_count   = 0;
+    string filename;
+    bool restore = false;
+};

--- a/cpp/scsictl/scsictl_core.cpp
+++ b/cpp/scsictl/scsictl_core.cpp
@@ -33,7 +33,8 @@ void ScsiCtl::Banner(const vector<char *>& args) const
 		cout << piscsi_util::Banner("(Controller App)")
 				<< "\nUsage: " << args[0] << " -i ID[:LUN] [-c CMD] [-C FILE] [-t TYPE] ...\n"
 				<< " where  ID[:LUN] ID := {0-" << (ControllerManager::GetScsiIdMax() - 1) << "},"
-				<< " LUN := {0-" << (ControllerManager::GetScsiLunMax() - 1) << "}, default is 0\n"
+				<< " LUN := {0-" << (ControllerManager::GetScsiLunMax() - 1)
+				<< "} for SCSI or {0-" << (ControllerManager::GetSasiLunMax() - 1) << "} for SASI, default is 0\n"
 				<< "Usage: " << args[0] << " -l\n"
 				<< "       Print device list.\n\n"
 				<< "DaynaPort profiles use one explicit parameter value, for example:\n"

--- a/cpp/shared/scsi.h
+++ b/cpp/shared/scsi.h
@@ -62,7 +62,10 @@ enum class scsi_command {
     eCmdRezero         = 0x01,
     eCmdRequestSense   = 0x03,
     eCmdFormatUnit     = 0x04,
+    // SASI READ CAPACITY (not the SCSI READ BLOCK LIMITS command)
     eCmdReadBlockLimits= 0x05,
+    // Legacy SASI FORMAT opcode
+    eCmdFormatLegacy   = 0x06,
     eCmdReassignBlocks = 0x07,
     eCmdRead6          = 0x08,
     // Bridge specific command
@@ -156,6 +159,8 @@ static const unordered_map<scsi_command, pair<int, string>> command_mapping = {
     {scsi_command::eCmdRezero, make_pair(6, "Rezero")},
     {scsi_command::eCmdRequestSense, make_pair(6, "RequestSense")},
     {scsi_command::eCmdFormatUnit, make_pair(6, "FormatUnit")},
+    {scsi_command::eCmdReadBlockLimits, make_pair(6, "SasiReadCapacity/ReadBlockLimits")},
+    {scsi_command::eCmdFormatLegacy, make_pair(6, "SasiFormat")},
     {scsi_command::eCmdReassignBlocks, make_pair(6, "ReassignBlocks")},
     {scsi_command::eCmdRead6, make_pair(6, "Read6/GetMessage10")},
     {scsi_command::eCmdRetrieveStats, make_pair(6, "RetrieveStats")},

--- a/cpp/shared/scsi.h
+++ b/cpp/shared/scsi.h
@@ -117,7 +117,10 @@ enum class scsi_command {
     eCmdSynchronizeCache16         = 0x91,
     eCmdReadCapacity16_ReadLong16  = 0x9E,
     eCmdWriteLong16                = 0x9F,
-    eCmdReportLuns                 = 0xA0
+    eCmdReportLuns                 = 0xA0,
+    // SASI/OMTI Assign Disk Parameters. The CDB is six bytes and is followed
+    // by a ten-byte parameter list in the data-out phase.
+    eCmdAssignDiskParameters       = 0xC2
 };
 
 enum class status {
@@ -198,5 +201,6 @@ static const unordered_map<scsi_command, pair<int, string>> command_mapping = {
     {scsi_command::eCmdSynchronizeCache16, make_pair(16, "SynchronizeCache16")},
     {scsi_command::eCmdReadCapacity16_ReadLong16, make_pair(16, "ReadCapacity16/ReadLong16")},
     {scsi_command::eCmdWriteLong16, make_pair(16, "WriteLong16")},
-    {scsi_command::eCmdReportLuns, make_pair(12, "ReportLuns")}};
+    {scsi_command::eCmdReportLuns, make_pair(12, "ReportLuns")},
+    {scsi_command::eCmdAssignDiskParameters, make_pair(6, "AssignDiskParameters")}};
 }; // namespace scsi_defs

--- a/cpp/test/bus_test.cpp
+++ b/cpp/test/bus_test.cpp
@@ -12,11 +12,13 @@
 
 TEST(BusTest, GetCommandByteCount)
 {
-    EXPECT_EQ(41, scsi_defs::command_mapping.size());
+    EXPECT_EQ(43, scsi_defs::command_mapping.size());
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x00));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x01));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x03));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x04));
+	EXPECT_EQ(6, BUS::GetCommandByteCount(0x05));
+	EXPECT_EQ(6, BUS::GetCommandByteCount(0x06));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x07));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x08));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x09));

--- a/cpp/test/bus_test.cpp
+++ b/cpp/test/bus_test.cpp
@@ -12,7 +12,7 @@
 
 TEST(BusTest, GetCommandByteCount)
 {
-    EXPECT_EQ(43, scsi_defs::command_mapping.size());
+    EXPECT_EQ(44, scsi_defs::command_mapping.size());
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x00));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x01));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x03));
@@ -56,6 +56,7 @@ TEST(BusTest, GetCommandByteCount)
     EXPECT_EQ(16, BUS::GetCommandByteCount(0x91));
     EXPECT_EQ(16, BUS::GetCommandByteCount(0x9e));
     EXPECT_EQ(16, BUS::GetCommandByteCount(0x9f));
+    EXPECT_EQ(6, BUS::GetCommandByteCount(0xc2));
     EXPECT_EQ(0, BUS::GetCommandByteCount(0x1f));
 }
 

--- a/cpp/test/controller_manager_test.cpp
+++ b/cpp/test/controller_manager_test.cpp
@@ -79,6 +79,30 @@ TEST(ControllerManagerTest, AttachToController)
 	EXPECT_FALSE(controller_manager.AttachToController(*bus, ID, device1));
 }
 
+TEST(ControllerManagerTest, AttachSasiDevices)
+{
+	const int ID = 4;
+
+	auto bus = make_shared<MockBus>();
+	ControllerManager controller_manager;
+	DeviceFactory device_factory;
+
+	auto sasi_lun0 = device_factory.CreateDevice(SAHD, 0, "");
+	EXPECT_TRUE(controller_manager.AttachToController(*bus, ID, sasi_lun0));
+	auto controller = controller_manager.FindController(ID);
+	EXPECT_TRUE(controller->IsSasi());
+	EXPECT_EQ(ControllerManager::GetSasiLunMax(), controller->GetMaxLuns());
+
+	auto sasi_lun1 = device_factory.CreateDevice(SAHD, 1, "");
+	EXPECT_TRUE(controller_manager.AttachToController(*bus, ID, sasi_lun1));
+
+	auto scsi_lun1 = device_factory.CreateDevice(SCHS, 1, "");
+	EXPECT_FALSE(controller_manager.AttachToController(*bus, ID, scsi_lun1));
+
+	auto invalid_sasi_lun = device_factory.CreateDevice(SAHD, 2, "");
+	EXPECT_FALSE(controller_manager.AttachToController(*bus, ID, invalid_sasi_lun));
+}
+
 TEST(ControllerManager, ProcessOnController)
 {
 	ControllerManager controller_manager;

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -19,6 +19,8 @@ TEST(DeviceFactoryTest, GetTypeForFile)
 {
 	DeviceFactory device_factory;
 
+	EXPECT_EQ(device_factory.GetTypeForFile("test.hdf"), SAHD);
+	EXPECT_EQ(device_factory.GetTypeForFile("test.HDF"), SAHD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.hd1"), SCHD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.hds"), SCHD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.HDS"), SCHD);
@@ -47,7 +49,8 @@ TEST(DeviceFactoryTest, GetExtensionMapping)
 	DeviceFactory device_factory;
 
 	auto mapping = device_factory.GetExtensionMapping();
-	EXPECT_EQ(14, mapping.size());
+	EXPECT_EQ(15, mapping.size());
+	EXPECT_EQ(SAHD, mapping["hdf"]);
 	EXPECT_EQ(SCHD, mapping["hd1"]);
 	EXPECT_EQ(SCHD, mapping["hds"]);
 	EXPECT_EQ(SCHD, mapping["hda"]);
@@ -71,11 +74,13 @@ TEST(DeviceFactoryTest, UnknownDeviceType)
 	auto device1 = device_factory.CreateDevice(UNDEFINED, 0, "test");
 	EXPECT_EQ(nullptr, device1);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	auto device2 = device_factory.CreateDevice(SAHD, 0, "test");
-#pragma GCC diagnostic pop
-	EXPECT_EQ(nullptr, device2);
+	EXPECT_NE(nullptr, device2);
+	EXPECT_EQ(SAHD, device2->GetType());
+
+	auto device3 = device_factory.CreateDevice(UNDEFINED, 0, "test.hdf");
+	EXPECT_NE(nullptr, device3);
+	EXPECT_EQ(SAHD, device3->GetType());
 }
 
 TEST(DeviceFactoryTest, SCHD_Device_Defaults)

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -160,6 +160,8 @@ class MockAbstractController : public AbstractController //NOSONAR Having many f
 	FRIEND_TEST(ScsiPrinterTest, Print);
 	FRIEND_TEST(ScsiCdTest, ReadToc);
 	FRIEND_TEST(ScsiCdTest, ReadTocAllocationLength);
+	FRIEND_TEST(SasiHdTest, X68000TestUnitReadyProbe);
+	FRIEND_TEST(SasiHdTest, X68000TestUnitReadyProbeSuccess);
 
 public:
 

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -199,6 +199,7 @@ class MockScsiController : public ScsiController
 	FRIEND_TEST(ScsiControllerTest, Error);
 	FRIEND_TEST(ScsiControllerTest, RequestSense);
 	FRIEND_TEST(PrimaryDeviceTest, RequestSense);
+	FRIEND_TEST(SasiHdTest, RequestSense);
 
 public:
 

--- a/cpp/test/piscsi_executor_test.cpp
+++ b/cpp/test/piscsi_executor_test.cpp
@@ -491,10 +491,7 @@ TEST(PiscsiExecutorTest, CreateDevice)
 	CommandContext context(command, "", "");
 
 	EXPECT_EQ(nullptr, executor.CreateDevice(context, UNDEFINED, 0, ""));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	EXPECT_EQ(nullptr, executor.CreateDevice(context, SAHD, 0, ""));
-#pragma GCC diagnostic pop
+	EXPECT_NE(nullptr, executor.CreateDevice(context, SAHD, 0, ""));
 	EXPECT_NE(nullptr, executor.CreateDevice(context, UNDEFINED, 0, "services"));
 	EXPECT_NE(nullptr, executor.CreateDevice(context, SCHS, 0, ""));
 }

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -171,7 +171,7 @@ TEST(PiscsiResponseTest, GetDeviceTypesInfo)
 
 	PbDeviceTypesInfo info;
 	response.GetDeviceTypesInfo(info);
-	EXPECT_EQ(8, info.properties().size());
+	EXPECT_EQ(9, info.properties().size());
 }
 
 TEST(PiscsiResponseTest, GetServerInfo)
@@ -259,5 +259,6 @@ TEST(PiscsiResponseTest, GetMappingInfo)
 
 	PbMappingInfo info;
 	response.GetMappingInfo(info);
-	EXPECT_EQ(14, info.mapping().size());
+	EXPECT_EQ(15, info.mapping().size());
+	EXPECT_EQ(SAHD, info.mapping().at("hdf"));
 }

--- a/cpp/test/sasi_hd_test.cpp
+++ b/cpp/test/sasi_hd_test.cpp
@@ -1,0 +1,65 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+// for Raspberry Pi
+//
+//---------------------------------------------------------------------------
+
+#include "mocks.h"
+#include "devices/sasi_hd.h"
+#include "shared/piscsi_exceptions.h"
+
+using namespace scsi_defs;
+
+TEST(SasiHdTest, Inquiry)
+{
+	auto [controller, hd] = CreateDevice(SAHD);
+
+	EXPECT_CALL(*controller, DataIn());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdInquiry));
+	EXPECT_EQ(2, controller->GetLength());
+	EXPECT_EQ(0, controller->GetBuffer()[0]);
+	EXPECT_EQ(0, controller->GetBuffer()[1]);
+}
+
+TEST(SasiHdTest, RequestSense)
+{
+	auto [controller, hd] = CreateDevice(SAHD);
+
+	EXPECT_CALL(*controller, DataIn());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdRequestSense));
+	EXPECT_EQ(4, controller->GetLength());
+	EXPECT_EQ(0, controller->GetBuffer()[0]);
+	EXPECT_EQ(0, controller->GetBuffer()[1]);
+}
+
+TEST(SasiHdTest, BlockSizesAndOpen)
+{
+	SasiHd hd(0);
+	EXPECT_TRUE(hd.GetSupportedSectorSizes().contains(256));
+	EXPECT_TRUE(hd.GetSupportedSectorSizes().contains(512));
+	EXPECT_TRUE(hd.GetSupportedSectorSizes().contains(1024));
+
+	EXPECT_THROW(hd.Open(), io_exception);
+	const path filename = CreateTempFile(2048);
+	hd.SetFilename(filename.string());
+	hd.Open();
+	EXPECT_EQ(256, hd.GetSectorSizeInBytes());
+	EXPECT_EQ(8, hd.GetBlockCount());
+}
+
+TEST(SasiHdTest, ReadCapacity)
+{
+	auto [controller, device] = CreateDevice(SAHD);
+	auto hd = dynamic_pointer_cast<SasiHd>(device);
+	const path filename = CreateTempFile(2048);
+	hd->SetFilename(filename.string());
+	hd->Open();
+
+	EXPECT_CALL(*controller, DataIn());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdReadBlockLimits));
+	EXPECT_EQ(6, controller->GetLength());
+	EXPECT_EQ(7, controller->GetBuffer()[3]);
+	EXPECT_EQ(1, controller->GetBuffer()[4]);
+	EXPECT_EQ(0, controller->GetBuffer()[5]);
+}

--- a/cpp/test/sasi_hd_test.cpp
+++ b/cpp/test/sasi_hd_test.cpp
@@ -33,6 +33,39 @@ TEST(SasiHdTest, RequestSense)
 	EXPECT_EQ(0, controller->GetBuffer()[1]);
 }
 
+TEST(SasiHdTest, X68000TestUnitReadyProbe)
+{
+	auto [controller, hd] = CreateDevice(SAHD);
+
+	controller->SetCmdByte(1, 0x28);
+	EXPECT_CALL(*controller, Status());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdTestUnitReady));
+	EXPECT_EQ(status::check_condition, controller->GetStatus());
+}
+
+TEST(SasiHdTest, X68000TestUnitReadyProbeSuccess)
+{
+	auto [controller, hd] = CreateDevice(SAHD);
+
+	controller->SetCmdByte(1, 0x03);
+	EXPECT_CALL(*controller, Status());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdTestUnitReady));
+	EXPECT_EQ(status::good, controller->GetStatus());
+}
+
+TEST(SasiHdTest, AssignDiskParameters)
+{
+	auto [controller, hd] = CreateDevice(SAHD);
+	auto sasi_hd = dynamic_pointer_cast<SasiHd>(hd);
+	const path filename = CreateTempFile(256);
+	sasi_hd->SetFilename(filename.string());
+	sasi_hd->Open();
+
+	EXPECT_CALL(*controller, DataOut());
+	EXPECT_NO_THROW(hd->Dispatch(scsi_command::eCmdAssignDiskParameters));
+	EXPECT_EQ(10, controller->GetLength());
+}
+
 TEST(SasiHdTest, BlockSizesAndOpen)
 {
 	SasiHd hd(0);

--- a/debian/piscsi.install
+++ b/debian/piscsi.install
@@ -1,11 +1,13 @@
 debian/tmp/usr/bin/piscsi usr/bin
 debian/tmp/usr/bin/scsictl usr/bin
 debian/tmp/usr/bin/scsidump usr/bin
+debian/tmp/usr/bin/sasidump usr/bin
 debian/tmp/usr/bin/scsiloop usr/bin
 debian/tmp/usr/bin/scsimon usr/bin
 debian/tmp/usr/share/man/man1/piscsi.1 usr/share/man/man1
 debian/tmp/usr/share/man/man1/scsictl.1 usr/share/man/man1
 debian/tmp/usr/share/man/man1/scsidump.1 usr/share/man/man1
+debian/tmp/usr/share/man/man1/sasidump.1 usr/share/man/man1
 debian/tmp/usr/share/man/man1/scsiloop.1 usr/share/man/man1
 debian/tmp/usr/share/man/man1/scsimon.1 usr/share/man/man1
 doc/piscsi-network-profile.8 usr/share/man/man8

--- a/debian/rules
+++ b/debian/rules
@@ -72,9 +72,9 @@ endif
 
 override_dh_auto_install:
 	install -d debian/tmp/usr/bin debian/tmp/usr/share/man/man1
-	install -m 0755 cpp/bin/piscsi cpp/bin/scsictl cpp/bin/scsimon cpp/bin/scsiloop cpp/bin/scsidump debian/tmp/usr/bin/
+	install -m 0755 cpp/bin/piscsi cpp/bin/scsictl cpp/bin/scsimon cpp/bin/scsiloop cpp/bin/scsidump cpp/bin/sasidump debian/tmp/usr/bin/
 	install -m 0755 debian/build/piscsi-web debian/build/piscsi-oled debian/build/piscsi-ctrlboard debian/tmp/usr/bin/
-	install -m 0644 doc/piscsi.1 doc/piscsi-web.1 doc/piscsi-oled.1 doc/piscsi-ctrlboard.1 doc/scsictl.1 doc/scsimon.1 doc/scsiloop.1 doc/scsidump.1 debian/tmp/usr/share/man/man1/
+	install -m 0644 doc/piscsi.1 doc/piscsi-web.1 doc/piscsi-oled.1 doc/piscsi-ctrlboard.1 doc/scsictl.1 doc/scsimon.1 doc/scsiloop.1 doc/scsidump.1 doc/sasidump.1 debian/tmp/usr/share/man/man1/
 	install -D -m 0644 go/piscsi-web/drive_properties.json debian/tmp/etc/piscsi-web/drive_properties.json
 	install -D -m 0644 debian/piscsi-web.piscsi-web.env debian/tmp/etc/piscsi-web/piscsi-web.env
 	@piscsi_version=$$(awk -F '[=;]' '\

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -14,6 +14,10 @@ if target.contains('scsidump')
     man_pages += 'scsidump.1'
 endif
 
+if target.contains('sasidump')
+    man_pages += 'sasidump.1'
+endif
+
 if target.contains('scsiloop')
     man_pages += 'scsiloop.1'
 endif

--- a/doc/piscsi.1
+++ b/doc/piscsi.1
@@ -1,4 +1,4 @@
-.Dd December 18, 2025
+.Dd August 23, 2026
 .Dt PISCSI 1
 .Os PiSCSI
 .Sh NAME
@@ -18,18 +18,24 @@
 .Op Fl t Ar TYPE
 .Op Fl z Ar LOCALE
 .Op Fl IDn Ns Oo :u Oc Ar FILE
-.Op Fl HDn Ns Oo :u Oc Ar FILE ...
 .Nm
 .Op Fl h
 .Nm
 .Op Fl v
 .Sh DESCRIPTION
 .Nm
-emulates SCSI devices using the Raspberry Pi GPIO pins.
+emulates a range of SCSI devices using the Raspberry Pi GPIO pins.
+It can also emulate SASI hard drives, which is a predecessor of SCSI.
 .Pp
-In the arguments to PiSCSI, one or more SCSI (-IDn[:u]) devices can be specified.
-The number (n) after the ID or HD identifier specifies the ID number for that device. The optional number (u) specifies the LUN (logical unit) for that device. The default LUN is 0.
-For SCSI: The ID is limited from 0-7. However, typically SCSI ID 7 is reserved for the "initiator" (the host computer). The LUN is limited from 0-31.
+In the arguments to PiSCSI, one or more SCSI or SASI (-IDn[:u]) devices can be
+specified.
+The number (n) after the ID identifier specifies the ID number for that device.
+The optional number (u) specifies the LUN (logical unit) for that device.
+The default LUN is 0.
+For SCSI: The ID is limited from 0-7.
+However, typically SCSI ID 7 is reserved for the "initiator" (the host computer).
+The LUN is limited from 0-31.
+SASI hard disks support LUNs 0-1 only.
 .Pp
 PiSCSI will determine the type of device based upon the file extension of the FILE argument.
     hds: Hard Disk image (generic, non-removable)
@@ -39,6 +45,7 @@ PiSCSI will determine the type of device based upon the file extension of the FI
     hdi: Hard Disk image (Anex86 proprietary - only used with PC-98 computers)
     nhd: Hard Disk image (T98Next proprietary - only used with PC-98 computers)
     hda: Hard Disk image (Apple compatible - typically used with Macintosh computers)
+    hdf: Hard Disk image (XM6 SASI HD image - typically used with X68000)
     mos: Magneto-Optical image (generic - typically used with NeXT, X68000, etc.)
     iso: CD-ROM or DVD-ROM image (ISO 9660 image)
     is1: CD-ROM or DVD-ROM image (ISO 9660 image, SCSI-1 compatibility mode)
@@ -46,6 +53,7 @@ PiSCSI will determine the type of device based upon the file extension of the FI
     tar: Tape archive (tape block data in tar format)
 .Pp
 If the file extension is not recognized, the device type can be specified explicitly using the -t option and a four letter code.
+    SAHD: SASI Hard Disk (raw, non-removable)
     SCCD: SCSI CD-ROM (generic CD-ROM or DVD-ROM drive)
     SCDP: SCSI DaynaPort (DaynaPort compatible network adapter)
     SCHD: SCSI Hard Disk (generic, non-removable)
@@ -58,17 +66,19 @@ If the file extension is not recognized, the device type can be specified explic
 For example, if you want to specify an Apple-compatible HD image on ID 0, you can use the following command:
     sudo piscsi -ID0 /path/to/drive/hdimage.hda
 .Pp
-Note: PiSCSI is a fork of RaSCSI. The two cannot be run in parallel on the same system.
+Note: PiSCSI cannot be run in parallel with other applications that use the same GPIO pins, such as RaSCSI or SCSI2Pi.
 .Pp
 Once PiSCSI starts, it will open a socket (default port is 6868) to allow external management commands.
-If another process is using this port, PiSCSI will terminate, since it is likely another instance of PiSCSI or RaSCSI.
+If another process is using this port, PiSCSI will terminate.
 Once PiSCSI has initialized, the scsictl utility can be used to send commands.
 .Pp
 To quit PiSCSI, press Control + C. If it is running in the background, you can kill it using an INT signal.
 .Sh OPTIONS
 .Bl -tag -width Ds
 .It Fl b Ar BLOCK_SIZE
-The optional block size, either 512, 1024, 2048 or 4096 bytes. Default size is 512 bytes.
+The optional block size.
+SASI hard disks support 256, 512, or 1024 bytes per sector and default to 256 bytes.
+Other disk devices support 512, 1024, 2048, or 4096 bytes and default to 512 bytes.
 .It Fl F Ar FOLDER
 The default folder for image files. For files in this folder no absolute path needs to be specified. The folder must already exist. The initial default folder is '/var/lib/piscsi/images'.
 .It Fl h
@@ -94,9 +104,11 @@ Display the piscsi version.
 .It Fl z Ar LOCALE
 Sets the default locale for client-facing error messages. The client can override the locale.
 .It Fl ID Ar n Ns Oo : Ar u Oc Ar FILE
-n is the SCSI ID number (0-7). u (0-31) is the optional LUN (logical unit). The default LUN is 0.
+n is the SCSI or SASI ID number (0-7).
+u is the optional LUN (logical unit): 0-31 for SCSI and 0-1 for SAHD.
+The default LUN is 0.
 .Pp
-FILE is the name of the image file to use for a SCSI mass storage device. For devices that do not support an image file (SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCDP it selects one explicit host networking profile: \fBmode=bridge:interface=piscsi_bridge\fR for a preconfigured wired Linux bridge, or \fBmode=proxyarp:interface=wlan0\fR for the configured Wi-Fi proxy-ARP uplink. The proxy-ARP profile supports IPv4 unicast and DHCP only; it is not an Ethernet bridge and does not support IPv6, AppleTalk, multicast, mDNS, or other non-IP Ethernet traffic. For SCLP it is the print command to be used and a reservation timeout in seconds, e.g. "cmd=lp -oraw %f:timeout=60".
+FILE is the name of the image file to use for a SCSI or SASI mass storage device. For devices that do not support an image file (SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCDP it selects one explicit host networking profile: \fBmode=bridge:interface=piscsi_bridge\fR for a preconfigured wired Linux bridge, or \fBmode=proxyarp:interface=wlan0\fR for the configured Wi-Fi proxy-ARP uplink. The proxy-ARP profile supports IPv4 unicast and DHCP only; it is not an Ethernet bridge and does not support IPv6, AppleTalk, multicast, mDNS, or other non-IP Ethernet traffic. For SCLP it is the print command to be used and a reservation timeout in seconds, e.g. "cmd=lp -oraw %f:timeout=60".
 .El
 .Sh EXAMPLES
 Launch PiSCSI with no emulated drives attached:

--- a/doc/sasidump.1
+++ b/doc/sasidump.1
@@ -1,0 +1,66 @@
+.Dd August 26, 2026
+.Dt SASIDUMP 1
+.Os PiSCSI
+.Sh NAME
+.Nm sasidump
+.Nd SASI disk dumping tool for PiSCSI
+.Sh SYNOPSIS
+.Nm
+.Fl i Ar ID
+.Op Fl u Ar UNIT
+.Op Fl b Ar BLOCK_SIZE
+.Fl c Ar COUNT
+.Fl f Ar FILE
+.Op Fl r
+.Sh DESCRIPTION
+.Nm
+copies data between a physical SASI disk and a local image file.
+In its default dump mode, it copies from the SASI disk to the local file.
+With restore mode enabled, it copies from the local file to the SASI disk.
+.Pp
+The disk geometry is not available through SASI, so the block count and block
+size must be supplied explicitly.
+.Sh NOTES
+.Nm
+requires either a direct connection (one without transceivers) or a FULLSPEC
+PiSCSI/RaSCSI board.
+.Pp
+SASI uses a target ID and unit ID rather than SCSI target and initiator IDs.
+The PiSCSI board operates as the SASI initiator.
+.Pp
+Restoring overwrites data on the physical SASI disk.
+Verify the target ID, unit ID, block size, and block count before proceeding.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl i Ar ID
+SASI ID of the target device (0-7).
+.It Fl u Ar UNIT
+Unit ID of the target device (0-1).
+The default is 0.
+.It Fl b Ar BLOCK_SIZE
+Block size in bytes.
+Supported values are 256, 512, and 1024.
+The default is 256.
+.It Fl c Ar COUNT
+Number of blocks to transfer.
+The maximum is 2,097,152, the largest addressable SASI disk size.
+.It Fl f Ar FILE
+Path to the image file.
+.It Fl r
+Run in restore mode.
+Dump mode is the default.
+.El
+.Sh EXAMPLES
+Dump a 10 MiB X68000 SASI disk with 256-byte blocks from SASI ID 0:
+.Pp
+.Dl Nm sasidump -i 0 -b 256 -c 40788 -f ./x68000.hds
+.Pp
+Restore that image to the same SASI disk:
+.Pp
+.Dl Nm sasidump -i 0 -b 256 -c 40788 -f ./x68000.hds -r
+.Sh SEE ALSO
+.Xr piscsi 1 ,
+.Xr scsidump 1 ,
+.Xr scsimon 1
+.Pp
+Full documentation is available at: <https://www.piscsi.com>

--- a/doc/scsictl.1
+++ b/doc/scsictl.1
@@ -41,6 +41,7 @@ Note: The command and type arguments are case insensitive. Only the first letter
 .Bl -tag -width Ds
 .It Fl b Ar BLOCK_SIZE
 The optional block size, either 512, 1024, 2048 or 4096 bytes. The default size is 512 bytes.
+For SASI drives 256, 512 or 1024 bytes, default is 256 bytes.
 .It Fl C Ar FILENAME:FILESIZE
 Create an image file in the default image folder with the specified name and size in bytes.
 .It Fl c Ar CMD

--- a/doc/scsidump.1
+++ b/doc/scsidump.1
@@ -61,6 +61,7 @@ Restore Mode: [PiSCSI host] ---> [SCSI Drive]
 Launch scsidump to restore/upload a drive image from the local file system to SCSI ID 0 with block size 1MiB:
 .Dl Nm scsidump -r -t 0 -f ./outimage.hda -s 1048576
 .Sh SEE ALSO
+.Xr sasidump 1 ,
 .Xr scsictl 1 ,
 .Xr piscsi 1 ,
 .Xr scsimon 1

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -400,10 +400,10 @@ func (s *Server) getImageFiles(mapping map[string]pb.PbDeviceType, attachedImage
 	return files, filesBySubdir
 }
 
-// mirrors the Python client's grouping of daemon-provided extensions:
-// hard disks, removable disks, magneto-optical disks, CD-ROMs, then tapes.
+// groups daemon-provided extensions by device family for display.
 func imageSuffixes(mapping map[string]pb.PbDeviceType) []string {
 	deviceTypes := []pb.PbDeviceType{
+		pb.PbDeviceType_SAHD,
 		pb.PbDeviceType_SCHD,
 		pb.PbDeviceType_SCRM,
 		pb.PbDeviceType_SCMO,
@@ -436,6 +436,7 @@ type creatableImageSuffix struct {
 // format-specific headers.
 func creatableImageSuffixes(mapping map[string]pb.PbDeviceType) []creatableImageSuffix {
 	deviceTypes := []pb.PbDeviceType{
+		pb.PbDeviceType_SAHD,
 		pb.PbDeviceType_SCHD,
 		pb.PbDeviceType_SCRM,
 		pb.PbDeviceType_SCMO,
@@ -475,6 +476,7 @@ func imageSuffixDescription(suffix string, deviceType pb.PbDeviceType) string {
 		"hda": "Hard Disk Image (Apple)",
 		"hdn": "Hard Disk Image (NEC)",
 		"hd1": "Hard Disk Image (SCSI-1)",
+		"hdf": "Hard Disk Image (SASI)",
 		"hdr": "Removable Disk Image",
 		"mos": "Magneto-Optical Disk Image",
 		"tap": "Tape Image",
@@ -502,6 +504,8 @@ func (s *Server) hardDiskDriveProfiles() []string {
 
 func deviceTypeName(deviceType pb.PbDeviceType) string {
 	switch deviceType {
+	case pb.PbDeviceType_SAHD:
+		return "SASI Hard Disk"
 	case pb.PbDeviceType_SCHD:
 		return "SCSI Hard Disk"
 	case pb.PbDeviceType_SCRM:
@@ -533,6 +537,7 @@ type deviceParameterControl struct {
 type deviceCatalogEntry struct {
 	Key           string
 	Name          string
+	MaxLUN        int32
 	Removable     bool
 	SupportsFile  bool
 	Parameters    []deviceParameterControl
@@ -569,6 +574,7 @@ func (s *Server) buildDeviceCatalog(
 		entry := deviceCatalogEntry{
 			Key:          deviceType.String(),
 			Name:         deviceTypeName(deviceType),
+			MaxLUN:       piscsi.MaxLUN(deviceType),
 			Removable:    properties.GetRemovable(),
 			SupportsFile: properties.GetSupportsFile(),
 		}
@@ -628,7 +634,7 @@ func (s *Server) buildDeviceCatalog(
 
 		if entry.SupportsFile {
 			for _, file := range files {
-				if detectedType, ok := file["DetectedType"].(string); ok && detectedType == entry.Key {
+				if imageFileCompatibleWithDevice(file, deviceType) {
 					entry.Files = append(entry.Files, file)
 				}
 			}
@@ -645,7 +651,19 @@ func (s *Server) buildDeviceCatalog(
 		catalog = append(catalog, entry)
 	}
 
+	// Keep the legacy SASI hard disk option at the end of device-type lists.
+	sort.SliceStable(catalog, func(i, j int) bool {
+		return catalog[i].Key != "SAHD" && catalog[j].Key == "SAHD"
+	})
+
 	return catalog
+}
+
+// imageFileCompatibleWithDevice reports whether an image listed by the daemon
+// can be selected for a device type.
+func imageFileCompatibleWithDevice(file map[string]interface{}, deviceType pb.PbDeviceType) bool {
+	detectedType, ok := file["DetectedType"].(string)
+	return ok && detectedType == deviceType.String()
 }
 
 // returns server health status
@@ -696,21 +714,21 @@ func (s *Server) handleAttach(c *gin.Context) {
 		return
 	}
 
-	lun, err := parseIntParam(unit)
-	if err != nil || lun < 0 || lun > 31 {
-		s.respond(c, ResponseOptions{
-			Error:   true,
-			Message: "Invalid LUN (must be 0-31)",
-		})
-		return
-	}
-
 	// Map device type string to protobuf enum
 	pbType, err := parseDeviceType(deviceType)
 	if err != nil {
 		s.respond(c, ResponseOptions{
 			Error:   true,
 			Message: "Invalid device type",
+		})
+		return
+	}
+
+	lun, err := parseIntParam(unit)
+	if err != nil || lun < 0 || lun > piscsi.MaxLUN(pbType) {
+		s.respond(c, ResponseOptions{
+			Error:   true,
+			Message: fmt.Sprintf("Invalid LUN for %s (must be 0-%d)", deviceTypeName(pbType), piscsi.MaxLUN(pbType)),
 		})
 		return
 	}

--- a/go/piscsi-web/internal/server/handlers_device_test.go
+++ b/go/piscsi-web/internal/server/handlers_device_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -163,7 +164,7 @@ func TestHandleAttach_UsesSelectedDaynaPortProfile(t *testing.T) {
 }
 
 func TestParseDeviceTypeSupportsEveryCurrentProtobufType(t *testing.T) {
-	for _, name := range []string{"SCHD", "SCRM", "SCMO", "SCCD", "SCDP", "SCHS", "SCLP", "SCTP"} {
+	for _, name := range []string{"SAHD", "SCHD", "SCRM", "SCMO", "SCCD", "SCDP", "SCHS", "SCLP", "SCTP"} {
 		t.Run(name, func(t *testing.T) {
 			got, err := parseDeviceType(strings.ToLower(name))
 			if err != nil {
@@ -179,10 +180,22 @@ func TestParseDeviceTypeSupportsEveryCurrentProtobufType(t *testing.T) {
 func TestBuildDeviceCatalogUsesDaemonCapabilities(t *testing.T) {
 	server := &Server{}
 	files := []map[string]interface{}{
+		{"Name": "disk.hdf", "DetectedType": "SAHD"},
 		{"Name": "disk.hds", "DetectedType": "SCHD"},
+		{"Name": "apple.hda", "DetectedType": "SCHD"},
+		{"Name": "scsi1.hd1", "DetectedType": "SCHD"},
+		{"Name": "pc98.hdn", "DetectedType": "SCHD"},
+		{"Name": "anex.hdi", "DetectedType": "SCHD"},
+		{"Name": "t98.nhd", "DetectedType": "SCHD"},
 		{"Name": "backup.tap", "DetectedType": "SCTP"},
 	}
 	info := &pb.PbDeviceTypesInfo{Properties: []*pb.PbDeviceTypeProperties{
+		{
+			Type: pb.PbDeviceType_SAHD,
+			Properties: &pb.PbDeviceProperties{
+				SupportsFile: true,
+			},
+		},
 		{
 			Type: pb.PbDeviceType_SCDP,
 			Properties: &pb.PbDeviceProperties{
@@ -202,8 +215,14 @@ func TestBuildDeviceCatalogUsesDaemonCapabilities(t *testing.T) {
 		{Name: "piscsi_bridge", Type: pb.PbNetworkInterfaceType_NETWORK_INTERFACE_BRIDGE, Up: true, SupportedMode: []string{"bridge"}},
 		{Name: "wlan0", Type: pb.PbNetworkInterfaceType_NETWORK_INTERFACE_WIFI, Up: true, SupportedMode: []string{"proxyarp"}},
 	})
-	if len(catalog) != 2 {
-		t.Fatalf("catalog length = %d, want 2", len(catalog))
+	if len(catalog) != 3 {
+		t.Fatalf("catalog length = %d, want 3", len(catalog))
+	}
+	if catalog[2].Key != "SAHD" || catalog[2].Name != "SASI Hard Disk" || catalog[2].MaxLUN != 1 {
+		t.Fatalf("unexpected SASI catalog entry: %#v", catalog[2])
+	}
+	if got, want := catalogFileNames(catalog[2]), []string{"disk.hdf"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SASI files = %#v", catalog[2].Files)
 	}
 	if catalog[0].Key != "SCDP" || len(catalog[0].Parameters) != 2 {
 		t.Fatalf("unexpected network catalog entry: %#v", catalog[0])
@@ -221,6 +240,15 @@ func TestBuildDeviceCatalogUsesDaemonCapabilities(t *testing.T) {
 	if len(catalog[1].Files) != 1 || catalog[1].Files[0]["Name"] != "backup.tap" {
 		t.Fatalf("tape files = %#v", catalog[1].Files)
 	}
+}
+
+func catalogFileNames(entry deviceCatalogEntry) []string {
+	names := make([]string, 0, len(entry.Files))
+	for _, file := range entry.Files {
+		name, _ := file["Name"].(string)
+		names = append(names, name)
+	}
+	return names
 }
 
 func TestHandleAttachInsertsMediaIntoEmptyRemovableDevice(t *testing.T) {
@@ -645,6 +673,47 @@ func TestHandleAttach_InvalidLUN(t *testing.T) {
 		if !strings.Contains(errorMessage, "Invalid LUN") {
 			t.Errorf("expected error about invalid LUN, got: %s", errorMessage)
 		}
+	}
+}
+
+func TestHandleAttachRejectsSASILUNAboveOne(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := sessions.NewCookieStore([]byte("test-secret-key"))
+	server := &Server{
+		sessionStore: store,
+		piscsiClient: &testutil.MockPiSCSIClient{SendCommandFunc: func(*pb.PbCommand) (*pb.PbResult, error) {
+			t.Fatal("SASI LUN validation sent a daemon command")
+			return nil, nil
+		}},
+		config: &config.Config{},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	router := gin.New()
+	router.POST("/scsi/attach", server.handleAttach)
+	form := url.Values{"scsi_id": {"6"}, "unit": {"2"}, "type": {"SAHD"}}
+	request := httptest.NewRequest(http.MethodPost, "/scsi/attach", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusSeeOther)
+	}
+	cookies := response.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("SASI LUN validation did not set an error flash")
+	}
+	verifyRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	verifyRequest.AddCookie(cookies[0])
+	session, err := store.Get(verifyRequest, sessionName)
+	if err != nil {
+		t.Fatalf("read error flash: %v", err)
+	}
+	_, errorMessage := GetFlashesForTemplate(session)
+	if !strings.Contains(errorMessage, "must be 0-1") {
+		t.Fatalf("error message = %q, want SASI LUN limit", errorMessage)
 	}
 }
 

--- a/go/piscsi-web/internal/server/handlers_image_test.go
+++ b/go/piscsi-web/internal/server/handlers_image_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestImageSuffixesUsesDaemonMapping(t *testing.T) {
 	mapping := map[string]pb.PbDeviceType{
+		"hdf":    pb.PbDeviceType_SAHD,
 		"tap":    pb.PbDeviceType_SCTP,
 		"iso":    pb.PbDeviceType_SCCD,
 		"hdr":    pb.PbDeviceType_SCRM,
@@ -37,7 +38,7 @@ func TestImageSuffixesUsesDaemonMapping(t *testing.T) {
 		"ignore": pb.PbDeviceType_UNDEFINED,
 	}
 
-	want := []string{"hd1", "hda", "hdr", "mos", "iso", "tap"}
+	want := []string{"hdf", "hd1", "hda", "hdr", "mos", "iso", "tap"}
 	if got := imageSuffixes(mapping); !reflect.DeepEqual(got, want) {
 		t.Fatalf("imageSuffixes() = %v, want %v", got, want)
 	}
@@ -45,15 +46,16 @@ func TestImageSuffixesUsesDaemonMapping(t *testing.T) {
 
 func TestCreatableImageSuffixesUsesDaemonMapping(t *testing.T) {
 	mapping := map[string]pb.PbDeviceType{
-		"tap": pb.PbDeviceType_SCTP,
-		"iso": pb.PbDeviceType_SCCD,
-		"hdr": pb.PbDeviceType_SCRM,
-		"hd1": pb.PbDeviceType_SCHD,
-		"hda": pb.PbDeviceType_SCHD,
-		"hds": pb.PbDeviceType_SCHD,
-		"HDI": pb.PbDeviceType_SCHD,
-		"nhd": pb.PbDeviceType_SCHD,
-		"mos": pb.PbDeviceType_SCMO,
+		"hdf":  pb.PbDeviceType_SAHD,
+		"tap":  pb.PbDeviceType_SCTP,
+		"iso":  pb.PbDeviceType_SCCD,
+		"hdr":  pb.PbDeviceType_SCRM,
+		"hd1":  pb.PbDeviceType_SCHD,
+		"hda":  pb.PbDeviceType_SCHD,
+		"hds":  pb.PbDeviceType_SCHD,
+		"HDI":  pb.PbDeviceType_SCHD,
+		"nhd":  pb.PbDeviceType_SCHD,
+		"mos":  pb.PbDeviceType_SCMO,
 	}
 
 	got := creatableImageSuffixes(mapping)
@@ -61,7 +63,7 @@ func TestCreatableImageSuffixesUsesDaemonMapping(t *testing.T) {
 	for _, imageType := range got {
 		gotSuffixes = append(gotSuffixes, imageType.Suffix)
 	}
-	want := []string{"hds", "hda", "hd1", "hdr", "mos", "tap"}
+	want := []string{"hdf", "hds", "hda", "hd1", "hdr", "mos", "tap"}
 	if !reflect.DeepEqual(gotSuffixes, want) {
 		t.Fatalf("creatableImageSuffixes() = %v, want %v", gotSuffixes, want)
 	}
@@ -496,11 +498,13 @@ func TestImageAndPropertiesOperationsStaySynchronized(t *testing.T) {
 	}
 }
 
-func TestDrivePresetTemplateDataIncludesCDROMAndTape(t *testing.T) {
+func TestDrivePresetTemplateDataIncludesSASIAndOtherDriveTypes(t *testing.T) {
 	tap := "tap"
 	iso := "iso"
+	sasi := "img"
 	size := int64(52445184)
 	data := drivePresetTemplateData([]driveprops.DriveProperty{
+		{DeviceType: "SAHD", Name: "SASI", FileType: &sasi, Size: &size},
 		{DeviceType: "SCTP", Name: "Tape", FileType: &tap, Size: &size},
 		{DeviceType: "SCCD", Name: "CD", FileType: &iso},
 	})
@@ -509,6 +513,9 @@ func TestDrivePresetTemplateDataIncludesCDROMAndTape(t *testing.T) {
 	}
 	if len(data["TapeDrives"]) != 1 {
 		t.Fatalf("TapeDrives count = %d, want 1", len(data["TapeDrives"]))
+	}
+	if len(data["SASIDrives"]) != 1 {
+		t.Fatalf("SASIDrives count = %d, want 1", len(data["SASIDrives"]))
 	}
 	if got := data["TapeDrives"][0]["FileType"]; got != "tap" {
 		t.Fatalf("tape file type = %v, want tap", got)

--- a/go/piscsi-web/internal/server/image_properties.go
+++ b/go/piscsi-web/internal/server/image_properties.go
@@ -27,6 +27,7 @@ type propertyMetadata struct {
 func drivePresetTemplateData(drives []driveprops.DriveProperty) map[string][]map[string]interface{} {
 	data := map[string][]map[string]interface{}{
 		"HardDrives":      {},
+		"SASIDrives":      {},
 		"CDROMDrives":     {},
 		"RemovableDrives": {},
 		"TapeDrives":      {},
@@ -47,6 +48,8 @@ func drivePresetTemplateData(drives []driveprops.DriveProperty) map[string][]map
 
 		var category string
 		switch drive.DeviceType {
+		case "SAHD":
+			category = "SASIDrives"
 		case "SCHD":
 			category = "HardDrives"
 		case "SCCD":

--- a/go/piscsi-web/internal/server/testutil/constants.go
+++ b/go/piscsi-web/internal/server/testutil/constants.go
@@ -66,6 +66,7 @@ const (
 // Device types
 const (
 	DeviceTypeHDD       = "SCHD" // Hard disk
+	DeviceTypeSASI      = "SAHD" // SASI hard disk
 	DeviceTypeCDROM     = "SCCD" // CD-ROM
 	DeviceTypeRemovable = "SCRM" // Removable media
 	DeviceTypeMO        = "SCMO" // Magneto-optical

--- a/go/piscsi-web/web/static/themes/modern/style.css
+++ b/go/piscsi-web/web/static/themes/modern/style.css
@@ -521,6 +521,7 @@ table#attached-devices tr.reserved td {
     background-image: url("icons/device-network.svg");
   }
 
+  table#attached-devices tr.device-sahd td.name,
   table#attached-devices tr.device-schd td.name {
     background-image: url("icons/device-hard-drive.svg");
   }

--- a/go/piscsi-web/web/templates/index.html
+++ b/go/piscsi-web/web/templates/index.html
@@ -452,7 +452,7 @@ Please create the PiSCSI configuration dir to use configurations: {{.ConfigDir}}
                 {{end}}
                 </select>
                 <label for="{{.Key}}_unit">LUN</label>
-                <input class="lun" name="unit" id="{{.Key}}_unit" type="number" value="0" min="0" max="31" step="1" size="3">
+                <input class="lun" name="unit" id="{{.Key}}_unit" type="number" value="0" min="0" max="{{.MaxLUN}}" step="1" size="3">
                 <input type="submit" value="Attach" title="Attach">
             </form>
         </td>

--- a/go/piscsi/commands.go
+++ b/go/piscsi/commands.go
@@ -9,6 +9,17 @@ import (
 	pb "github.com/piscsi/piscsi/go/proto"
 )
 
+const defaultMaxLUN int32 = 31
+
+// MaxLUN returns the highest addressable LUN for a device type. SASI targets
+// have a two-LUN limit, while SCSI targets support the daemon-wide maximum.
+func MaxLUN(deviceType pb.PbDeviceType) int32 {
+	if deviceType == pb.PbDeviceType_SAHD {
+		return 1
+	}
+	return defaultMaxLUN
+}
+
 // CommandBuilder provides methods to build protobuf commands for the piscsi daemon
 type CommandBuilder struct {
 	token  string

--- a/go/piscsi/commands_test.go
+++ b/go/piscsi/commands_test.go
@@ -67,3 +67,12 @@ func TestShutDown(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxLUN(t *testing.T) {
+	if got := MaxLUN(pb.PbDeviceType_SAHD); got != 1 {
+		t.Errorf("MaxLUN(SAHD) = %d, want 1", got)
+	}
+	if got := MaxLUN(pb.PbDeviceType_SCHD); got != 31 {
+		t.Errorf("MaxLUN(SCHD) = %d, want 31", got)
+	}
+}

--- a/go/piscsi/configuration/configuration.go
+++ b/go/piscsi/configuration/configuration.go
@@ -154,18 +154,19 @@ func Parse(data []byte) (*Configuration, []*pb.PbDeviceDefinition, []int32, erro
 		if saved.ID < 0 || saved.ID > 7 {
 			return nil, nil, nil, fmt.Errorf("device %d has invalid SCSI ID %d", index, saved.ID)
 		}
-		if saved.Unit < 0 || saved.Unit > 31 {
-			return nil, nil, nil, fmt.Errorf("device %d has invalid LUN %d", index, saved.Unit)
+		typeValue, exists := pb.PbDeviceType_value[strings.ToUpper(saved.DeviceType)]
+		if !exists || pb.PbDeviceType(typeValue) == pb.PbDeviceType_UNDEFINED {
+			return nil, nil, nil, fmt.Errorf("device %d has invalid type %q", index, saved.DeviceType)
+		}
+		deviceType := pb.PbDeviceType(typeValue)
+		if saved.Unit < 0 || saved.Unit > piscsi.MaxLUN(deviceType) {
+			return nil, nil, nil, fmt.Errorf("device %d has invalid LUN %d for %s (must be 0-%d)", index, saved.Unit, deviceType, piscsi.MaxLUN(deviceType))
 		}
 		location := [2]int32{saved.ID, saved.Unit}
 		if _, exists := occupied[location]; exists {
 			return nil, nil, nil, fmt.Errorf("duplicate device at SCSI ID %d LUN %d", saved.ID, saved.Unit)
 		}
 		occupied[location], usedIDs[saved.ID] = struct{}{}, struct{}{}
-		typeValue, exists := pb.PbDeviceType_value[strings.ToUpper(saved.DeviceType)]
-		if !exists || pb.PbDeviceType(typeValue) == pb.PbDeviceType_UNDEFINED {
-			return nil, nil, nil, fmt.Errorf("device %d has invalid type %q", index, saved.DeviceType)
-		}
 		params := make(map[string]string, len(saved.Params)+1)
 		for key, value := range saved.Params {
 			params[key] = value
@@ -173,7 +174,7 @@ func Parse(data []byte) (*Configuration, []*pb.PbDeviceDefinition, []int32, erro
 		if saved.Image != nil && *saved.Image != "" {
 			params["file"] = *saved.Image
 		}
-		definition := &pb.PbDeviceDefinition{Id: saved.ID, Unit: saved.Unit, Type: pb.PbDeviceType(typeValue), Params: params, Protected: saved.Protected}
+		definition := &pb.PbDeviceDefinition{Id: saved.ID, Unit: saved.Unit, Type: deviceType, Params: params, Protected: saved.Protected}
 		if saved.Vendor != nil {
 			definition.Vendor = *saved.Vendor
 		}

--- a/go/piscsi/configuration/configuration_test.go
+++ b/go/piscsi/configuration/configuration_test.go
@@ -55,3 +55,19 @@ func TestLoaderAppliesValidatedConfigurationInOrder(t *testing.T) {
 		t.Fatalf("image path = %q, want %q", got, want)
 	}
 }
+
+func TestParseValidatesSASILUNRange(t *testing.T) {
+	valid := []byte(`{"devices":[{"id":2,"unit":1,"device_type":"SAHD","image":"disk.img","params":{}}],"reserved_ids":[]}`)
+	_, devices, _, err := Parse(valid)
+	if err != nil {
+		t.Fatalf("Parse(valid SASI configuration): %v", err)
+	}
+	if len(devices) != 1 || devices[0].GetType() != pb.PbDeviceType_SAHD {
+		t.Fatalf("parsed devices = %#v, want one SAHD", devices)
+	}
+
+	invalid := []byte(`{"devices":[{"id":2,"unit":2,"device_type":"SAHD","params":{}}],"reserved_ids":[]}`)
+	if _, _, _, err := Parse(invalid); err == nil {
+		t.Fatal("Parse accepted SASI LUN 2")
+	}
+}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,7 +8,7 @@ option(
 option(
     'target',
     type : 'array',
-    choices : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'test'],
-    value : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'test'],
+    choices : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'sasidump', 'test'],
+    value : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'sasidump', 'test'],
     description : 'Targets to build'
 )

--- a/proto/piscsi_interface.proto
+++ b/proto/piscsi_interface.proto
@@ -23,8 +23,8 @@ package piscsi_interface;
 // The available device types
 enum PbDeviceType {
     UNDEFINED = 0;
-    // Non-removable SASI drive, not supported anymore but must not be removed because of backwards compatibility
-    SAHD = 1 [deprecated = true];
+    // Non-removable SASI drive
+    SAHD = 1;
     // Non-removable SCSI drive
     SCHD = 2;
     // Removable SCSI drive


### PR DESCRIPTION
Introduce a SASI controller and SAHD disk implementation alongside the existing SCSI path. Select the appropriate controller when attaching a device, prevent SASI and SCSI devices from sharing a target ID, and implement SASI-specific selection, message, status, timing, and LUN handling. The implementation encodes a number of X68000 quirks ported from the old RaSCSI code as well as inspired by BlueSCSI v2. 

Restore SAHD in the protocol and expose it consistently through the device factory, command-line client, configuration validation, web interface, drive profiles, and manual. Enforce the two-LUN limit for SASI targets wherever device definitions are created or parsed.

Bring back handling of the hdf image format and map it to the SAHD device type. The hdf file ending is the established one for SASI raw disk images used in the X68000 emulation community, however it is a raw data format without any special header. 

Restore the sasidump tool for dumping physical SASI hard disks to local file through piscsi GPIO. It has been slightly refactored to align with the current C++ coding standards. 

Add focused C++ and Go coverage for SASI devices, controller selection, LUN validation, and web-facing behavior.

the Sleep() function now takes a parameter: common bus wait times are now defined in a central place, and passed to the Sleep() function