### PR TITLE
fix NEC image sector size handling

### DIFF
--- a/cpp/devices/scsihd_nec.cpp
+++ b/cpp/devices/scsihd_nec.cpp
@@ -41,7 +41,7 @@ void SCSIHD_NEC::Open()
 	// Determine parameters by extension
 	const auto [image_size, sector_size] = SetParameters(root_sector, static_cast<int>(size));
 
-	SetSectorSizeShiftCount(static_cast<uint32_t>(size));
+	SetSectorSizeShiftCount(CalculateShiftCount(sector_size));
 
 	SetBlockCount(image_size >> GetSectorSizeShiftCount());
 

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -382,6 +382,7 @@ class MockSCSIHD_NEC : public SCSIHD_NEC //NOSONAR Ignore inheritance hierarchy 
 	FRIEND_TEST(ScsiHdNecTest, TestAddErrorPage);
 	FRIEND_TEST(ScsiHdNecTest, TestAddFormatPage);
 	FRIEND_TEST(ScsiHdNecTest, TestAddDrivePage);
+	FRIEND_TEST(ScsiHdNecTest, OpenHdnSetsPc98Geometry);
 	FRIEND_TEST(PiscsiExecutorTest, ProcessDeviceCmd);
 
 	using SCSIHD_NEC::SCSIHD_NEC;

--- a/cpp/test/scsihd_nec_test.cpp
+++ b/cpp/test/scsihd_nec_test.cpp
@@ -102,6 +102,30 @@ TEST(ScsiHdNecTest, TestAddDrivePage)
 	EXPECT_EQ(1, pages.size()) << "Unexpected number of mode pages";
 }
 
+TEST(ScsiHdNecTest, OpenHdnSetsPc98Geometry)
+{
+	MockSCSIHD_NEC hd(0);
+
+	// One PC-9801-55 cylinder: 8 heads, 25 sectors per track, 512 bytes per sector.
+	path tmp = CreateTempFile(8 * 25 * 512);
+	const auto hdn = path((string)tmp + ".hdn");
+	rename(tmp, hdn);
+	hd.SetFilename(string(hdn));
+	hd.Open();
+
+	EXPECT_EQ(9, hd.GetSectorSizeShiftCount());
+	EXPECT_EQ(200, hd.GetBlockCount());
+
+	map<int, vector<byte>> pages;
+	hd.SetUpModePages(pages, 0x03, false);
+	const vector<byte>& format_page = pages[3];
+	EXPECT_EQ(8, GetInt16(format_page, 2));
+	EXPECT_EQ(25, GetInt16(format_page, 10));
+	EXPECT_EQ(512, GetInt16(format_page, 12));
+
+	remove(hdn);
+}
+
 TEST(ScsiHdNecTest, SetParameters)
 {
 	MockSCSIHD_NEC hd_hdn(0);


### PR DESCRIPTION
Use the validated image sector size to derive SCSIHD_NEC's sector shift count, instead of the complete image size. This restores correct capacity and MODE SENSE geometry for PC-98 HDN images.