### PR TITLE
restore X68000 Host Bridge support

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -17,6 +17,7 @@
 #include "hal/gpiobus.h"
 #include "hal/systimer.h"
 #include "controllers/controller_manager.h"
+#include "devices/scsi_host_bridge.h"
 #include "devices/scsi_daynaport.h"
 #include "devices/mode_page_device.h"
 #include "devices/disk.h"
@@ -802,6 +803,15 @@ bool ScsiController::XferOutBlockOriented(bool cont)
 		case scsi_command::eCmdWrite10:
 		case scsi_command::eCmdWrite16:
 		{
+			if (auto bridge = dynamic_pointer_cast<SCSIBR>(device); bridge) {
+				if (!bridge->ReadWrite(GetCmd(), GetBuffer())) {
+					return false;
+				}
+
+				ResetOffset();
+				break;
+			}
+
 			// TODO Get rid of this special case for SCDP
 			if (auto daynaport = dynamic_pointer_cast<SCSIDaynaPort>(device); daynaport) {
 				if (!daynaport->Write(GetCmd(), GetBuffer())) {

--- a/cpp/devices/cfilesystem.cpp
+++ b/cpp/devices/cfilesystem.cpp
@@ -1,0 +1,3939 @@
+//---------------------------------------------------------------------------
+//
+//	SCSI Target Emulator PiSCSI
+//	for Raspberry Pi
+//
+//	Powered by XM6 TypeG Technology.
+//	Copyright (C) 2016-2020 GIMONS
+//
+//	Imported sava's bugfix patch(in RASDRV DOS edition).
+//
+//  [ Host File System for the X68000 ]
+//
+//  Note: This functionality is specific to the X68000 operating system.
+//        It is highly unlikely that this will work for other platforms.
+//
+//---------------------------------------------------------------------------
+
+#include "cfilesystem.h"
+#include <sys/stat.h>
+#include <dirent.h>
+#include <iconv.h>
+#include <utime.h>
+
+#define ARRAY_SIZE(x) (sizeof(x)/(sizeof(x[0])))
+
+//---------------------------------------------------------------------------
+//
+//  Kanji code conversion
+//
+//---------------------------------------------------------------------------
+static const int IC_BUF_SIZE = 1024;
+static char convert_buf[IC_BUF_SIZE];
+#define CONVERT(src, dest, inbuf, outbuf, outsize) \
+	convert(src, dest, (char *)inbuf, outbuf, outsize)
+static void convert(char const *src, char const *dest,
+	char *inbuf, char *outbuf, size_t outsize)
+{
+	*outbuf = '\0';
+	size_t in = strlen(inbuf);
+	size_t out = outsize - 1;
+
+	iconv_t cd = iconv_open(dest, src);
+	if (cd == (iconv_t)-1) {
+		return;
+	}
+
+	if (const size_t ret = iconv(cd, &inbuf, &in, &outbuf, &out); ret == (size_t)-1) {
+		return;
+	}
+
+	iconv_close(cd);
+	*outbuf = '\0';
+}
+
+//---------------------------------------------------------------------------
+//
+// SJIS->UTF8 conversion
+//
+//---------------------------------------------------------------------------
+static char* SJIS2UTF8(const char *sjis, char *utf8, size_t bufsize)
+{
+	CONVERT("SJIS", "UTF-8", sjis, utf8, bufsize);
+	return convert_buf;
+}
+
+//---------------------------------------------------------------------------
+//
+// UTF8->SJIS conversion
+//
+//---------------------------------------------------------------------------
+static char* UTF82SJIS(const char *utf8, char *sjis, size_t bufsize)
+{
+	CONVERT("UTF-8", "SJIS", utf8, sjis, bufsize);
+	return convert_buf;
+}
+
+//---------------------------------------------------------------------------
+//
+// SJIS->UTF8 conversion (simplified versoin)
+//
+//---------------------------------------------------------------------------
+static char* S2U(const char *sjis)
+{
+	SJIS2UTF8(sjis, convert_buf, IC_BUF_SIZE);
+	return convert_buf;
+}
+
+//---------------------------------------------------------------------------
+//
+// UTF8->SJIS conversion (simplified version)
+//
+//---------------------------------------------------------------------------
+static char* U2S(const char *utf8)
+{
+	UTF82SJIS(utf8, convert_buf, IC_BUF_SIZE);
+	return convert_buf;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get path name
+///
+/// From the structure used in Human68k namests, get the Human68k path name.
+/// A 66 byte buffer is required for writing.
+//
+//---------------------------------------------------------------------------
+void Human68k::namests_t::GetCopyPath(uint8_t* szPath) const
+{
+	assert(szPath);
+
+	uint8_t* p = szPath;
+	for (uint8_t c : path) {
+		if (c == '\0')
+			break;
+		if (c == 0x09) {
+			c = '/';
+		}
+		*p++ = c;
+	}
+
+	*p = '\0';
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get file name
+///
+/// From the structure used in Human68k namests, get the Human68k file name.
+/// A 23 byte buffer is required for writing.
+//
+//---------------------------------------------------------------------------
+void Human68k::namests_t::GetCopyFilename(uint8_t* szFilename) const
+{
+	assert(szFilename);
+
+	size_t i;
+	uint8_t* p = szFilename;
+
+	// Transfer the base file name
+	for (i = 0; i < 8; i++) {
+		uint8_t c = name[i];
+		if (c == ' ') {
+			// Check that the file name continues after a space is detected
+			/// TODO: Should change this function to be compatible with 8+3 chars and TwentyOne
+			// Continue if add[0] is a valid character
+			if (add[0] != '\0')
+				goto next_name;
+			// Continue if a non-space character exists after name[i]
+			for (size_t j = i + 1; j < 8; j++) {
+				if (name[j] != ' ')
+					goto next_name;
+			}
+			// Exit if the file name ends
+			break;
+		}
+	next_name:
+		*p++ = c;
+	}
+	// At this point, the number of read characters becomes i >= 8
+
+	// If the body of the file name exceeds 8 characters, add the extraneous part
+	if (i >= 8) {
+		// Transfer the extraneous part
+		for (i = 0; i < 10; i++) {
+			const uint8_t c = add[i];
+			if (c == '\0')
+				break;
+			*p++ = c;
+		}
+		// At this point, the number of read characters becomes i >= 10
+	}
+
+	// Transfer the file extension if it exists
+	if (ext[0] != ' ' || ext[1] != ' ' || ext[2] != ' ') {
+		*p++ = '.';
+		for (i = 0; i < 3; i++) {
+			const uint8_t c = ext[i];
+			if (c == ' ') {
+				// Check that the file extension continues after a space is detected
+				/// TODO: Should change this function to be compatible with 8+3 chars and TwentyOne
+				// Continue if a non-space character exists after ext[i]
+				for (size_t j = i + 1; j < 3; j++) {
+					if (ext[j] != ' ')
+						goto next_ext;
+				}
+				// If the extension ends, the transfer ends
+				break;
+			}
+		next_ext:
+			*p++ = c;
+		}
+		//  When all the characters are read, here i >= 3
+	}
+
+	//  Add sentinel
+	*p = '\0';
+}
+
+//===========================================================================
+//
+//	Host side drive
+//
+//===========================================================================
+
+CHostDrv::~CHostDrv()
+{
+	CHostPath* p;
+	while ((p = (CHostPath*)m_cRing.Next()) != &m_cRing) {
+		delete p;
+		assert(m_nRing);
+		m_nRing--;
+	}
+
+	//  Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+	assert(m_nRing == 0);
+}
+
+//---------------------------------------------------------------------------
+//
+// Initialization (device boot and load)
+//
+//---------------------------------------------------------------------------
+void CHostDrv::Init(const TCHAR* szBase, uint32_t nFlag)
+{
+	assert(szBase);
+	assert(strlen(szBase) < FILEPATH_MAX);
+	assert(!m_bWriteProtect);
+	assert(!m_bEnable);
+	assert(m_capCache.sectors == 0);
+	assert(!m_bVolumeCache);
+	assert(m_szVolumeCache[0] == '\0');
+
+	// Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+	assert(m_nRing == 0);
+
+	m_capCache.sectors = 0;
+
+	// Receive parameters
+	if (nFlag & FSFLAG_WRITE_PROTECT)
+		m_bWriteProtect = true;
+	strcpy(m_szBase, szBase);
+
+	// Remove the last path delimiter in the base path
+	// @warning needs to be modified when using Unicode
+	TCHAR* pClear = nullptr;
+	TCHAR* p = m_szBase;
+	for (;;) {
+		const TCHAR c = *p;
+		if (c == '\0')
+			break;
+		if (c == '/' || c == '\\') {
+			pClear = p;
+		} else {
+			pClear = nullptr;
+		}
+		if ((c <= (TCHAR)0x9F) || (TCHAR)0xE0 <= c) {	// To be precise: 0x81~0x9F 0xE0~0xEF
+			p++;
+			if (*p == '\0')
+				break;
+		}
+		p++;
+	}
+	if (pClear)
+		*pClear = '\0';
+
+	// Status update
+	m_bEnable = true;
+}
+
+//---------------------------------------------------------------------------
+//
+// Media check
+//
+//---------------------------------------------------------------------------
+bool CHostDrv::isMediaOffline() const
+{
+	// Offline status check
+	return !m_bEnable;
+}
+
+//---------------------------------------------------------------------------
+//
+// Get media bytes
+//
+//---------------------------------------------------------------------------
+uint8_t CHostDrv::GetMediaByte() const
+{
+	return Human68k::MEDIA_REMOTE;
+}
+
+//---------------------------------------------------------------------------
+//
+// Get drive status
+//
+//---------------------------------------------------------------------------
+uint32_t CHostDrv::GetStatus() const
+{
+	return 0x40 | (m_bEnable ? (m_bWriteProtect ? 0x08 : 0) | 0x02 : 0);
+}
+
+//---------------------------------------------------------------------------
+//
+// Media status settings
+//
+//---------------------------------------------------------------------------
+void CHostDrv::SetEnable(bool bEnable)
+{
+	m_bEnable = bEnable;
+
+	if (!bEnable) {
+		// Clear cache
+		m_capCache.sectors = 0;
+		m_bVolumeCache = false;
+		m_szVolumeCache[0] = '\0';
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+// Media change check
+//
+//---------------------------------------------------------------------------
+bool CHostDrv::CheckMedia()
+{
+	// Status update
+	Update();
+	if (!m_bEnable)
+		CleanCache();
+
+	return m_bEnable;
+}
+
+//---------------------------------------------------------------------------
+//
+// Media status update
+//
+//---------------------------------------------------------------------------
+void CHostDrv::Update()
+{
+	// Considered as media insertion
+	// Media status reflected
+	SetEnable(true);
+}
+
+//---------------------------------------------------------------------------
+//
+// Eject
+//
+//---------------------------------------------------------------------------
+void CHostDrv::Eject()
+{
+	// Media discharge
+	CleanCache();
+	SetEnable(false);
+
+	// Status update
+	Update();
+}
+
+//---------------------------------------------------------------------------
+//
+// Get volume label
+//
+//---------------------------------------------------------------------------
+void CHostDrv::GetVolume(TCHAR* szLabel)
+{
+	assert(szLabel);
+	assert(m_bEnable);
+
+	// Get volume label
+	strcpy(m_szVolumeCache, "RASDRV ");
+	if (m_szBase[0]) {
+		strcat(m_szVolumeCache, m_szBase);
+	} else {
+		strcat(m_szVolumeCache, "/");
+	}
+
+	// Cache update
+	m_bVolumeCache = true;
+
+	// Transfer content
+	strcpy(szLabel, m_szVolumeCache);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get volume label from cache
+///
+/// Transfer the cached volume label information.
+/// Return true if the cache contents are valid.
+//
+//---------------------------------------------------------------------------
+bool CHostDrv::GetVolumeCache(TCHAR* szLabel) const
+{
+	assert(szLabel);
+
+	// Transfer contents
+	strcpy(szLabel, m_szVolumeCache);
+
+	return m_bVolumeCache;
+}
+
+uint32_t CHostDrv::GetCapacity(Human68k::capacity_t* pCapacity)
+{
+	assert(pCapacity);
+	assert(m_bEnable);
+
+	const uint32_t nFree = 0x7FFF8000;
+	uint32_t freearea;
+	uint32_t clusters;
+	uint32_t sectors;
+
+	freearea = 0xFFFF;
+	clusters = 0xFFFF;
+	sectors = 64;
+
+	// Estimated parameter range
+	assert(freearea <= 0xFFFF);
+	assert(clusters <= 0xFFFF);
+	assert(sectors <= 64);
+
+	// Update cache
+	m_capCache.freearea = (uint16_t)freearea;
+	m_capCache.clusters = (uint16_t)clusters;
+	m_capCache.sectors = (uint16_t)sectors;
+	m_capCache.bytes = 512;
+
+	// Transfer contents
+	memcpy(pCapacity, &m_capCache, sizeof(m_capCache));
+
+	return nFree;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get capacity from the cache
+///
+/// Transfer the capacity data stored in cache.
+/// Return true if the contents of the cache are valid.
+//
+//---------------------------------------------------------------------------
+bool CHostDrv::GetCapacityCache(Human68k::capacity_t* pCapacity) const
+{
+	assert(pCapacity);
+
+	// Transfer contents
+	memcpy(pCapacity, &m_capCache, sizeof(m_capCache));
+
+	return m_capCache.sectors != 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update all cache
+//
+//---------------------------------------------------------------------------
+void CHostDrv::CleanCache() const
+{
+	for (auto p = (CHostPath*)m_cRing.Next(); p != &m_cRing;) {
+		p->Release();
+		p = (CHostPath*)p->Next();
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update the cache for the specified path
+//
+//---------------------------------------------------------------------------
+void CHostDrv::CleanCache(const uint8_t* szHumanPath)
+{
+	assert(szHumanPath);
+
+	CHostPath* p = FindCache(szHumanPath);
+	if (p) {
+		p->Restore();
+		p->Release();
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update the cache below and including the specified path
+//
+//---------------------------------------------------------------------------
+void CHostDrv::CleanCacheChild(const uint8_t* szHumanPath) const
+{
+	assert(szHumanPath);
+
+	auto p = (CHostPath*)m_cRing.Next();
+	while (p != &m_cRing) {
+		if (p->isSameChild(szHumanPath))
+			p->Release();
+		p = (CHostPath*)p->Next();
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Delete the cache for the specified path
+//
+//---------------------------------------------------------------------------
+void CHostDrv::DeleteCache(const uint8_t* szHumanPath)
+{
+	auto p = FindCache(szHumanPath);
+	if (p) {
+		delete p;
+		assert(m_nRing);
+		m_nRing--;
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Check if the specified path is cached
+///
+/// Check if whether it is a perfect match with the cache buffer, and return the name if found.
+/// File names are excempted.
+/// Make sure to lock from the top.
+//
+//---------------------------------------------------------------------------
+CHostPath* CHostDrv::FindCache(const uint8_t* szHuman)
+{
+	assert(szHuman);
+
+	// Find something that matches perfectly with either of the stored file names
+	for (auto p = (CHostPath*)m_cRing.Next(); p != &m_cRing;) {
+		if (p->isSameHuman(szHuman))
+			return p;
+		p = (CHostPath*)p->Next();
+	}
+
+	return nullptr;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get the host side name from cached data.
+///
+/// Confirm if the path is cached. If not, throw an error.
+/// Carry out an update check on found cache. If an update is needed, throw an error.
+/// Make sure to lock from the top.
+//
+//---------------------------------------------------------------------------
+CHostPath* CHostDrv::CopyCache(CHostFiles* pFiles)
+{
+	assert(pFiles);
+	assert(strlen((const char*)pFiles->GetHumanPath()) < HUMAN68K_PATH_MAX);
+
+	// Find in cache
+	CHostPath* pPath = FindCache(pFiles->GetHumanPath());
+	if (pPath == nullptr) {
+		return nullptr;	// Error: No cache
+	}
+
+	// Move to the beginning of the ring
+	pPath->Insert(&m_cRing);
+
+	// Cache update check
+	if (pPath->isRefresh()) {
+		return nullptr;	// Error: Cache update is required
+	}
+
+	// Store the host side path
+	pFiles->SetResult(pPath->GetHost());
+
+	return pPath;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get all the data required for a host side name structure
+///
+/// File names can be abbreviated. (Normally not selected)
+/// Make sure to lock from the top.
+/// Be careful not to append the path separator char to the end of the base path.
+/// Initiate VM threads when there is a chance of multiple file accesses.
+///
+/// How to use:
+/// When CopyCache() throws an error execute MakeCache(). It ensures you get a correct host side path.
+///
+/// Split all file names and path names.
+/// Confirm that it's cached from the top level directory down.
+/// If it's cached, do a destruction check. If it was destroyed, treat it as uncached.
+/// If it isn't cached, build cache.
+/// Exit after processing all directory and file names in order.
+/// Make it nullptr is an error is thrown.
+//
+//---------------------------------------------------------------------------
+CHostPath* CHostDrv::MakeCache(CHostFiles* pFiles)
+{
+	assert(pFiles);
+	assert(strlen((const char*)pFiles->GetHumanPath()) < HUMAN68K_PATH_MAX);
+
+	assert(m_szBase);
+	assert(strlen(m_szBase) < FILEPATH_MAX);
+
+	uint8_t szHumanPath[HUMAN68K_PATH_MAX];	// Path names are entered in order from the route
+	szHumanPath[0] = '\0';
+	size_t nHumanPath = 0;
+
+	TCHAR szHostPath[FILEPATH_MAX];
+	strcpy(szHostPath, m_szBase);
+	size_t nHostPath = strlen(szHostPath);
+
+	CHostPath* pPath;
+	const uint8_t* p = pFiles->GetHumanPath();
+	for (;;) {
+		// Add path separators
+		if (nHumanPath + 1 >= HUMAN68K_PATH_MAX)
+			return nullptr;				// Error: The Human68k path is too long
+		szHumanPath[nHumanPath++] = '/';
+		szHumanPath[nHumanPath] = '\0';
+		if (nHostPath + 1 >= FILEPATH_MAX)
+			return nullptr;				// Error: The host side path is too long
+		szHostPath[nHostPath++] = '/';
+		szHostPath[nHostPath] = '\0';
+
+		// Insert one file
+		uint8_t szHumanFilename[24];		// File name part
+		p = SeparateCopyFilename(p, szHumanFilename);
+		if (p == nullptr)
+			return nullptr;				// Error: Failed to read file name
+		size_t n = strlen((const char*)szHumanFilename);
+		if (nHumanPath + n >= HUMAN68K_PATH_MAX)
+			return nullptr;				// Error: The Human68k path is too long
+
+		// Is the relevant path cached?
+		pPath = FindCache(szHumanPath);
+		if (pPath == nullptr) {
+			// Check for max number of cache
+			if (m_nRing >= XM6_HOST_DIRENTRY_CACHE_MAX) {
+				// Destroy the oldest cache and reuse it
+				pPath = (CHostPath*)m_cRing.Prev();
+				pPath->Clean();			// Release all files. Release update check handlers.
+			} else {
+				// Register new
+				pPath = new CHostPath;
+				assert(pPath);
+				m_nRing++;
+			}
+			pPath->SetHuman(szHumanPath);
+			pPath->SetHost(szHostPath);
+
+			// Update status
+			pPath->Refresh();
+		}
+
+		// Cache update check
+		if (pPath->isRefresh()) {
+			Update();
+
+			// Update status
+			pPath->Refresh();
+		}
+
+		// Into the beginning of the ring
+		pPath->Insert(&m_cRing);
+
+		// Exit if there is not file name
+		if (n == 0)
+			break;
+
+		// Find the next path
+		// Confirm if directory from the middle of the path
+		const CHostFilename* pFilename;
+		if (*p != '\0')
+			pFilename = pPath->FindFilename(szHumanFilename, Human68k::AT_DIRECTORY);
+		else
+			pFilename = pPath->FindFilename(szHumanFilename);
+		if (pFilename == nullptr)
+			return nullptr;				// Error: Could not find path or file names in the middle
+
+		// Link path name
+		strcpy((char*)szHumanPath + nHumanPath, (const char*)szHumanFilename);
+		nHumanPath += n;
+
+		n = strlen(pFilename->GetHost());
+		if (nHostPath + n >= FILEPATH_MAX)
+			return nullptr;				// Error: Host side path is too long
+		strcpy(szHostPath + nHostPath, pFilename->GetHost());
+		nHostPath += n;
+
+		// PLEASE CONTINUE
+		if (*p == '\0')
+			break;
+	}
+
+	// Store the host side path name
+	pFiles->SetResult(szHostPath);
+
+	return pPath;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find host side name (path name + file name (can be abbeviated) + attribute)
+///
+/// Set all Human68k parameters once more.
+//
+//---------------------------------------------------------------------------
+bool CHostDrv::Find(CHostFiles* pFiles)
+{
+	assert(pFiles);
+
+	// Get path name and build cache
+	const CHostPath* pPath = CopyCache(pFiles);
+	if (pPath == nullptr) {
+		pPath = MakeCache(pFiles);
+		if (pPath == nullptr) {
+			CleanCache();
+			return false;	// Error: Failed to build cache
+		}
+	}
+
+	// Store host side path
+	pFiles->SetResult(pPath->GetHost());
+
+	// Exit if only path name
+	if (pFiles->isPathOnly()) {
+		return true;		// Normal exit: only path name
+	}
+
+	// Find file name
+	const CHostFilename* pFilename = pFiles->Find(pPath);
+	if (pFilename == nullptr) {
+		return false;		// Error: Could not get file name
+	}
+
+	// Store the Human68k side search results
+	pFiles->SetEntry(pFilename);
+
+	// Store the host side full path name
+	pFiles->AddResult(pFilename->GetHost());
+
+	return true;
+}
+
+//===========================================================================
+//
+//	Directory entry: File name
+//
+//===========================================================================
+
+//---------------------------------------------------------------------------
+//
+/// Set host side name
+//
+//---------------------------------------------------------------------------
+void CHostFilename::SetHost(const TCHAR* szHost)
+{
+	assert(szHost);
+	assert(strlen(szHost) < FILEPATH_MAX);
+
+	strcpy(m_szHost, szHost);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Copy the Human68k file name elements
+//
+//---------------------------------------------------------------------------
+uint8_t* CHostFilename::CopyName(uint8_t* pWrite, const uint8_t* pFirst, const uint8_t* pLast)	// static
+{
+	assert(pWrite);
+	assert(pFirst);
+	assert(pLast);
+
+	for (const uint8_t* p = pFirst; p < pLast; p++) {
+		*pWrite++ = *p;
+	}
+
+	return pWrite;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Convert the Human68k side name
+///
+/// Once more, execute SetHost().
+/// Carry out name conversion to the 18+3 standard.
+/// Automatically delete spaces in the beginning and end of the names, since Human68k can't handle them.
+/// The directory entry name segment is created at the time of conversion using knowledge of the location of the file name extension.
+/// Afterwards, a file name validity check is performed. (Ex. file names consisting of 8 spaces only.)
+/// No file name duplication check is performed so be careful. Such validation is carried out in classes higher up.
+/// Adhers to the naming standards of: TwentyOne version 1.36c modified +14 patchlevel9 or later
+//
+//---------------------------------------------------------------------------
+void CHostFilename::ConvertHuman(int nCount)
+{
+	// Don't do conversion for special directory names
+	if (m_szHost[0] == '.' &&
+		(m_szHost[1] == '\0' || (m_szHost[1] == '.' && m_szHost[2] == '\0'))) {
+		strcpy((char*)m_szHuman, m_szHost);
+
+		m_bCorrect = true;
+		m_pszHumanLast = m_szHuman + strlen((const char*)m_szHuman);
+		m_pszHumanExt = m_pszHumanLast;
+		return;
+	}
+
+	size_t nMax = 18;	// Number of bytes for the base segment (base name and extension)
+	uint32_t nOption = CFileSys::GetFileOption();
+	if (nOption & WINDRV_OPT_CONVERT_LENGTH)
+		nMax = 8;
+
+	// Preparations to adjust the base name segment
+	uint8_t szNumber[8];
+	uint8_t* pNumber = nullptr;
+	if (nCount >= 0) {
+		pNumber = &szNumber[8];
+		for (uint32_t i = 0; i < 5; i++) {	// Max 5+1 digits (always leave the first 2 bytes of the base name)
+			int n = nCount % 36;
+			nMax--;
+			pNumber--;
+			*pNumber = (uint8_t)(n + (n < 10 ? '0' : 'A' - 10));
+			nCount /= 36;
+			if (nCount == 0)
+				break;
+		}
+		nMax--;
+		pNumber--;
+		auto c = (uint8_t)((nOption >> 24) & 0x7F);
+		if (c == 0)
+			c = XM6_HOST_FILENAME_MARK;
+		*pNumber = c;
+	}
+
+	// Char conversion
+	uint8_t szHuman[FILEPATH_MAX];
+	const uint8_t* pFirst = szHuman;
+	uint8_t* pLast;
+	uint8_t* pExt = nullptr;
+
+	{
+		char szHost[FILEPATH_MAX];
+		strcpy(szHost, m_szHost);
+		auto pRead = (const uint8_t*)szHost;
+		uint8_t* pWrite = szHuman;
+		const auto pPeriod = SeparateExt(pRead);
+
+		for (bool bFirst = true;; bFirst = false) {
+			uint8_t c = *pRead++;
+			switch (c) {
+				case ' ':
+					if (nOption & WINDRV_OPT_REDUCED_SPACE)
+						continue;
+					if (nOption & WINDRV_OPT_CONVERT_SPACE)
+						c = '_';
+					else if (pWrite == szHuman)
+						continue;	// Ignore spaces in the beginning
+					break;
+				case '=':
+				case '+':
+					if (nOption & WINDRV_OPT_REDUCED_BADCHAR)
+						continue;
+					if (nOption & WINDRV_OPT_CONVERT_BADCHAR)
+						c = '_';
+					break;
+				case '-':
+					if (bFirst) {
+						if (nOption & WINDRV_OPT_REDUCED_HYPHEN)
+							continue;
+						if (nOption & WINDRV_OPT_CONVERT_HYPHEN)
+							c = '_';
+						break;
+					}
+					if (nOption & WINDRV_OPT_REDUCED_HYPHENS)
+						continue;
+					if (nOption & WINDRV_OPT_CONVERT_HYPHENS)
+						c = '_';
+					break;
+				case '.':
+					if (pRead - 1 == pPeriod) {		// Make exception for Human68k extensions
+						pExt = pWrite;
+						break;
+					}
+					if (bFirst) {
+						if (nOption & WINDRV_OPT_REDUCED_PERIOD)
+							continue;
+						if (nOption & WINDRV_OPT_CONVERT_PERIOD)
+							c = '_';
+						break;
+					}
+					if (nOption & WINDRV_OPT_REDUCED_PERIODS)
+						continue;
+					if (nOption & WINDRV_OPT_CONVERT_PERIODS)
+						c = '_';
+					break;
+				default:
+					break;
+			}
+			*pWrite++ = c;
+			if (c == '\0')
+				break;
+		}
+
+		pLast = pWrite - 1;
+	}
+
+	// Adjust extensions
+	if (pExt) {
+		// Delete spaces at the end
+		while (pExt < pLast - 1 && *(pLast - 1) == ' ') {
+			pLast--;
+			auto p = pLast;
+			*p = '\0';
+		}
+
+		// Delete if the file name disappeared after conversion
+		if (pExt + 1 >= pLast) {
+			pLast = pExt;
+			*pLast = '\0';		// Just in case
+		}
+	} else {
+		pExt = pLast;
+	}
+
+	// Introducing the cast of characters
+	//
+	// pFirst: I'm the glorious leader. The start of the file name.
+	// pCut: A.k.a. Phase. Location of the initial period. Afterwards becomes the end of the base name.
+	// pSecond: Hello there! I'm the incredible Murdock. The start of the file name extension. What's it to you?
+	// pExt: B.A. Baracus. The Human68k extension genius. But don't you dare giving me more than 3 chars, fool.
+	// The location of the final period. If not applicable, gets the same value as pLast.
+	//
+	// ↓pFirst            ↓pStop ↓pSecond ←                ↓pExt
+	// T h i s _ i s _ a . V e r y . L o n g . F i l e n a m e . t x t \0
+	//         ↑pCut ← ↑pCut initial location                   ↑pLast
+	//
+	// The above example becomes "This.Long.Filename.txt" after conversion
+
+	// Evaluate first char
+	const uint8_t* pCut = pFirst;
+	const uint8_t* pStop = pExt - nMax;	// Allow for up to 17 bytes for extension (leave base name)
+	if (pFirst < pExt) {
+		pCut++;		// 1 byte always uses the base name
+		uint8_t c = *pFirst;
+		if ((0x80 <= c && c <= 0x9F) || 0xE0 <= c) {	// Specifically 0x81~0x9F 0xE0~0xEF
+			pCut++;		// Base name. At least 2 bytes.
+			pStop++;	// File extension. Max 16 bytes.
+		}
+	}
+	if (pStop < pFirst)
+		pStop = pFirst;
+
+	// Evaluate base name
+	pCut = (const uint8_t*)strchr((const char*)pCut, '.');	// The 2nd byte of Shift-JIS is always 0x40 or higher, so this is ok
+	if (pCut == nullptr)
+		pCut = pLast;
+	if ((size_t)(pCut - pFirst) > nMax)
+		pCut = pFirst + nMax;	// Execute Shift-JIS 2 byte evaluation/adjustment later. Not allowed to do it here.
+
+	// Evaluate extension
+	const uint8_t* pSecond = pExt;
+	const uint8_t* p;
+	for (p = pExt - 1; pStop < p; p--) {
+		if (*p == '.')
+			pSecond = p;	// The 2nd byte of Shift-JIS is always 0x40 or higher, so this is ok
+	}
+
+	// Shorten base name
+	// Length of extension segment
+	if (size_t nExt = pExt - pSecond; (size_t)(pCut - pFirst) + nExt > nMax)
+		pCut = pFirst + nMax - nExt;
+	// If in the middle of a 2 byte char, shorten even further
+	for (p = pFirst; p < pCut; p++) {
+		uint8_t c = *p;
+		if ((0x80 <= c && c <= 0x9F) || 0xE0 <= c) {	// Specifically 0x81~0x9F 0xE0~0xEF
+			p++;
+			if (p >= pCut) {
+				pCut--;
+				break;
+			}
+		}
+	}
+
+	// Joining the name
+	uint8_t* pWrite = m_szHuman;
+	pWrite = CopyName(pWrite, pFirst, pCut);	// Transfer the base name
+	if (pNumber)
+		pWrite = CopyName(pWrite, pNumber, &szNumber[8]);	// Transfer the adjustment char
+	pWrite = CopyName(pWrite, pSecond, pExt);	// Transfer the extension name
+	m_pszHumanExt = pWrite;						// Store the extention position
+	pWrite = CopyName(pWrite, pExt, pLast);		// Transfer the Human68k extension
+	m_pszHumanLast = pWrite;					// Store the end position
+	*pWrite = '\0';
+
+	// Confirm the conversion results
+	m_bCorrect = true;
+
+	// Fail if the base file name does not exist
+	if (m_pszHumanExt <= m_szHuman)
+		m_bCorrect = false;
+
+	// Fail if the base file name is more than 1 char and ends with a space
+	// While it is theoretically valid to have a base file name exceed 8 chars,
+	// Human68k is unable to handle it, so failing this case too.
+	else if (m_pszHumanExt[-1] == ' ')
+		m_bCorrect = false;
+
+	// Fail if the conversion result is the same as a special directory name
+	if (m_szHuman[0] == '.' &&
+		(m_szHuman[1] == '\0' || (m_szHuman[1] == '.' && m_szHuman[2] == '\0')))
+		m_bCorrect = false;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Human68k side name duplication
+///
+/// Duplicates the file name segment data, then executes the correspoding initialization with ConvertHuman().
+//
+//---------------------------------------------------------------------------
+void CHostFilename::CopyHuman(const uint8_t* szHuman)
+{
+	assert(szHuman);
+	assert(strlen((const char*)szHuman) < 23);
+
+	strcpy((char*)m_szHuman, (const char*)szHuman);
+	m_bCorrect = true;
+	m_pszHumanLast = m_szHuman + strlen((const char*)m_szHuman);
+	m_pszHumanExt = SeparateExt(m_szHuman);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Set Human68k directory entry
+///
+/// Apply the set file name to the directory entry with ConvertHuman().
+//
+//---------------------------------------------------------------------------
+void CHostFilename::SetEntryName()
+{
+	// Set file name
+	const uint8_t* p = m_szHuman;
+	size_t i;
+	for (i = 0; i < 8; i++) {
+		if (p < m_pszHumanExt)
+			m_dirHuman.name[i] = *p++;
+		else
+			m_dirHuman.name[i] = ' ';
+	}
+
+	for (i = 0; i < 10; i++) {
+		if (p < m_pszHumanExt)
+			m_dirHuman.add[i] = *p++;
+		else
+			m_dirHuman.add[i] = '\0';
+	}
+
+	if (*p == '.')
+		p++;
+	for (i = 0; i < 3; i++) {
+		uint8_t c = *p;
+		if (c)
+			p++;
+		m_dirHuman.ext[i] = c;
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Investigate if the Human68k side name has been processed
+//
+//---------------------------------------------------------------------------
+bool CHostFilename::isReduce() const
+{
+	return strcmp((const char *)m_szHost, (const char*)m_szHuman) != 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Evaluate Human68k directory entry attribute
+//
+//---------------------------------------------------------------------------
+int CHostFilename::CheckAttribute(uint32_t nHumanAttribute) const
+{
+	uint8_t nAttribute = m_dirHuman.attr;
+	if ((nAttribute & (Human68k::AT_ARCHIVE | Human68k::AT_DIRECTORY | Human68k::AT_VOLUME)) == 0)
+		nAttribute |= Human68k::AT_ARCHIVE;
+
+	return nAttribute & nHumanAttribute;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Split the extension from Human68k file name
+//
+//---------------------------------------------------------------------------
+const uint8_t* CHostFilename::SeparateExt(const uint8_t* szHuman)		// static
+{
+	// Obtain the file name length
+	const size_t nLength = strlen((const char*)szHuman);
+	const uint8_t* pFirst = szHuman;
+	const uint8_t* pLast = pFirst + nLength;
+
+	// Confirm the position of the Human68k extension
+	auto pExt = (const uint8_t*)strrchr((const char*)pFirst, '.');	// The 2nd byte of Shift-JIS is always 0x40 or higher, so this is ok
+	if (pExt == nullptr)
+		pExt = pLast;
+	// Special handling of the pattern where the file name is 20~22 chars, and the 19th char is '.' or ends with '.'
+	if (20 <= nLength && nLength <= 22 && pFirst[18] == '.' && pFirst[nLength - 1] == '.')
+		pExt = pFirst + 18;
+	// Calculate the number of chars in the extension (-1:None 0:Only period 1~3:Human68k extension 4 or above:extension name)
+	// Consider it an extension only when '.' is anywhere except the beginning of the string, and between 1~3 chars long
+	if (size_t nExt = pLast - pExt - 1; pExt == pFirst || nExt < 1 || nExt > 3)
+		pExt = pLast;
+
+	return pExt;
+}
+
+//===========================================================================
+//
+//	Directory entry: path name
+//
+//===========================================================================
+
+uint32_t CHostPath::g_nId;				///< Identifier creation counter
+
+CHostPath::~CHostPath()
+{
+	Clean();
+}
+
+//---------------------------------------------------------------------------
+//
+/// File name memory allocation
+///
+/// In most cases, the length of the host side file name is way shorter
+/// than the size of the buffer. In addition, file names may be created in huge volumes.
+/// Therefore, allocate variable lengths that correspond to the number of chars.
+//
+//---------------------------------------------------------------------------
+CHostPath::ring_t* CHostPath::Alloc(size_t nLength)	// static
+{
+	assert(nLength < FILEPATH_MAX);
+
+	const size_t n = offsetof(ring_t, f) + CHostFilename::Offset() + (nLength + 1) * sizeof(TCHAR);
+	auto p = (ring_t*)malloc(n);
+	assert(p);
+
+	p->r.Init();	// This is nothing to worry about!
+
+	return p;
+}
+
+//---------------------------------------------------------------------------
+//
+// Release file name allocations
+//
+//---------------------------------------------------------------------------
+void CHostPath::Free(ring_t* pRing)	// static
+{
+	assert(pRing);
+
+	pRing->~ring_t();
+	free(pRing);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Initialize for reuse
+//
+//---------------------------------------------------------------------------
+void CHostPath::Clean()
+{
+	Release();
+
+	// Release all file names
+	ring_t* p;
+	while ((p = (ring_t*)m_cRing.Next()) != (ring_t*)&m_cRing) {
+		Free(p);
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Specify Human68k side names directly
+//
+//---------------------------------------------------------------------------
+void CHostPath::SetHuman(const uint8_t* szHuman)
+{
+	assert(szHuman);
+	assert(strlen((const char*)szHuman) < HUMAN68K_PATH_MAX);
+
+	strcpy((char*)m_szHuman, (const char*)szHuman);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Specify host side names directly
+//
+//---------------------------------------------------------------------------
+void CHostPath::SetHost(const TCHAR* szHost)
+{
+	assert(szHost);
+	assert(strlen(szHost) < FILEPATH_MAX);
+
+	strcpy(m_szHost, szHost);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Compare arrays (supports wildcards)
+//
+//---------------------------------------------------------------------------
+int CHostPath::Compare(const uint8_t* pFirst, const uint8_t* pLast, const uint8_t* pBufFirst, const uint8_t* pBufLast)
+{
+	assert(pFirst);
+	assert(pLast);
+	assert(pBufFirst);
+	assert(pBufLast);
+
+	// Compare chars
+	bool bSkip0 = false;
+	bool bSkip1 = false;
+	for (const uint8_t* p = pFirst; p < pLast; p++) {
+		// Read 1 char
+		uint8_t c = *p;
+		uint8_t d = '\0';
+		if (pBufFirst < pBufLast)
+			d = *pBufFirst++;
+
+		// Ajust char for comparison
+		if (!bSkip0) {
+			if (!bSkip1) {	// First byte for both c and d
+				if ((0x80 <= c && c <= 0x9F) || 0xE0 <= c) {	// Specifically 0x81~0x9F 0xE0~0xEF
+					bSkip0 = true;
+				}
+				if ((0x80 <= d && d <= 0x9F) || 0xE0 <= d) {	// Specifically 0x81~0x9F 0xE0~0xEF
+					bSkip1 = true;
+				}
+				if (c == d)
+					continue;	// Finishes the evaluation here with high probability
+				if ((CFileSys::GetFileOption() & WINDRV_OPT_ALPHABET) == 0) {
+					if ('A' <= c && c <= 'Z')
+						c += 'a' - 'A';	// To lower case
+					if ('A' <= d && d <= 'Z')
+						d += 'a' - 'A';	// To lower case
+				}
+				// Unify slashes and backslashes for comparison
+				if (c == '\\') {
+					c = '/';
+				}
+				if (d == '\\') {
+					d = '/';
+				}
+			} else {		// Only c is first byte
+				if ((0x80 <= c && c <= 0x9F) || 0xE0 <= c) {	// Specifically 0x81~0x9F 0xE0~0xEF
+					bSkip0 = true;
+				}
+				bSkip1 = false;
+			}
+		} else {
+			if (!bSkip1) {	// Only d is first byte
+				bSkip0 = false;
+				if ((0x80 <= d && d <= 0x9F) || 0xE0 <= d) {	// Specifically 0x81~0x9F 0xE0~0xEF
+					bSkip1 = true;
+				}
+			} else {		// Second byte for both c and d
+				bSkip0 = false;
+				bSkip1 = false;
+			}
+		}
+
+		// Compare
+		if (c == d)
+			continue;
+		if (c == '?')
+			continue;
+		return 1;
+	}
+	if (pBufFirst < pBufLast)
+		return 2;
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Compare Human68k side name
+//
+//---------------------------------------------------------------------------
+bool CHostPath::isSameHuman(const uint8_t* szHuman) const
+{
+	assert(szHuman);
+
+	// Calulate number of chars
+	const size_t nLength = strlen((const char*)m_szHuman);
+	const size_t n = strlen((const char*)szHuman);
+
+	// Check number of chars
+	if (nLength != n)
+		return false;
+
+	// Compare Human68k path name
+	return Compare(m_szHuman, m_szHuman + nLength, szHuman, szHuman + n) == 0;
+}
+
+bool CHostPath::isSameChild(const uint8_t* szHuman) const
+{
+	assert(szHuman);
+
+	// Calulate number of chars
+	size_t nLength = strlen((const char*)m_szHuman);
+	size_t n = strlen((const char*)szHuman);
+
+	// Check number of chars
+	if (nLength < n)
+		return false;
+
+	// Compare Human68k path name
+	return Compare(m_szHuman, m_szHuman + n, szHuman, szHuman + n) == 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find file name
+///
+/// Check if whether it is a perfect match with the cache buffer, and return the name if found.
+/// Path names are excempted.
+/// Make sure to lock from the top.
+//
+//---------------------------------------------------------------------------
+const CHostFilename* CHostPath::FindFilename(const uint8_t* szHuman, uint32_t nHumanAttribute) const
+{
+	assert(szHuman);
+
+	// Calulate number of chars
+	const uint8_t* pFirst = szHuman;
+	size_t nLength = strlen((const char*)pFirst);
+	const uint8_t* pLast = pFirst + nLength;
+
+	// Find something that matches perfectly with either of the stored file names
+	const ring_t* p = (ring_t*)m_cRing.Next();
+	for (; p != (const ring_t*)&m_cRing; p = (ring_t*)p->r.Next()) {
+		if (p->f.CheckAttribute(nHumanAttribute) == 0)
+			continue;
+		// Calulate number of chars
+		const uint8_t* pBufFirst = p->f.GetHuman();
+		const uint8_t* pBufLast = p->f.GetHumanLast();
+		// Check number of chars
+		if (size_t nBufLength = pBufLast - pBufFirst; nLength != nBufLength)
+			continue;
+		// File name check
+		if (Compare(pFirst, pLast, pBufFirst, pBufLast) == 0)
+			return &p->f;
+	}
+
+	return nullptr;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find file name (with wildcard support)
+///
+/// Check if whether it is a perfect match with the cache buffer, and return the name if found.
+/// Path names are excempted.
+/// Make sure to lock from the top.
+//
+//---------------------------------------------------------------------------
+const CHostFilename* CHostPath::FindFilenameWildcard(const uint8_t* szHuman, uint32_t nHumanAttribute, find_t* pFind) const
+{
+	assert(szHuman);
+	assert(pFind);
+
+	// Split the base file name and Human68k file extension
+	const uint8_t* pFirst = szHuman;
+	const uint8_t* pLast = pFirst + strlen((const char*)pFirst);
+	const uint8_t* pExt = CHostFilename::SeparateExt(pFirst);
+
+	// Move to the start position
+	auto p = (const ring_t*)m_cRing.Next();
+	if (pFind->count > 0) {
+		if (pFind->id == m_nId) {
+			// If the same directory entry, continue right away from the previous position
+			p = pFind->pos;
+		} else {
+			// Find the start position in the directory entry contents
+			uint32_t n = 0;
+			for (;; p = (const ring_t*)p->r.Next()) {
+				if (p == (const ring_t*)&m_cRing) {
+					// Extrapolate from the count when the same entry isn't found (just in case)
+					p = (const ring_t*)m_cRing.Next();
+					n = 0;
+					for (; p != (const ring_t*)&m_cRing; p = (const ring_t*)p->r.Next()) {
+						if (n >= pFind->count)
+							break;
+						n++;
+					}
+					break;
+				}
+				if (p->f.isSameEntry(&pFind->entry)) {
+					// Same entry is found
+					pFind->count = n;
+					break;
+				}
+				n++;
+			}
+		}
+	}
+
+	// Find files
+	for (; p != (const ring_t*)&m_cRing; p = (const ring_t*)p->r.Next()) {
+		pFind->count++;
+
+		if (p->f.CheckAttribute(nHumanAttribute) == 0)
+			continue;
+
+		// Split the base file name and Human68k file extension
+		const uint8_t* pBufFirst = p->f.GetHuman();
+		const uint8_t* pBufLast = p->f.GetHumanLast();
+		const uint8_t* pBufExt = p->f.GetHumanExt();
+
+		// Compare base file name
+		if (Compare(pFirst, pExt, pBufFirst, pBufExt))
+			continue;
+
+		// Compare Human68k extension
+		// In the case of a '.???' extension, match the Human68k extension without period.
+		if (strcmp((const char*)pExt, ".???") == 0 ||
+			Compare(pExt, pLast, pBufExt, pBufLast) == 0) {
+			// Store the contents of the next candidate's directory entry
+			const auto pNext = (const ring_t*)p->r.Next();
+			pFind->id = m_nId;
+			pFind->pos = pNext;
+			if (pNext != (const ring_t*)&m_cRing)
+				memcpy(&pFind->entry, pNext->f.GetEntry(), sizeof(pFind->entry));
+			else
+				memset(&pFind->entry, 0, sizeof(pFind->entry));
+			return &p->f;
+		}
+	}
+
+	pFind->id = m_nId;
+	pFind->pos = p;
+	memset(&pFind->entry, 0, sizeof(pFind->entry));
+	return nullptr;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Confirm that the file update has been carried out
+//
+//---------------------------------------------------------------------------
+bool CHostPath::isRefresh() const
+{
+	return m_bRefresh;
+}
+
+//---------------------------------------------------------------------------
+//
+/// ASCII sort function
+//
+//---------------------------------------------------------------------------
+int AsciiSort(const dirent **a, const dirent **b)
+{
+	return strcmp((*a)->d_name, (*b)->d_name);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Reconstruct the file
+///
+/// Here we carry out the first host side file system observation.
+/// Always lock from the top.
+//
+//---------------------------------------------------------------------------
+void CHostPath::Refresh()
+{
+	assert(strlen(m_szHost) + 22 < FILEPATH_MAX);
+
+	// Store time stamp
+	Backup();
+
+	TCHAR szPath[FILEPATH_MAX];
+	strcpy(szPath, m_szHost);
+
+	// Update refresh flag
+	m_bRefresh = false;
+
+	// Store previous cache contents
+	CRing cRingBackup;
+	m_cRing.InsertRing(&cRingBackup);
+
+	// Register file name
+	bool bUpdate = false;
+	dirent **pd = nullptr;
+	int nument = 0;
+	int maxent = XM6_HOST_DIRENTRY_FILE_MAX;
+	for (int i = 0; i < maxent; i++) {
+		TCHAR szFilename[FILEPATH_MAX];
+		if (pd == nullptr) {
+			nument = scandir(S2U(szPath), &pd, nullptr, AsciiSort);
+			if (nument == -1) {
+				pd = nullptr;
+				break;
+			}
+			maxent = nument;
+		}
+
+		// When at the top level directory, exclude current and parent
+		const dirent* pe = pd[i];
+		if (m_szHuman[0] == '/' && m_szHuman[1] == 0) {
+			if (strcmp(pe->d_name, ".") == 0 || strcmp(pe->d_name, "..") == 0) {
+				continue;
+			}
+		}
+
+		// Get file name
+		strcpy(szFilename, U2S(pe->d_name));
+
+		// Allocate file name memory
+		ring_t* pRing = Alloc(strlen(szFilename));
+		CHostFilename* pFilename = &pRing->f;
+		pFilename->SetHost(szFilename);
+
+		// If there is a relevant file name in the previous cache, prioritize that for the Human68k name
+		auto pCache = (ring_t*)cRingBackup.Next();
+		for (;;) {
+			if (pCache == (ring_t*)&cRingBackup) {
+				pCache = nullptr;			// No relevant entry
+				bUpdate = true;			// Confirm new entry
+				pFilename->ConvertHuman();
+				break;
+			}
+			if (strcmp(pFilename->GetHost(), pCache->f.GetHost()) == 0) {
+				pFilename->CopyHuman(pCache->f.GetHuman());	// Copy Human68k name
+				break;
+			}
+			pCache = (ring_t*)pCache->r.Next();
+		}
+
+		// If there is a new entry, carry out file name duplication check.
+		// If the host side file name changed, or if Human68k cannot express the file name,
+		// generate a new file name that passes all the below checks:
+		// - File name correctness
+		// - No duplicated names in previous entries
+		// - No entity with the same name exists
+		if (pFilename->isReduce() || !pFilename->isCorrect()) {	// Confirm that file name update is required
+			for (uint32_t n = 0; n < XM6_HOST_FILENAME_PATTERN_MAX; n++) {
+				// Confirm file name validity
+				if (pFilename->isCorrect()) {
+					// Confirm match with previous entry
+					const CHostFilename* pCheck = FindFilename(pFilename->GetHuman());
+					if (pCheck == nullptr) {
+						// If no match, confirm existence of real file
+						strcpy(szPath, m_szHost);
+						strcat(szPath, (const char*)pFilename->GetHuman());
+						if (struct stat sb; stat(S2U(szPath), &sb))
+							break;	// Discover available patterns
+					}
+				}
+				// Generate new name
+				pFilename->ConvertHuman(n);
+			}
+		}
+
+		// Directory entry name
+		pFilename->SetEntryName();
+
+		// Get data
+		strcpy(szPath, m_szHost);
+		strcat(szPath, U2S(pe->d_name));
+
+		struct stat sb;
+		if (stat(S2U(szPath), &sb))
+			continue;
+
+		uint8_t nHumanAttribute = Human68k::AT_ARCHIVE;
+		if (S_ISDIR(sb.st_mode))
+			nHumanAttribute = Human68k::AT_DIRECTORY;
+		if ((sb.st_mode & 0200) == 0)
+			nHumanAttribute |= Human68k::AT_READONLY;
+		pFilename->SetEntryAttribute(nHumanAttribute);
+
+		auto nHumanSize = (uint32_t)sb.st_size;
+		pFilename->SetEntrySize(nHumanSize);
+
+		uint16_t nHumanDate = 0;
+		uint16_t nHumanTime = 0;
+		if (tm pt = {}; localtime_r(&sb.st_mtime, &pt) != nullptr) {
+			nHumanDate = (uint16_t)(((pt.tm_year - 80) << 9) | ((pt.tm_mon + 1) << 5) | pt.tm_mday);
+			nHumanTime = (uint16_t)((pt.tm_hour << 11) | (pt.tm_min << 5) | (pt.tm_sec >> 1));
+		}
+		pFilename->SetEntryDate(nHumanDate);
+		pFilename->SetEntryTime(nHumanTime);
+
+		pFilename->SetEntryCluster(0);
+
+		// Compare with previous cached contents
+		if (pCache) {
+			if (pCache->f.isSameEntry(pFilename->GetEntry())) {
+				Free(pRing);			// Destroy entry that was created here
+				pRing = pCache;			// Use previous cache
+			} else {
+				Free(pCache);			// Remove from the next search target
+				bUpdate = true;			// Flag for update if no match
+			}
+		}
+
+		// Add to end of ring
+		pRing->r.InsertTail(&m_cRing);
+	}
+
+	// Release directory entry
+	if (pd) {
+		for (int i = 0; i < nument; i++) {
+			free(pd[i]);
+		}
+		free(pd);
+	}
+
+	// Delete remaining cache
+	ring_t* p;
+	while ((p = (ring_t*)cRingBackup.Next()) != (ring_t*)&cRingBackup) {
+		bUpdate = true;					// Confirms the decrease in entries due to deletion
+		Free(p);
+	}
+
+	// Update the identifier if the update has been carried out
+	if (bUpdate)
+		m_nId = ++g_nId;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Store the host side time stamp
+//
+//---------------------------------------------------------------------------
+void CHostPath::Backup()
+{
+	assert(m_szHost);
+	assert(strlen(m_szHost) < FILEPATH_MAX);
+
+	TCHAR szPath[FILEPATH_MAX];
+	strcpy(szPath, m_szHost);
+	size_t len = strlen(szPath);
+
+	m_tBackup = 0;
+	if (len > 1) {	// Don't do anything if it is the root directory
+		len--;
+		assert(szPath[len] == '/');
+		szPath[len] = '\0';
+		if (struct stat sb; stat(S2U(szPath), &sb) == 0)
+			m_tBackup = sb.st_mtime;
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Restore the host side time stamp
+//
+//---------------------------------------------------------------------------
+void CHostPath::Restore() const
+{
+	assert(m_szHost);
+	assert(strlen(m_szHost) < FILEPATH_MAX);
+
+	TCHAR szPath[FILEPATH_MAX];
+	strcpy(szPath, m_szHost);
+	size_t len = strlen(szPath);
+
+	if (m_tBackup) {
+		assert(len);
+		len--;
+		assert(szPath[len] == '/');
+		szPath[len] = '\0';
+
+		utimbuf ut;
+		ut.actime = m_tBackup;
+		ut.modtime = m_tBackup;
+		utime(szPath, &ut);
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update
+//
+//---------------------------------------------------------------------------
+void CHostPath::Release()
+{
+	m_bRefresh = true;
+}
+
+//===========================================================================
+//
+//	Manage directory entries
+//
+//===========================================================================
+
+CHostEntry::~CHostEntry()
+{
+	Clean();
+
+#ifdef DEBUG
+	// Confirm object
+	for (const auto& d : m_pDrv) {
+		assert(d == nullptr);
+	}
+#endif
+}
+
+//---------------------------------------------------------------------------
+//
+/// Initialize (when the driver is installed)
+//
+//---------------------------------------------------------------------------
+void CHostEntry::Init() const
+{
+#ifdef DEBUG
+	// Confirm object
+	for (const auto& d : m_pDrv) {
+		assert(d == nullptr);
+	}
+#endif
+}
+
+//---------------------------------------------------------------------------
+//
+/// Release (at startup and reset)
+//
+//---------------------------------------------------------------------------
+void CHostEntry::Clean()
+{
+	// Delete object
+	for (auto& d: m_pDrv) {
+		delete d;
+		d = nullptr;
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update all cache
+//
+//---------------------------------------------------------------------------
+void CHostEntry::CleanCache() const
+{
+	for (const auto& d : m_pDrv) {
+		if (d)
+			d->CleanCache();
+	}
+
+	CHostPath::InitId();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update the cache for the specified unit
+//
+//---------------------------------------------------------------------------
+void CHostEntry::CleanCache(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->CleanCache();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update the cache for the specified path
+//
+//---------------------------------------------------------------------------
+void CHostEntry::CleanCache(uint32_t nUnit, const uint8_t* szHumanPath) const
+{
+	assert(szHumanPath);
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->CleanCache(szHumanPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Update all cache for the specified path and below
+//
+//---------------------------------------------------------------------------
+void CHostEntry::CleanCacheChild(uint32_t nUnit, const uint8_t* szHumanPath) const
+{
+	assert(szHumanPath);
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->CleanCacheChild(szHumanPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Delete cache for the specified path
+//
+//---------------------------------------------------------------------------
+void CHostEntry::DeleteCache(uint32_t nUnit, const uint8_t* szHumanPath) const
+{
+	assert(szHumanPath);
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->DeleteCache(szHumanPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find host side names (path name + file name (can be abbreviated) + attribute)
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::Find(uint32_t nUnit, CHostFiles* pFiles) const
+{
+	assert(pFiles);
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->Find(pFiles);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Drive settings
+//
+//---------------------------------------------------------------------------
+void CHostEntry::SetDrv(uint32_t nUnit, CHostDrv* pDrv)
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit] == nullptr);
+
+	m_pDrv[nUnit] = pDrv;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Is it write-protected?
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::isWriteProtect(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->isWriteProtect();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Is it accessible?
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::isEnable(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->isEnable();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Media check
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::isMediaOffline(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->isMediaOffline();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get media byte
+//
+//---------------------------------------------------------------------------
+uint8_t CHostEntry::GetMediaByte(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->GetMediaByte();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get drive status
+//
+//---------------------------------------------------------------------------
+uint32_t CHostEntry::GetStatus(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->GetStatus();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Media change check
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::CheckMedia(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->CheckMedia();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Eject
+//
+//---------------------------------------------------------------------------
+void CHostEntry::Eject(uint32_t nUnit) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->Eject();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get volume label
+//
+//---------------------------------------------------------------------------
+void CHostEntry::GetVolume(uint32_t nUnit, TCHAR* szLabel) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	m_pDrv[nUnit]->GetVolume(szLabel);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get volume label from cache
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::GetVolumeCache(uint32_t nUnit, TCHAR* szLabel) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->GetVolumeCache(szLabel);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get capacity
+//
+//---------------------------------------------------------------------------
+uint32_t CHostEntry::GetCapacity(uint32_t nUnit, Human68k::capacity_t* pCapacity) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->GetCapacity(pCapacity);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get cluster size from cache
+//
+//---------------------------------------------------------------------------
+bool CHostEntry::GetCapacityCache(uint32_t nUnit, Human68k::capacity_t* pCapacity) const
+{
+	assert(nUnit < DRIVE_MAX);
+	assert(m_pDrv[nUnit]);
+
+	return m_pDrv[nUnit]->GetCapacityCache(pCapacity);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Split and copy the first element from the Human68k full path name
+///
+/// Get the first element from the Human68k full path name and delete the path separator char.
+/// 23 bytes is required in the buffer to write to.
+/// A Human68k path always starts with a '/'.
+/// Throw an error if 2 '/' appears in sequence.
+/// If the array ends with a '/' treat it as an empty array and don't trow an error.
+//
+//---------------------------------------------------------------------------
+const uint8_t* CHostDrv::SeparateCopyFilename(const uint8_t* szHuman, uint8_t* szBuffer)		// static
+{
+	assert(szHuman);
+	assert(szBuffer);
+
+	const size_t nMax = 22;
+	const uint8_t* p = szHuman;
+
+	uint8_t c = *p++;				// Read
+	if (c != '/' && c != '\\')
+		return nullptr;			// Error: Invalid path name
+
+	// Insert one file
+	size_t i = 0;
+	for (;;) {
+		c = *p;					// Read
+		if (c == '\0')
+			break;				// Exit if at the end of an array (return the end position)
+		if (c == '/' || c == '\\') {
+			if (i == 0)
+				return nullptr;	// Error: Two separator chars appear in sequence
+			break;				// Exit after reading the separator (return the char position)
+		}
+		p++;
+
+		if (i >= nMax)
+			return nullptr;		// Error: The first byte hits the end of the buffer
+		szBuffer[i++] = c;		// Read
+
+		if ((0x80 <= c && c <= 0x9F) || 0xE0 <= c) {	// Specifically 0x81~0x9F and 0xE0~0xEF
+			c = *p++;			// Read
+			if (c < 0x40)
+				return nullptr;	// Error: Invalid Shift-JIS 2nd byte
+
+			if (i >= nMax)
+				return nullptr;	// Error: The second byte hits the end of the buffer
+			szBuffer[i++] = c;	// Read
+		}
+	}
+	szBuffer[i] = '\0';			// Read
+
+	return p;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Generate path and file name internally
+//
+//---------------------------------------------------------------------------
+void CHostFiles::SetPath(const Human68k::namests_t* pNamests)
+{
+	assert(pNamests);
+
+	pNamests->GetCopyPath(m_szHumanPath);
+	pNamests->GetCopyFilename(m_szHumanFilename);
+	m_nHumanWildcard = 0;
+	m_nHumanAttribute = Human68k::AT_ARCHIVE;
+	m_findNext.Clear();
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find file on the Human68k side and create data on the host side
+//
+//---------------------------------------------------------------------------
+bool CHostFiles::Find(uint32_t nUnit, const CHostEntry* pEntry)
+{
+	assert(pEntry);
+
+	return pEntry->Find(nUnit, this);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Find file name
+//
+//---------------------------------------------------------------------------
+const CHostFilename* CHostFiles::Find(const CHostPath* pPath)
+{
+	assert(pPath);
+
+	if (m_nHumanWildcard)
+		return pPath->FindFilenameWildcard(m_szHumanFilename, m_nHumanAttribute, &m_findNext);
+
+	return pPath->FindFilename(m_szHumanFilename, m_nHumanAttribute);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Store the Human68k side search results
+//
+//---------------------------------------------------------------------------
+void CHostFiles::SetEntry(const CHostFilename* pFilename)
+{
+	assert(pFilename);
+
+	// Store Human68k directory entry
+	memcpy(&m_dirHuman, pFilename->GetEntry(), sizeof(m_dirHuman));
+
+	// Stire Human68k file name
+	strcpy((char*)m_szHumanResult, (const char*)pFilename->GetHuman());
+}
+
+//---------------------------------------------------------------------------
+//
+/// Set host side name
+//
+//---------------------------------------------------------------------------
+void CHostFiles::SetResult(const TCHAR* szPath)
+{
+	assert(szPath);
+	assert(strlen(szPath) < FILEPATH_MAX);
+
+	strcpy(m_szHostResult, szPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Add file name to the host side name
+//
+//---------------------------------------------------------------------------
+void CHostFiles::AddResult(const TCHAR* szPath)
+{
+	assert(szPath);
+	assert(strlen(m_szHostResult) + strlen(szPath) < FILEPATH_MAX);
+
+	strcat(m_szHostResult, szPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Add a new Human68k file name to the host side name
+//
+//---------------------------------------------------------------------------
+void CHostFiles::AddFilename()
+{
+	assert(strlen(m_szHostResult) + strlen((const char*)m_szHumanFilename) < FILEPATH_MAX);
+	strncat(m_szHostResult, (const char*)m_szHumanFilename, ARRAY_SIZE(m_szHumanFilename));
+}
+
+//===========================================================================
+//
+//	File search memory manager
+//
+//===========================================================================
+
+#ifdef _DEBUG
+CHostFilesManager::~CHostFilesManager()
+{
+	// Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+}
+#endif	// _DEBUG
+
+//---------------------------------------------------------------------------
+//
+/// Initialization (when the driver is installed)
+//
+//---------------------------------------------------------------------------
+void CHostFilesManager::Init()
+{
+
+	// Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+
+	// Allocate memory
+	for (uint32_t i = 0; i < XM6_HOST_FILES_MAX; i++) {
+		auto p = new ring_t();
+		p->r.Insert(&m_cRing);
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Release (at startup and reset)
+//
+//---------------------------------------------------------------------------
+void CHostFilesManager::Clean()
+{
+
+	// Release memory
+	CRing* p;
+	while ((p = m_cRing.Next()) != &m_cRing) {
+		delete (ring_t*)p;
+	}
+}
+
+CHostFiles* CHostFilesManager::Alloc(uint32_t nKey)
+{
+	assert(nKey);
+
+	// Select from the end
+	auto p = (ring_t*)m_cRing.Prev();
+
+	// Move to the start of the ring
+	p->r.Insert(&m_cRing);
+
+	p->f.SetKey(nKey);
+
+	return &p->f;
+}
+
+CHostFiles* CHostFilesManager::Search(uint32_t nKey)
+{
+	// assert(nKey);	// The search key may become 0 due to DPB damage
+
+	// Find the relevant object
+	auto p = (ring_t*)m_cRing.Next();
+	for (; p != (ring_t*)&m_cRing; p = (ring_t*)p->r.Next()) {
+		if (p->f.isSameKey(nKey)) {
+			// Move to the start of the ring
+			p->r.Insert(&m_cRing);
+			return &p->f;
+		}
+	}
+
+	return nullptr;
+}
+
+void CHostFilesManager::Free(CHostFiles* pFiles)
+{
+	assert(pFiles);
+
+	// Release
+	pFiles->SetKey(0);
+
+	// Move to the end of the ring
+	auto p = (ring_t*)((size_t)pFiles - offsetof(ring_t, f));
+	p->r.InsertTail(&m_cRing);
+}
+
+//===========================================================================
+//
+//	FCB processing
+//
+//===========================================================================
+
+//---------------------------------------------------------------------------
+//
+/// Set file open mode
+//
+//---------------------------------------------------------------------------
+bool CHostFcb::SetMode(uint32_t nHumanMode)
+{
+	switch (nHumanMode & Human68k::OP_MASK) {
+		case Human68k::OP_READ:
+			m_pszMode = "rb";
+			break;
+		case Human68k::OP_WRITE:
+			m_pszMode = "wb";
+			break;
+		case Human68k::OP_FULL:
+			m_pszMode = "r+b";
+			break;
+		default:
+			return false;
+	}
+
+	m_bFlag = (nHumanMode & Human68k::OP_SPECIAL) != 0;
+
+	return true;
+}
+
+void CHostFcb::SetFilename(const TCHAR* szFilename)
+{
+	assert(szFilename);
+	assert(strlen(szFilename) < FILEPATH_MAX);
+
+	strcpy(m_szFilename, szFilename);
+}
+
+void CHostFcb::SetHumanPath(const uint8_t* szHumanPath)
+{
+	assert(szHumanPath);
+	assert(strlen((const char*)szHumanPath) < HUMAN68K_PATH_MAX);
+
+	strcpy((char*)m_szHumanPath, (const char*)szHumanPath);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Create file
+///
+/// Return false if error is thrown.
+//
+//---------------------------------------------------------------------------
+bool CHostFcb::Create(uint32_t, bool bForce)
+{
+	assert((Human68k::AT_DIRECTORY | Human68k::AT_VOLUME) == 0);
+	assert(strlen(m_szFilename) > 0);
+	assert(m_pFile == nullptr);
+
+	// Duplication check
+	if (!bForce) {
+		if (struct stat sb; stat(S2U(m_szFilename), &sb) == 0)
+			return false;
+	}
+
+	// Create file
+	m_pFile = fopen(S2U(m_szFilename), "w+b");	/// @warning The ideal operation is to overwrite each attribute
+
+	return m_pFile != nullptr;
+}
+
+//---------------------------------------------------------------------------
+//
+/// File open
+///
+/// Return false if error is thrown.
+//
+//---------------------------------------------------------------------------
+bool CHostFcb::Open()
+{
+	assert(strlen(m_szFilename) > 0);
+
+	// Fail if directory
+	if (struct stat st; stat(S2U(m_szFilename), &st) == 0 && ((st.st_mode & S_IFMT) == S_IFDIR)) {
+		return false || m_bFlag;
+	}
+
+	// File open
+	if (m_pFile == nullptr)
+		m_pFile = fopen(S2U(m_szFilename), m_pszMode);
+
+	return m_pFile != nullptr || m_bFlag;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Read file
+///
+/// Handle a 0 byte read as normal operation too.
+/// Return -1 if error is thrown.
+//
+//---------------------------------------------------------------------------
+uint32_t CHostFcb::Read(uint8_t* pBuffer, uint32_t nSize)
+{
+	assert(pBuffer);
+	assert(m_pFile);
+
+	size_t nResult = fread(pBuffer, sizeof(uint8_t), nSize, m_pFile);
+	if (ferror(m_pFile))
+		nResult = (size_t)-1;
+
+	return (uint32_t)nResult;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Write file
+///
+/// Handle a 0 byte read as normal operation too.
+/// Return -1 if error is thrown.
+//
+//---------------------------------------------------------------------------
+uint32_t CHostFcb::Write(const uint8_t* pBuffer, uint32_t nSize)
+{
+	assert(pBuffer);
+	assert(m_pFile);
+
+	size_t nResult = fwrite(pBuffer, sizeof(uint8_t), nSize, m_pFile);
+	if (ferror(m_pFile))
+		nResult = (size_t)-1;
+
+	return (uint32_t)nResult;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Truncate file
+///
+/// Return false if error is thrown.
+//
+//---------------------------------------------------------------------------
+bool CHostFcb::Truncate() const
+{
+	assert(m_pFile);
+
+	return ftruncate(fileno(m_pFile), ftell(m_pFile)) == 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// File seek
+///
+/// Return -1 if error is thrown.
+//
+//---------------------------------------------------------------------------
+uint32_t CHostFcb::Seek(uint32_t nOffset, Human68k::seek_t nHumanSeek)
+{
+	assert(m_pFile);
+
+	int nSeek;
+	switch (nHumanSeek) {
+		case Human68k::seek_t::SK_BEGIN:
+			nSeek = SEEK_SET;
+			break;
+		case Human68k::seek_t::SK_CURRENT:
+			nSeek = SEEK_CUR;
+			break;
+			// case SK_END:
+		default:
+			nSeek = SEEK_END;
+			break;
+	}
+	if (fseek(m_pFile, nOffset, nSeek))
+		return (uint32_t)-1;
+
+	return (uint32_t)ftell(m_pFile);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Set file time stamp
+///
+/// Return false if error is thrown.
+//
+//---------------------------------------------------------------------------
+bool CHostFcb::TimeStamp(uint32_t nHumanTime) const
+{
+	assert(m_pFile || m_bFlag);
+
+	tm t = { };
+	t.tm_year = (nHumanTime >> 25) + 80;
+	t.tm_mon = ((nHumanTime >> 21) - 1) & 15;
+	t.tm_mday = (nHumanTime >> 16) & 31;
+	t.tm_hour = (nHumanTime >> 11) & 31;
+	t.tm_min = (nHumanTime >> 5) & 63;
+	t.tm_sec = (nHumanTime & 31) << 1;
+	time_t ti = mktime(&t);
+	if (ti == (time_t)-1)
+		return false;
+	utimbuf ut;
+	ut.actime = ti;
+	ut.modtime = ti;
+
+	// This is for preventing the last updated time stamp to be overwritten upon closing.
+	// Flush and synchronize before updating the time stamp.
+	fflush(m_pFile);
+
+	return utime(S2U(m_szFilename), &ut) == 0 || m_bFlag;
+}
+
+//---------------------------------------------------------------------------
+//
+/// File close
+///
+/// Return false if error is thrown.
+//
+//---------------------------------------------------------------------------
+void CHostFcb::Close()
+{
+	// File close
+	// Always initialize because of the Close→Free (internally one more Close) flow.
+	if (m_pFile) {
+		fclose(m_pFile);
+		m_pFile = nullptr;
+	}
+}
+
+//===========================================================================
+//
+// FCB processing manager
+//
+//===========================================================================
+
+#ifdef _DEBUG
+CHostFcbManager::~CHostFcbManager()
+{
+	// Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+}
+#endif	// _DEBUG
+
+//---------------------------------------------------------------------------
+//
+// Initialization (when the driver is installed)
+//
+//---------------------------------------------------------------------------
+void CHostFcbManager::Init()
+{
+	// Confirm that the entity does not exist (just in case)
+	assert(m_cRing.Next() == &m_cRing);
+	assert(m_cRing.Prev() == &m_cRing);
+
+	// Memory allocation
+	for (uint32_t i = 0; i < XM6_HOST_FCB_MAX; i++) {
+		auto p = new ring_t;
+		assert(p);
+		p->r.Insert(&m_cRing);
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+// Clean (at startup/reset)
+//
+//---------------------------------------------------------------------------
+void CHostFcbManager::Clean() const
+{
+	//  Fast task killer
+	CRing* p;
+	while ((p = m_cRing.Next()) != &m_cRing) {
+		delete (ring_t*)p;
+	}
+}
+
+CHostFcb* CHostFcbManager::Alloc(uint32_t nKey)
+{
+	assert(nKey);
+
+	// Select from the end
+	auto p = (ring_t*)m_cRing.Prev();
+
+	// Error if in use (just in case)
+	if (!p->f.isSameKey(0)) {
+		assert(false);
+		return nullptr;
+	}
+
+	// Move to the top of the ring
+	p->r.Insert(&m_cRing);
+
+	//  Set key
+	p->f.SetKey(nKey);
+
+	return &p->f;
+}
+
+CHostFcb* CHostFcbManager::Search(uint32_t nKey)
+{
+	assert(nKey);
+
+	// Search for applicable objects
+	auto p = (ring_t*)m_cRing.Next();
+	while (p != (ring_t*)&m_cRing) {
+		if (p->f.isSameKey(nKey)) {
+			 // Move to the top of the ring
+			p->r.Insert(&m_cRing);
+			return &p->f;
+		}
+		p = (ring_t*)p->r.Next();
+	}
+
+	return nullptr;
+}
+
+void CHostFcbManager::Free(CHostFcb* pFcb)
+{
+	assert(pFcb);
+
+	// Free
+	pFcb->SetKey(0);
+	pFcb->Close();
+
+	// Move to the end of the ring
+	auto p = (ring_t*)((size_t)pFcb - offsetof(ring_t, f));
+	p->r.InsertTail(&m_cRing);
+}
+
+//===========================================================================
+//
+// Host side file system
+//
+//===========================================================================
+
+uint32_t CFileSys::g_nOption;		// File name conversion flag
+
+//---------------------------------------------------------------------------
+//
+/// Reset (close all)
+//
+//---------------------------------------------------------------------------
+void CFileSys::Reset()
+{
+	// Initialize virtual sectors
+	m_nHostSectorCount = 0;
+	memset(m_nHostSectorBuffer, 0, sizeof(m_nHostSectorBuffer));
+
+	// File search memory - release (on startup and reset)
+	m_cFiles.Clean();
+
+	// FCB operation memory (on startup and reset)
+	m_cFcb.Clean();
+
+	// Directory entry - release (on startup and reset)
+	m_cEntry.Clean();
+
+	// Initialize TwentyOne option monitoring
+	m_nKernel = 0;
+	m_nKernelSearch = 0;
+
+	// Initialize operational flags
+	SetOption(m_nOptionDefault);
+}
+
+//---------------------------------------------------------------------------
+//
+/// Initialize (device startup and load)
+//
+//---------------------------------------------------------------------------
+void CFileSys::Init()
+{
+	// Initialize file search memory (device startup and load)
+	m_cFiles.Init();
+
+	// Initialize FCB operation memory (device startup and load)
+	m_cFcb.Init();
+
+	// Initialize directory entries (device startup and load)
+	m_cEntry.Init();
+
+	// Evaluate per-path setting validity
+	uint32_t nDrives = m_nDrives;
+	if (nDrives == 0) {
+		// Use root directory instead of per-path settings
+		strcpy(m_szBase[0], "/");
+		m_nFlag[0] = 0;
+		nDrives++;
+	}
+
+	// Register file system
+	uint32_t nUnit = 0;
+	for (uint32_t n = 0; n < nDrives; n++) {
+		// Don't register is base path do not exist
+		if (m_szBase[n][0] == '\0')
+			continue;
+
+		// Create 1 unit file system
+		auto p = new CHostDrv;
+		if (p) {
+			m_cEntry.SetDrv(nUnit, p);
+			p->Init(m_szBase[n], m_nFlag[n]);
+
+			// To the next unit
+			nUnit++;
+		}
+	}
+
+	// Store the registered number of drives
+	m_nUnits = nUnit;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $40 - Device startup
+//
+//---------------------------------------------------------------------------
+uint32_t CFileSys::InitDevice(const Human68k::argument_t* pArgument)
+{
+	InitOption(pArgument);
+
+	// File system initialization
+	Init();
+
+	return m_nUnits;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $41 - Directory check
+//
+//---------------------------------------------------------------------------
+int CFileSys::CheckDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_INVALIDFUNC;	// Avoid triggering a fatal error in mint when resuming with an invalid drive
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	if (f.isRootPath())
+		return 0;
+	f.SetPathOnly();
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_DIRNOTFND;
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $42 - Create directory
+//
+//---------------------------------------------------------------------------
+int CFileSys::MakeDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetPathOnly();
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_INVALIDPATH;
+	f.AddFilename();
+
+	// Create directory
+	if (mkdir(S2U(f.GetPath()), 0777))
+		return FS_INVALIDPATH;
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $43 - Delete directory
+//
+//---------------------------------------------------------------------------
+int CFileSys::RemoveDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetAttribute(Human68k::AT_DIRECTORY);
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_DIRNOTFND;
+
+	// Delete cache
+	uint8_t szHuman[HUMAN68K_PATH_MAX + 24];
+	assert(strlen((const char*)f.GetHumanPath()) +
+		strlen((const char*)f.GetHumanFilename()) < HUMAN68K_PATH_MAX + 24);
+	strcpy((char*)szHuman, (const char*)f.GetHumanPath());
+	strcat((char*)szHuman, (const char*)f.GetHumanFilename());
+	strcat((char*)szHuman, "/");
+	m_cEntry.DeleteCache(nUnit, szHuman);
+
+	// Delete directory
+	if (rmdir(S2U(f.GetPath())))
+		return FS_CANTDELETE;
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $44 - Change file name
+//
+//---------------------------------------------------------------------------
+int CFileSys::Rename(uint32_t nUnit, const Human68k::namests_t* pNamests, const Human68k::namests_t* pNamestsNew) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetAttribute(Human68k::AT_ALL);
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_FILENOTFND;
+
+	CHostFiles fNew;
+	fNew.SetPath(pNamestsNew);
+	fNew.SetPathOnly();
+	if (!fNew.Find(nUnit, &m_cEntry))
+		return FS_INVALIDPATH;
+	fNew.AddFilename();
+
+	// Update cache
+	if (f.GetAttribute() & Human68k::AT_DIRECTORY)
+		m_cEntry.CleanCacheChild(nUnit, f.GetHumanPath());
+
+	// Change file name
+	char szFrom[FILENAME_MAX];
+	char szTo[FILENAME_MAX];
+	SJIS2UTF8(f.GetPath(), szFrom, FILENAME_MAX);
+	SJIS2UTF8(fNew.GetPath(), szTo, FILENAME_MAX);
+	if (rename(szFrom, szTo)) {
+		return FS_FILENOTFND;
+	}
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+	m_cEntry.CleanCache(nUnit, fNew.GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $45 - Delete file
+//
+//---------------------------------------------------------------------------
+int CFileSys::Delete(uint32_t nUnit, const Human68k::namests_t* pNamests) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_FILENOTFND;
+
+	// Delete file
+	if (unlink(S2U(f.GetPath())))
+		return FS_CANTDELETE;
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $46 - Get/set file attribute
+//
+//---------------------------------------------------------------------------
+int CFileSys::Attribute(uint32_t nUnit, const Human68k::namests_t* pNamests, uint32_t nHumanAttribute) const
+{
+	assert(pNamests);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetAttribute(Human68k::AT_ALL);
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_FILENOTFND;
+
+	// Exit if attribute is acquired
+	if (nHumanAttribute == 0xFF)
+		return f.GetAttribute();
+
+	// Attribute check
+	if (nHumanAttribute & Human68k::AT_VOLUME)
+		return FS_CANTACCESS;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Generate attribute
+	if (uint32_t nAttribute = (nHumanAttribute & Human68k::AT_READONLY) | (f.GetAttribute() & ~Human68k::AT_READONLY);
+		f.GetAttribute() != nAttribute) {
+		struct stat sb;
+		if (stat(S2U(f.GetPath()), &sb))
+			return FS_FILENOTFND;
+		mode_t m = sb.st_mode & 0777;
+		if (nAttribute & Human68k::AT_READONLY)
+			m &= 0555;	// ugo-w
+		else
+			m |= 0200;	// u+w
+
+		// Set attribute
+		if (chmod(S2U(f.GetPath()), m))
+			return FS_FILENOTFND;
+	}
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+
+	// Get attribute after changing
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_FILENOTFND;
+
+	return f.GetAttribute();
+}
+
+//---------------------------------------------------------------------------
+//
+/// $47 - File search
+//
+//---------------------------------------------------------------------------
+int CFileSys::Files(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::files_t* pFiles)
+{
+	assert(pNamests);
+	assert(nKey);
+	assert(pFiles);
+
+	// Release if memory with the same key already exists
+	CHostFiles* pHostFiles = m_cFiles.Search(nKey);
+	if (pHostFiles != nullptr) {
+		m_cFiles.Free(pHostFiles);
+	}
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Get volume label
+	/** @note
+	This skips the media check when getting the volume label to avoid triggering a fatal error
+	with host side removable media (CD-ROM, etc.) Some poorly coded applications will attempt to
+    get the volume label even though a proper error was thrown doing a media change check just before.
+	*/
+	if ((pFiles->fatr & (Human68k::AT_ARCHIVE | Human68k::AT_DIRECTORY | Human68k::AT_VOLUME))
+		== Human68k::AT_VOLUME) {
+		// Path check
+		CHostFiles f;
+		f.SetPath(pNamests);
+		if (!f.isRootPath())
+			return FS_FILENOTFND;
+
+		// Immediately return the results without allocating buffer
+		if (!FilesVolume(nUnit, pFiles))
+			return FS_FILENOTFND;
+		return 0;
+	}
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Allocate buffer
+	pHostFiles = m_cFiles.Alloc(nKey);
+	if (pHostFiles == nullptr)
+		return FS_OUTOFMEM;
+
+	// Directory check
+	pHostFiles->SetPath(pNamests);
+	if (!pHostFiles->isRootPath()) {
+		pHostFiles->SetPathOnly();
+		if (!pHostFiles->Find(nUnit, &m_cEntry)) {
+			m_cFiles.Free(pHostFiles);
+			return FS_DIRNOTFND;
+		}
+	}
+
+	// Enable wildcards
+	pHostFiles->SetPathWildcard();
+	pHostFiles->SetAttribute(pFiles->fatr);
+
+	// Find file
+	if (!pHostFiles->Find(nUnit, &m_cEntry)) {
+		m_cFiles.Free(pHostFiles);
+		return FS_FILENOTFND;
+	}
+
+	// Store search results
+	pFiles->attr = (uint8_t)pHostFiles->GetAttribute();
+	pFiles->date = pHostFiles->GetDate();
+	pFiles->time = pHostFiles->GetTime();
+	pFiles->size = pHostFiles->GetSize();
+	strcpy((char*)pFiles->full, (const char*)pHostFiles->GetHumanResult());
+
+	// Specify pseudo-directory entry
+	pFiles->sector = nKey;
+	pFiles->offset = 0;
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $48 - Search next file
+//
+//---------------------------------------------------------------------------
+int CFileSys::NFiles(uint32_t nUnit, uint32_t nKey, Human68k::files_t* pFiles)
+{
+	assert(nKey);
+	assert(pFiles);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Find buffer
+	CHostFiles* pHostFiles = m_cFiles.Search(nKey);
+	if (pHostFiles == nullptr)
+		return FS_INVALIDPTR;
+
+	// Find file
+	if (!pHostFiles->Find(nUnit, &m_cEntry)) {
+		m_cFiles.Free(pHostFiles);
+		return FS_FILENOTFND;
+	}
+
+	assert(pFiles->sector == nKey);
+	assert(pFiles->offset == 0);
+
+	// Store search results
+	pFiles->attr = (uint8_t)pHostFiles->GetAttribute();
+	pFiles->date = pHostFiles->GetDate();
+	pFiles->time = pHostFiles->GetTime();
+	pFiles->size = pHostFiles->GetSize();
+	strcpy((char*)pFiles->full, (const char*)pHostFiles->GetHumanResult());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $49 - Create new file
+//
+//---------------------------------------------------------------------------
+int CFileSys::Create(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::fcb_t* pFcb, uint32_t nHumanAttribute, bool bForce)
+{
+	assert(pNamests);
+	assert(nKey);
+	assert(pFcb);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Release if memory with the same key already exists
+	if (m_cFcb.Search(nKey) != nullptr)
+		return FS_INVALIDPTR;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetPathOnly();
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_INVALIDPATH;
+	f.AddFilename();
+
+	// Attribute check
+	if (nHumanAttribute & (Human68k::AT_DIRECTORY | Human68k::AT_VOLUME))
+		return FS_CANTACCESS;
+
+	// Store path name
+	CHostFcb* pHostFcb = m_cFcb.Alloc(nKey);
+	if (pHostFcb == nullptr)
+		return FS_OUTOFMEM;
+	pHostFcb->SetFilename(f.GetPath());
+	pHostFcb->SetHumanPath(f.GetHumanPath());
+
+	// Set open mode
+	pFcb->mode = (uint16_t)((pFcb->mode & ~Human68k::OP_MASK) | Human68k::OP_FULL);
+	if (!pHostFcb->SetMode(pFcb->mode)) {
+		m_cFcb.Free(pHostFcb);
+		return FS_ILLEGALMOD;
+	}
+
+	// Create file
+	if (!pHostFcb->Create(nHumanAttribute, bForce)) {
+		m_cFcb.Free(pHostFcb);
+		return FS_FILEEXIST;
+	}
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, f.GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4A - File open
+//
+//---------------------------------------------------------------------------
+int CFileSys::Open(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::fcb_t* pFcb)
+{
+	assert(pNamests);
+	assert(nKey);
+	assert(pFcb);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	switch (pFcb->mode & Human68k::OP_MASK) {
+		case Human68k::OP_WRITE:
+		case Human68k::OP_FULL:
+			if (m_cEntry.isWriteProtect(nUnit))
+				return FS_FATAL_WRITEPROTECT;
+			break;
+		default: break;
+	}
+
+	// Release if memory with the same key already exists
+	if (m_cFcb.Search(nKey) != nullptr)
+		return FS_INVALIDPRM;
+
+	// Generate path name
+	CHostFiles f;
+	f.SetPath(pNamests);
+	f.SetAttribute(Human68k::AT_ALL);
+	if (!f.Find(nUnit, &m_cEntry))
+		return FS_FILENOTFND;
+
+	// Time stamp
+	pFcb->date = f.GetDate();
+	pFcb->time = f.GetTime();
+
+	// File size
+	pFcb->size = f.GetSize();
+
+	// Store path name
+	CHostFcb* pHostFcb = m_cFcb.Alloc(nKey);
+	if (pHostFcb == nullptr)
+		return FS_OUTOFMEM;
+	pHostFcb->SetFilename(f.GetPath());
+	pHostFcb->SetHumanPath(f.GetHumanPath());
+
+	// Set open mode
+	if (!pHostFcb->SetMode(pFcb->mode)) {
+		m_cFcb.Free(pHostFcb);
+		return FS_ILLEGALMOD;
+	}
+
+	// File open
+	if (!pHostFcb->Open()) {
+		m_cFcb.Free(pHostFcb);
+		return FS_INVALIDPATH;
+	}
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4B - File close
+//
+//---------------------------------------------------------------------------
+int CFileSys::Close(uint32_t nUnit, uint32_t nKey, const Human68k::fcb_t* /* pFcb */)
+{
+	assert(nKey);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Throw error if memory with the same key does not exist
+	CHostFcb* pHostFcb = m_cFcb.Search(nKey);
+	if (pHostFcb == nullptr)
+		return FS_INVALIDPRM;
+
+	// File close and release memory
+	m_cFcb.Free(pHostFcb);
+
+	// Update cache
+	if (pHostFcb->isUpdate())
+		m_cEntry.CleanCache(nUnit, pHostFcb->GetHumanPath());
+
+	/// TODO: Match the FCB status on close with other devices
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4C - Read file
+///
+/// Clean exit when 0 bytes are read.
+//
+//---------------------------------------------------------------------------
+int CFileSys::Read(uint32_t nKey, Human68k::fcb_t* pFcb, uint8_t* pBuffer, uint32_t nSize)
+{
+	assert(nKey);
+	assert(pFcb);
+	// assert(pBuffer);			// Evaluate only when needed
+	assert(nSize <= 0xFFFFFF);	// Clipped
+
+	// Throw error if memory with the same key does not exist
+	CHostFcb* pHostFcb = m_cFcb.Search(nKey);
+	if (pHostFcb == nullptr)
+		return FS_NOTOPENED;
+
+	// Confirm the existence of the buffer
+	if (pBuffer == nullptr) {
+		m_cFcb.Free(pHostFcb);
+		return FS_INVALIDFUNC;
+	}
+
+	// Read
+	const uint32_t nResult = pHostFcb->Read(pBuffer, nSize);
+	if (nResult == (uint32_t)-1) {
+		m_cFcb.Free(pHostFcb);
+		return FS_INVALIDFUNC;	// TODO: Should return error code 10 (read error) as well here
+	}
+	assert(nResult <= nSize);
+
+	// Update file pointer
+	pFcb->fileptr += nResult;	/// TODO: Maybe an overflow check is needed here?
+
+	return nResult;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4D - Write file
+///
+/// Truncate file if 0 bytes are written.
+//
+//---------------------------------------------------------------------------
+int CFileSys::Write(uint32_t nKey, Human68k::fcb_t* pFcb, const uint8_t* pBuffer, uint32_t nSize)
+{
+	assert(nKey);
+	assert(pFcb);
+	// assert(pBuffer);			// Evaluate only when needed
+	assert(nSize <= 0xFFFFFF);	// Clipped
+
+	// Throw error if memory with the same key does not exist
+	CHostFcb* pHostFcb = m_cFcb.Search(nKey);
+	if (pHostFcb == nullptr)
+		return FS_NOTOPENED;
+
+	uint32_t nResult;
+	if (nSize == 0) {
+		// Truncate
+		if (!pHostFcb->Truncate()) {
+			m_cFcb.Free(pHostFcb);
+			return FS_CANTSEEK;
+		}
+
+		// Update file size
+		pFcb->size = pFcb->fileptr;
+
+		nResult = 0;
+	} else {
+		// Confirm the existence of the buffer
+		if (pBuffer == nullptr) {
+			m_cFcb.Free(pHostFcb);
+			return FS_INVALIDFUNC;
+		}
+
+		// Write
+		nResult = pHostFcb->Write(pBuffer, nSize);
+		if (nResult == (uint32_t)-1) {
+			m_cFcb.Free(pHostFcb);
+			return FS_CANTWRITE;	/// TODO: Should return error code 11 (write error) as well here
+		}
+		assert(nResult <= nSize);
+
+		// Update file pointer
+		pFcb->fileptr += nResult;	/// TODO: Do we need an overflow check here?
+
+		// Update file size
+		if (pFcb->size < pFcb->fileptr)
+			pFcb->size = pFcb->fileptr;
+	}
+
+	// Update flag
+	pHostFcb->SetUpdate();
+
+	return nResult;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4E - File seek
+//
+//---------------------------------------------------------------------------
+int CFileSys::Seek(uint32_t nKey, Human68k::fcb_t* pFcb, uint32_t nSeek, int nOffset)
+{
+	assert(pFcb);
+
+	// Throw error if memory with the same key does not exist
+	CHostFcb* pHostFcb = m_cFcb.Search(nKey);
+	if (pHostFcb == nullptr)
+		return FS_NOTOPENED;
+
+	// Parameter check
+	if (nSeek > (uint32_t)Human68k::seek_t::SK_END) {
+		m_cFcb.Free(pHostFcb);
+		return FS_INVALIDPRM;
+	}
+
+	// File seek
+	uint32_t nResult = pHostFcb->Seek(nOffset, (Human68k::seek_t)nSeek);
+	if (nResult == (uint32_t)-1) {
+		m_cFcb.Free(pHostFcb);
+		return FS_CANTSEEK;
+	}
+
+	// Update file pointer
+	pFcb->fileptr = nResult;
+
+	return nResult;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $4F - Get/set file time stamp
+///
+/// Throw error when the top 16 bits are $FFFF.
+//
+//---------------------------------------------------------------------------
+uint32_t CFileSys::TimeStamp(uint32_t nUnit, uint32_t nKey, Human68k::fcb_t* pFcb, uint32_t nHumanTime)
+{
+	assert(nKey);
+	assert(pFcb);
+
+	// Get only
+	if (nHumanTime == 0)
+		return ((uint32_t)pFcb->date << 16) | pFcb->time;
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Throw error if memory with the same key does not exist
+	CHostFcb* pHostFcb = m_cFcb.Search(nKey);
+	if (pHostFcb == nullptr)
+		return FS_NOTOPENED;
+
+	// Set time stamp
+	if (!pHostFcb->TimeStamp(nHumanTime)) {
+		m_cFcb.Free(pHostFcb);
+		return FS_INVALIDPRM;
+	}
+	pFcb->date = (uint16_t)(nHumanTime >> 16);
+	pFcb->time = (uint16_t)nHumanTime;
+
+	// Update cache
+	m_cEntry.CleanCache(nUnit, pHostFcb->GetHumanPath());
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $50 - Get capacity
+//
+//---------------------------------------------------------------------------
+int CFileSys::GetCapacity(uint32_t nUnit, Human68k::capacity_t* pCapacity) const
+{
+	assert(pCapacity);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Get capacity
+	return m_cEntry.GetCapacity(nUnit, pCapacity);
+}
+
+//---------------------------------------------------------------------------
+//
+/// $51 - Inspect/control drive status
+//
+//---------------------------------------------------------------------------
+int CFileSys::CtrlDrive(uint32_t nUnit, Human68k::ctrldrive_t* pCtrlDrive) const
+{
+	assert(pCtrlDrive);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_INVALIDFUNC;	// Avoid triggering a fatal error in mint when resuming with an invalid drive
+
+	switch (pCtrlDrive->status) {
+		case 0:		// Inspect status
+		case 9:		// Inspect status 2
+			pCtrlDrive->status = (uint8_t)m_cEntry.GetStatus(nUnit);
+			return pCtrlDrive->status;
+
+		case 1:		// Eject
+		case 2:		// Eject forbidden 1 (not implemented)
+		case 3:		// Eject allowed 1 (not implemented)
+		case 4:		// Flash LED when media is not inserted (not implemented)
+		case 5:		// Turn off LED when media is not inserted (not implemented)
+		case 6:		// Eject forbidden 2 (not implemented)
+		case 7:		// Eject allowed 2 (not implemented)
+			return 0;
+
+		case 8:		// Eject inspection
+			return 1;
+
+		default:
+			break;
+	}
+
+	return FS_INVALIDFUNC;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $52 - Get DPB
+///
+/// If DPB cannot be acquired after resuming, the drive will be torn down internally in Human68k.
+/// Therefore, treat even a unit out of bounds as normal operation.
+//
+//---------------------------------------------------------------------------
+int CFileSys::GetDPB(uint32_t nUnit, Human68k::dpb_t* pDpb) const
+{
+	assert(pDpb);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+
+	Human68k::capacity_t cap;
+	uint8_t media = Human68k::MEDIA_REMOTE;
+	if (nUnit < m_nUnits) {
+		media = m_cEntry.GetMediaByte(nUnit);
+
+		// Acquire sector data
+		if (!m_cEntry.GetCapacityCache(nUnit, &cap)) {
+			// Carry out an extra media check here because it may be skipped when doing a manual eject
+			// Media check
+			if (!m_cEntry.isEnable(nUnit) || m_cEntry.isMediaOffline(nUnit)) {
+				cap.clusters = 4;	// This is totally fine, right?
+				cap.sectors = 64;
+				cap.bytes = 512;
+			}
+			else {
+				// Get drive status
+				m_cEntry.GetCapacity(nUnit, &cap);
+			}
+		}
+	} else {
+		cap.clusters = 4;	// This is totally fine, right?
+		cap.sectors = 64;
+		cap.bytes = 512;
+	}
+
+	// Calculate number of shifts
+	uint32_t nSize = 1;
+	uint32_t nShift = 0;
+	for (;;) {
+		if (nSize >= cap.sectors)
+			break;
+		nSize <<= 1;
+		nShift++;
+	}
+
+	// Sector number calculation
+	//
+	// In the following order:
+	// Cluster 0: Unused
+	// Cluster 1: FAT
+	// Cluster 2: Root directory
+	// Cluster 3: Data memory (pseudo-sector)
+	const uint32_t nFat = cap.sectors;
+	const uint32_t nRoot = cap.sectors * 2;
+	const uint32_t nData = cap.sectors * 3;
+
+	// Set DPB
+	pDpb->sector_size = cap.bytes;		// Bytes per sector
+	pDpb->cluster_size =
+		(uint8_t)(cap.sectors - 1);				// Sectors per cluster - 1
+	pDpb->shift = (uint8_t)nShift;					// Number of cluster → sector shifts
+	pDpb->fat_sector = (uint16_t)nFat;				// First FAT sector number
+	pDpb->fat_max = 1;							// Number of FAT memory spaces
+	pDpb->fat_size = (uint8_t)cap.sectors;			// Number of sectors controlled by FAT (excluding copies)
+	pDpb->file_max =
+		(uint16_t)(cap.sectors * cap.bytes / 0x20);	// Number of files in the root directory
+	pDpb->data_sector = (uint16_t)nData;			// First sector number of data memory
+	pDpb->cluster_max = cap.clusters;		// Total number of clusters + 1
+	pDpb->root_sector = (uint16_t)nRoot;			// First sector number of the root directory
+	pDpb->media = media;						// Media byte
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $53 - Read sector
+///
+/// We use pseudo-sectors.
+/// Buffer size is hard coded to $200 byte.
+//
+//---------------------------------------------------------------------------
+int CFileSys::DiskRead(uint32_t nUnit, uint8_t* pBuffer, uint32_t nSector, uint32_t nSize)
+{
+	assert(pBuffer);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// This occurs when resuming with an invalid drive
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Throw error if number of sectors exceed 1
+	if (nSize != 1)
+		return FS_INVALIDPRM;
+
+	// Acquire sector data
+	Human68k::capacity_t cap;
+	if (!m_cEntry.GetCapacityCache(nUnit, &cap)) {
+		// Get drive status
+		m_cEntry.GetCapacity(nUnit, &cap);
+	}
+
+	// Access pseudo-directory entry
+	const CHostFiles* pHostFiles = m_cFiles.Search(nSector);
+	if (pHostFiles) {
+		// Generate pseudo-directory entry
+		auto dir = (Human68k::dirent_t*)pBuffer;
+		memcpy(pBuffer, pHostFiles->GetEntry(), sizeof(*dir));
+		memset(pBuffer + sizeof(*dir), 0xE5, 0x200 - sizeof(*dir));
+
+		// Register the pseudo-sector number that points to the file entity inside the pseudo-directory.
+		// Note that in lzdsys the sector number to read is calculated by the following formula:
+		// (dirent.cluster - 2) * (dpb.cluster_size + 1) + dpb.data_sector
+		/// @warning little endian only
+		dir->cluster = (uint16_t)(m_nHostSectorCount + 2);		// Pseudo-sector number
+		m_nHostSectorBuffer[m_nHostSectorCount] = nSector;	// Entity that points to the pseudo-sector
+		m_nHostSectorCount++;
+		m_nHostSectorCount %= XM6_HOST_PSEUDO_CLUSTER_MAX;
+
+		return 0;
+	}
+
+	// Calculate the sector number from the cluster number
+	uint32_t n = nSector - (3 * cap.sectors);
+	uint32_t nMod = 1;
+	if (cap.sectors) {
+		// Beware that cap.sectors becomes 0 when media does not exist
+		nMod = n % cap.sectors;
+		n /= cap.sectors;
+	}
+
+	// Access the file entity
+	if (nMod == 0 && n < XM6_HOST_PSEUDO_CLUSTER_MAX) {
+		pHostFiles = m_cFiles.Search(m_nHostSectorBuffer[n]);	// Find entity
+		if (pHostFiles) {
+			// Generate pseudo-sector
+			CHostFcb f;
+			f.SetFilename(pHostFiles->GetPath());
+			f.SetMode(Human68k::OP_READ);
+			if (!f.Open())
+				return FS_INVALIDPRM;
+			memset(pBuffer, 0, 0x200);
+			uint32_t nResult = f.Read(pBuffer, 0x200);
+			f.Close();
+			if (nResult == (uint32_t)-1)
+				return FS_INVALIDPRM;
+
+			return 0;
+		}
+	}
+
+	return FS_INVALIDPRM;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $54 - Write sector
+//
+//---------------------------------------------------------------------------
+int CFileSys::DiskWrite(uint32_t nUnit) const
+{
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Write-protect check
+	if (m_cEntry.isWriteProtect(nUnit))
+		return FS_FATAL_WRITEPROTECT;
+
+	// Thrust at reality
+	return FS_INVALIDPRM;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $55 - IOCTRL
+//
+//---------------------------------------------------------------------------
+int CFileSys::Ioctrl(uint32_t nUnit, uint32_t nFunction, Human68k::ioctrl_t* pIoctrl)
+{
+	assert(pIoctrl);
+
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_INVALIDFUNC;	// Avoid triggering a fatal error in mint when resuming with an invalid drive
+
+	switch (nFunction) {
+		case 0:
+			// Acquire media byte
+			pIoctrl->media = m_cEntry.GetMediaByte(nUnit);
+			return 0;
+
+		case 1:
+			// Dummy for Human68k compatibility
+			pIoctrl->param = -1;
+			return 0;
+
+		case 2:
+			switch (pIoctrl->param) {
+				case (uint32_t)-1:
+					// Re-identify media
+					m_cEntry.isMediaOffline(nUnit);
+					return 0;
+
+				case 0:
+				case 1:
+					// Dummy for Human68k compatibility
+					return 0;
+
+				default:
+					return FS_NOTIOCTRL;
+			}
+			break;
+
+		case (uint32_t)-1:
+			// Resident evaluation
+			memcpy(pIoctrl->buffer, "WindrvXM", 8);
+			return 0;
+
+		case (uint32_t)-2:
+			// Set options
+			SetOption(pIoctrl->param);
+			return 0;
+
+		case (uint32_t)-3:
+			// Get options
+			pIoctrl->param = GetOption();
+			return 0;
+
+		default:
+			break;
+	}
+
+	return FS_NOTIOCTRL;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $56 - Flush
+//
+//---------------------------------------------------------------------------
+int CFileSys::Flush(uint32_t nUnit) const
+{
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_INVALIDFUNC;	// Avoid triggering a fatal error returning from a mint command when resuming with an invalid drive
+
+	// Always succeed
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $57 - Media change check
+//
+//---------------------------------------------------------------------------
+int CFileSys::CheckMedia(uint32_t nUnit) const
+{
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	if (nUnit >= m_nUnits)
+		return FS_INVALIDFUNC;	// Avoid triggering a fatal error in mint when resuming with an invalid drive
+
+	// Media change check
+	// Throw error when media is not inserted
+	if (!m_cEntry.CheckMedia(nUnit)) {
+		return FS_INVALIDFUNC;
+	}
+
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// $58 - Lock
+//
+//---------------------------------------------------------------------------
+int CFileSys::Lock(uint32_t nUnit) const
+{
+	// Unit check
+	if (nUnit >= CHostEntry::DRIVE_MAX)
+		return FS_FATAL_INVALIDUNIT;
+	assert(nUnit < m_nUnits);
+	if (nUnit >= m_nUnits)
+		return FS_FATAL_MEDIAOFFLINE;	// Just in case
+
+	// Media check
+	if (m_cEntry.isMediaOffline(nUnit))
+		return FS_FATAL_MEDIAOFFLINE;
+
+	// Always succeed
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Set options
+//
+//---------------------------------------------------------------------------
+void CFileSys::SetOption(uint32_t nOption)
+{
+	// Clear cache when option settings change
+	if (m_nOption ^ nOption)
+		m_cEntry.CleanCache();
+
+	m_nOption = nOption;
+	g_nOption = nOption;
+}
+
+//---------------------------------------------------------------------------
+//
+/// Initialize options
+//
+//---------------------------------------------------------------------------
+void CFileSys::InitOption(const Human68k::argument_t* pArgument)
+{
+	assert(pArgument);
+
+	// Initialize number of drives
+	m_nDrives = 0;
+
+	const uint8_t* pp = pArgument->buf;
+	pp += strlen((const char*)pp) + 1;
+
+	uint32_t nOption = m_nOptionDefault;
+	for (;;) {
+		assert(pp < pArgument->buf + sizeof(*pArgument));
+		const uint8_t* p = pp;
+		uint8_t c = *p++;
+		if (c == '\0')
+			break;
+
+		uint32_t nMode;
+		if (c == '+') {
+			nMode = 1;
+		} else if (c == '-') {
+			nMode = 0;
+		} else if (c == '/') {
+			// Specify default base path
+			if (m_nDrives < CHostEntry::DRIVE_MAX) {
+				p--;
+				strcpy(m_szBase[m_nDrives], (const char *)p);
+				m_nDrives++;
+			}
+			pp += strlen((const char*)pp) + 1;
+			continue;
+		} else {
+			// Continue since no option is specified
+			pp += strlen((const char*)pp) + 1;
+			continue;
+		}
+
+		for (;;) {
+			c = *p++;
+			if (c == '\0')
+				break;
+
+			uint32_t nBit = 0;
+			switch (c) {
+				case 'A': case 'a': nBit = WINDRV_OPT_CONVERT_LENGTH; break;
+				case 'T': case 't': nBit = WINDRV_OPT_COMPARE_LENGTH; nMode ^= 1; break;
+				case 'C': case 'c': nBit = WINDRV_OPT_ALPHABET; break;
+
+				case 'E': nBit = WINDRV_OPT_CONVERT_PERIOD; break;
+				case 'P': nBit = WINDRV_OPT_CONVERT_PERIODS; break;
+				case 'N': nBit = WINDRV_OPT_CONVERT_HYPHEN; break;
+				case 'H': nBit = WINDRV_OPT_CONVERT_HYPHENS; break;
+				case 'X': nBit = WINDRV_OPT_CONVERT_BADCHAR; break;
+				case 'S': nBit = WINDRV_OPT_CONVERT_SPACE; break;
+
+				case 'e': nBit = WINDRV_OPT_REDUCED_PERIOD; break;
+				case 'p': nBit = WINDRV_OPT_REDUCED_PERIODS; break;
+				case 'n': nBit = WINDRV_OPT_REDUCED_HYPHEN; break;
+				case 'h': nBit = WINDRV_OPT_REDUCED_HYPHENS; break;
+				case 'x': nBit = WINDRV_OPT_REDUCED_BADCHAR; break;
+				case 's': nBit = WINDRV_OPT_REDUCED_SPACE; break;
+
+				default: break;
+			}
+
+			if (nMode)
+				nOption |= nBit;
+			else
+				nOption &= ~nBit;
+		}
+
+		pp = p;
+	}
+
+	// Set options
+	if (nOption != m_nOption) {
+		SetOption(nOption);
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+/// Get volume label
+//
+//---------------------------------------------------------------------------
+bool CFileSys::FilesVolume(uint32_t nUnit, Human68k::files_t* pFiles) const
+{
+	assert(pFiles);
+
+	// Get volume label
+	TCHAR szVolume[32];
+	if (bool bResult = m_cEntry.GetVolumeCache(nUnit, szVolume); !bResult) {
+		// Carry out an extra media check here because it may be skipped when doing a manual eject
+		if (!m_cEntry.isEnable(nUnit))
+			return false;
+
+		// Media check
+		if (m_cEntry.isMediaOffline(nUnit))
+			return false;
+
+		// Get volume label
+		m_cEntry.GetVolume(nUnit, szVolume);
+	}
+	if (szVolume[0] == '\0')
+		return false;
+
+	pFiles->attr = Human68k::AT_VOLUME;
+	pFiles->time = 0;
+	pFiles->date = 0;
+	pFiles->size = 0;
+
+	CHostFilename fname;
+	fname.SetHost(szVolume);
+	fname.ConvertHuman();
+	strcpy((char*)pFiles->full, (const char*)fname.GetHuman());
+
+	return true;
+}

--- a/cpp/devices/cfilesystem.h
+++ b/cpp/devices/cfilesystem.h
@@ -1,0 +1,939 @@
+//---------------------------------------------------------------------------
+//
+//	SCSI Target Emulator PiSCSI
+//	for Raspberry Pi
+//
+//	Powered by XM6 TypeG Technology.
+//	Copyright (C) 2016-2020 GIMONS
+//
+//	[ Host File System for the X68000 ]
+//
+//  Note: This functionality is specific to the X68000 operating system.
+//        It is highly unlikely that this will work for other platforms.
+//
+//---------------------------------------------------------------------------
+
+#pragma once
+
+#include <cassert>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <cstddef>
+#include <cstdio>
+#include <time.h>
+#include <unistd.h>
+
+using TCHAR = char;
+
+static const int FILEPATH_MAX = 260;
+
+//---------------------------------------------------------------------------
+//
+//	Status code definitions
+//
+//---------------------------------------------------------------------------
+static const int FS_INVALIDFUNC	=	0xFFFFFFFF;	///< Executed an invalid function
+static const int FS_FILENOTFND =	0xFFFFFFFE;	///< The selected file can not be found
+static const int FS_DIRNOTFND =		0xFFFFFFFD;	///< The selected directory can not be found
+static const int FS_OVEROPENED =	0xFFFFFFFC;	///< There are too many files open
+static const int FS_CANTACCESS =	0xFFFFFFFB;	///< Can not access the direcory or volume
+static const int FS_NOTOPENED =		0xFFFFFFFA;	///< The selected handle is not opened
+static const int FS_INVALIDMEM =	0xFFFFFFF9;	///< Memory management has been destroyed
+static const int FS_OUTOFMEM =		0xFFFFFFF8;	///< Insufficient memory for execution
+static const int FS_INVALIDPTR =	0xFFFFFFF7;	///< Selected an invalid memory management pointer
+static const int FS_INVALIDENV =	0xFFFFFFF6;	///< Selected an invalid environment
+static const int FS_ILLEGALFMT =	0xFFFFFFF5;	///< The exeucted file is in an invalid format
+static const int FS_ILLEGALMOD =	0xFFFFFFF4;	///< Invalid open access mode
+static const int FS_INVALIDPATH =	0xFFFFFFF3;	///< Mistake in selected file name
+static const int FS_INVALIDPRM =	0xFFFFFFF2;	///< Called with an invalid parameter
+static const int FS_INVALIDDRV =	0xFFFFFFF1;	///< Mistake in selected drive
+static const int FS_DELCURDIR =		0xFFFFFFF0;	///< Unable to delete the current directory
+static const int FS_NOTIOCTRL =		0xFFFFFFEF;	///< Unable to use IOCTRL with the device
+static const int FS_LASTFILE =		0xFFFFFFEE;	///< Can not find any more files
+static const int FS_CANTWRITE =		0xFFFFFFED;	///< Selected file can not be written
+static const int FS_DIRALREADY =	0xFFFFFFEC;	///< Selected directory is already registered
+static const int FS_CANTDELETE =	0xFFFFFFEB;	///< Can not delete because of a file
+static const int FS_CANTRENAME =	0xFFFFFFEA;	///< Can not rename because of a file
+static const int FS_DISKFULL =		0xFFFFFFE9;	///< Can not create a file because the disk is full
+static const int FS_DIRFULL =		0xFFFFFFE8;	///< Can not create a file because the directory is full
+static const int FS_CANTSEEK =		0xFFFFFFE7;	///< Can not seek in the selected location
+static const int FS_SUPERVISOR =	0xFFFFFFE6;	///< Selected supervisor in supervisor mode
+static const int FS_THREADNAME =	0xFFFFFFE5;	///< A thread with this name already exists
+static const int FS_BUFWRITE =		0xFFFFFFE4;	///< Writing to inter-process communication buffers is disallowed
+static const int FS_BACKGROUND =	0xFFFFFFE3;	///< Unable to start a background process
+static const int FS_OUTOFLOCK =		0xFFFFFFE0;	///< Insufficient lock space
+static const int FS_LOCKED =		0xFFFFFFDF;	///< Can not access because it is locked
+static const int FS_DRIVEOPENED =	0xFFFFFFDE;	///< Selected drive has an open handler
+static const int FS_LINKOVER =		0xFFFFFFDD;	///< The symbolic link is nested over 16 times
+static const int FS_FILEEXIST =		0xFFFFFFB0;	///< The file exists
+
+static const int FS_FATAL_MEDIAOFFLINE =	0xFFFFFFA3;	///< No media inserted
+static const int FS_FATAL_WRITEPROTECT =	0xFFFFFFA2;	///< Write protected
+static const int FS_FATAL_INVALIDCOMMAND =	0xFFFFFFA1;	///< Invalid command number
+static const int FS_FATAL_INVALIDUNIT =	0xFFFFFFA0;	///< Invalid unit number
+
+static const int HUMAN68K_PATH_MAX = 96;		///< Longest path allowed in Human68k
+
+//===========================================================================
+//
+/// Human68k name space
+//
+//===========================================================================
+namespace Human68k {
+	/// File attribute bit
+	enum attribute_t {
+		AT_READONLY = 0x01,		///< Read only attribute
+		AT_HIDDEN = 0x02,		///< Hidden attribute
+		AT_SYSTEM = 0x04,		///< System attribute
+		AT_VOLUME = 0x08,		///< Volume label attribute
+		AT_DIRECTORY = 0x10,		///< Directory attribute
+		AT_ARCHIVE = 0x20,		///< Archive attribute
+		AT_ALL = 0xFF,			///< All attribute bits are 1
+	};
+
+	/// File open modes
+	enum open_t {
+		OP_READ = 0,			///< Read
+		OP_WRITE = 1,			///< Write
+		OP_FULL = 2,			///< Read/Write
+		OP_MASK = 0x0F,			///< Decision mask
+		OP_SHARE_NONE = 0x10,		///< Sharing forbidden
+		OP_SHARE_READ = 0x20,		///< Read sharing
+		OP_SHARE_WRITE = 0x30,		///< Write sharing
+		OP_SHARE_FULL = 0x40,		///< Read/Write sharing
+		OP_SHARE_MASK = 0x70,		///< Sharing decision mask
+		OP_SPECIAL = 0x100,		///< Dictionary access
+	};
+
+	/// Seek types
+	enum class seek_t {
+		SK_BEGIN = 0,			///< From the beginning of a file
+		SK_CURRENT = 1,			///< From the current location
+		SK_END = 2,			///< From the end of the file
+	};
+
+	// Media byte
+	const static int MEDIA_REMOTE = 0xF3;		///< Remote drive
+
+	struct namests_t {
+		uint8_t wildcard;			///< Wildcard character length
+		uint8_t drive;			///< Drive number
+		uint8_t path[65];			///< Path (subdirectory +/)
+		uint8_t name[8];			///< File name (PADDING 0x20)
+		uint8_t ext[3];			///< Extension (PADDING 0x20)
+		uint8_t add[10];			///< File name addition (PADDING 0x00)
+
+		void GetCopyPath(uint8_t* szPath) const;
+		void GetCopyFilename(uint8_t* szFilename) const;
+	};
+
+	struct files_t {
+		uint8_t fatr;			///< + 0 search attribute; read-only
+		//		uint8_t drive;	///< + 1 drive number; read-only
+		uint32_t sector;			///< + 2 directory sector; DOS _FILES first address substitute
+		//		uint16_t cluster;	///< + 6 directory cluster; details unknown (unused)
+		uint16_t offset;			///< + 8 directory entry; write-only
+		//		uint8_t name[8];	///< +10 working file name; write-only (unused)
+		//		uint8_t ext[3];	///< +18 working extension; write-only (unused)
+		uint8_t attr;			///< +21 file attribute; write-only
+		uint16_t time;			///< +22 last change time of day; write-only
+		uint16_t date;			///< +24 last change date; write-only
+		uint32_t size;			///< +26 file size; write-only
+		uint8_t full[23];			///< +30 full name; write-only
+	};
+
+	struct fcb_t {
+		//		uint8_t pad00[6];	///< + 0~+ 5	(unused)
+		uint32_t fileptr;			///< + 6~+ 9	file pointer
+		//		uint8_t pad01[4];	///< +10~+13	(unused)
+		uint16_t mode;			///< +14~+15	open mode
+		//		uint8_t pad02[16];	///< +16~+31	(unused)
+		//		uint32_t zero;	///< +32~+35	zeros are written when opened (unused)
+		//		uint8_t name[8];	///< +36~+43	file name (PADDING 0x20) (unused)
+		//		uint8_t ext[3];	///< +44~+46	extension (PADDING 0x20) (unused)
+		uint8_t attr;			///< +47	file attribute
+		//		uint8_t add[10];	///< +48~+57	file name addition (PADDING 0x00) (unused)
+		uint16_t time;			///< +58~+59	last change time of day
+		uint16_t date;			///< +60~+61	last change date
+		//		uint16_t cluster;	///< +62~+63	cluster number (unused)
+		uint32_t size;			///< +64~+67	file size
+		//		uint8_t pad03[28];	///< +68~+95	FAT cache (unused)
+	};
+
+	struct capacity_t {
+		uint16_t freearea;			///< + 0	Number of available clusters
+		uint16_t clusters;			///< + 2	Total number of clusters
+		uint16_t sectors;			///< + 4	Number of sectors per cluster
+		uint16_t bytes;			///< + 6	Number of bytes per sector
+	};
+
+	struct ctrldrive_t {
+		uint8_t status;			///< +13	status
+		uint8_t pad[3];			///< Padding
+	};
+
+	struct dpb_t {
+		uint16_t sector_size;		///< + 0	Number of bytes in one sector
+		uint8_t cluster_size;		///< + 2	Number sectors in one cluster -1
+		uint8_t shift;			///< + 3	Number of cluster→sector shifts
+		uint16_t fat_sector;		///< + 4	FAT first sector number
+		uint8_t fat_max;			///< + 6	FAT storage quantity
+		uint8_t fat_size;			///< + 7	FAT controlled sector number (excluding duplicates)
+		uint16_t file_max;			///< + 8	Number of files in the root directory
+		uint16_t data_sector;		///< +10	First sector number of data storage
+		uint16_t cluster_max;		///< +12	Total number of clusters +1
+		uint16_t root_sector;		///< +14	First sector number of root directory
+		//	uint32_t driverentry;	///< +16	Device driver pointer (unused)
+		uint8_t media;			///< +20	Media identifier
+		//	uint8_t flag;		///< +21	Flag used by DPB (unused)
+	};
+
+	/// Directory entry struct
+	struct dirent_t {
+		uint8_t name[8];			///< + 0	File name (PADDING 0x20)
+		uint8_t ext[3];			///< + 8	Extension (PADDING 0x20)
+		uint8_t attr;			///< +11	File attribute
+		uint8_t add[10];			///< +12	File name addition (PADDING 0x00)
+		uint16_t time;			///< +22	Last change time of day
+		uint16_t date;			///< +24	Last change date
+		uint16_t cluster;			///< +26	Cluster number
+		uint32_t size;			///< +28	File size
+	};
+
+	/// IOCTRL parameter union
+	union ioctrl_t {
+		uint8_t buffer[8];			///< Access in byte units
+		uint32_t param;			///< Parameter (First 4 bytes)
+		uint16_t media;			///< Media byte (First 2 bytes)
+	};
+
+	/// Command line parameter struct
+	/**
+	The driver itself is included in the beginning of the argument,
+	so setting to a length longer than HUMAN68K_PATH_MAX
+	*/
+	struct argument_t {
+		uint8_t buf[256];			///< Command line argument
+	};
+}
+
+/// Number of FILES buffers
+/**
+Under normal circumstances it's enough with just a few buffers,
+but Human68k multitasking may lead to multiple threads working
+deeply in the system, which is why this value is set this high.
+
+Default is 20 buffers.
+*/
+static const int XM6_HOST_FILES_MAX = 20;
+
+/// Number of FCB buffers
+/**
+This decides how many files can be opened at the same time.
+
+Default is 100 files.
+*/
+static const int XM6_HOST_FCB_MAX = 100;
+
+/// Max number of virtual clusters and sectors
+/**
+Number of virtual sectors used for accessing the first sector of a file entity.
+Allocating a generous amount to exceed the number of threads lzdsys uses for access.
+
+Default is 10 sectors.
+*/
+static const int XM6_HOST_PSEUDO_CLUSTER_MAX = 10;
+
+/// Number of caches for directory entries
+/**
+Human68k carries out a large number of checks of directory entries when doing an operation
+inside a subdirectory. This specifies the number of caches used to speed up this operation.
+Cache is allocated per drive. The more you add the faster it gets, but use too many
+and the host OS gets under a heavy load, so be careful.
+
+Default is 16.
+*/
+static const int XM6_HOST_DIRENTRY_CACHE_MAX = 16;
+
+/// Max number of entries that can be stored per directory
+/**
+When a large number of files are stored in a directory, a larger amount of data than
+contemporanous applications can handle will be returned. This may lead to errors such as
+partial data being recognized, performance dropping significantly, or OOM crashes.
+To guard against this, an upper limit is defined here. In the case of a particular
+file manager, the upper limit is 2560 files. This is one good example to use as reference.
+
+Default is around 60000 entries. (Upper limit of the FAT root directory)
+*/
+static const int XM6_HOST_DIRENTRY_FILE_MAX	= 65535;
+
+/// Max number of patterns for file name deduplication
+/**
+The file names on the Human68k side are automatically created based on the file system on
+the host side. However, Human68k have stricter file name length restrictions than the host has.
+Because of this, there is a risk that file name duplication will occur. When this happens,
+WindrvXM will use a certain renaming heuristic to generate alternate file names to resolve
+the duplication. Theoretically, there are over 60 million (36^5) unique file names that
+can be generated by this method. However, in reality any more than a few hundred
+deduplications will take excessive processing time. So here an upper limit to deduplication
+is set in order to maintain system performance. If a system is operated with common sense,
+you should only need a few dozen deduplication patterns, so this value can be kept low
+to further improve performance. In the case deduplication is not carried out, multiple files
+with the same name will be created. When trying to access such files,
+only the first entry will ever be accessed.
+
+Default is 36 patterns.
+*/
+static const int XM6_HOST_FILENAME_PATTERN_MAX = 36;
+
+/// Duplicate file identification mark
+/**
+A symbol used to distinguish between host and Human68k files.
+Do not use a command shell escape character, or similar protected symbol.
+
+Default is '@'.
+*/
+static const char XM6_HOST_FILENAME_MARK = '@';
+
+/// WINDRV operational flags
+/**
+Normally set to 0. When put in the OS trash can for deletion, it is set to 1.
+Other values are reserved for future use.
+Can be used for future extentions such as internal operational flags or mock media byte.
+*/
+enum {
+	WINDRV_OPT_REMOVE =		0x00000001,	///< Bit 0: File delete process			0:Directly 1:Trash can
+	WINDRV_OPT_ALPHABET =		0x00000020,	///< Bit 5: File name comparison; Alphabet distinction		0:No 1:Yes	0:-C 1:+C
+	WINDRV_OPT_COMPARE_LENGTH =	0x00000040,	///< Bit 6: File name comparison; String length (unimplemented)	0:18+3 1:8+3	0:+T 1:-T
+	WINDRV_OPT_CONVERT_LENGTH =	0x00000080,	///< Bit 7: File name conversion; String length		0:18+3 1:8+3	0:-A 1:+A
+	WINDRV_OPT_CONVERT_SPACE =	0x00000100,	///< Bit 8: File name conversion; Space		0:No 1:'_'
+	WINDRV_OPT_CONVERT_BADCHAR =	0x00000200,	///< Bit 9: File name conversion; Invalid char		0:No 1:'_'
+	WINDRV_OPT_CONVERT_HYPHENS =	0x00000400,	///< Bit10: File name conversion; Middle hyphen	0:No 1:'_'
+	WINDRV_OPT_CONVERT_HYPHEN =	0x00000800,	///< Bit11: File name conversion; Initial hyphen	0:No 1:'_'
+	WINDRV_OPT_CONVERT_PERIODS =	0x00001000,	///< Bit12: File name conversion; Middle period	0:No 1:'_'
+	WINDRV_OPT_CONVERT_PERIOD =	0x00002000,	///< Bit13: File name conversion; Initial period	0:No 1:'_'
+	WINDRV_OPT_REDUCED_SPACE =	0x00010000,	///< Bit16: File name reduction; Space		0:No 1:Reduced
+	WINDRV_OPT_REDUCED_BADCHAR =	0x00020000,	///< Bit17: File name reduction; Invalid char		0:No 1:Reduced
+	WINDRV_OPT_REDUCED_HYPHENS =	0x00040000,	///< Bit18: File name reduction Middle hyphen	0:No 1:Reduced
+	WINDRV_OPT_REDUCED_HYPHEN =	0x00080000,	///< Bit19: File name reduction Initial hyphen	0:No 1:Reduced
+	WINDRV_OPT_REDUCED_PERIODS =	0x00100000,	///< Bit20: File name reduction Middle period	0:No 1:Reduced
+	WINDRV_OPT_REDUCED_PERIOD =	0x00200000,	///< Bit21: File name reduction Initial period	0:No 1:Reduced
+	// Bit24～30 Duplicate file identification mark			0:Automatic 1～127:Chars
+};
+
+/// File system operational flag
+/**
+Normal is 0. Becomes 1 if attempting to mount in read-only mode.
+Reserving the other values for future use.
+Insurance against hard-to-detect devices such as homemade USB storage.
+*/
+static const uint32_t FSFLAG_WRITE_PROTECT = 0x00000001;	///< Bit0: Force write protect
+
+//===========================================================================
+//
+/// Full ring list
+///
+/// First (root.next) is the most recent object.
+/// Last (root.prev) is the oldest / unused object.
+/// For code optimization purposes, always upcast the pointer when deleting.
+//
+//===========================================================================
+class CRing {
+public:
+	CRing() { Init(); }
+	~CRing() { Remove(); }
+	CRing(CRing&) = default;
+	CRing& operator=(const CRing&) = default;
+
+	void  Init() { next = prev = this; }
+
+	CRing*  Next() const { return next; }			///< Get the next element
+	CRing*  Prev() const { return prev; }			///< Get the previous element
+
+	void  Insert(CRing* pRoot)
+	{
+			// Separate the relevant objects
+		assert(next);
+		assert(prev);
+		next->prev = prev;
+		prev->next = next;
+		// Insert into the beginning of the ring
+		assert(pRoot);
+		assert(pRoot->next);
+		next = pRoot->next;
+		prev = pRoot;
+		pRoot->next->prev = this;
+		pRoot->next = this;
+	}
+										///< Separate objects & insert into the beginning of the ring
+
+	void  InsertTail(CRing* pRoot)
+	{
+			// Separate the relevant objects
+		assert(next);
+		assert(prev);
+		next->prev = prev;
+		prev->next = next;
+		// Insert into the end of the ring
+		assert(pRoot);
+		assert(pRoot->prev);
+		next = pRoot;
+		prev = pRoot->prev;
+		pRoot->prev->next = this;
+		pRoot->prev = this;
+	}
+										///< Separate objects & insert into the end of the ring
+
+	void  InsertRing(CRing* pRoot)
+	{
+			if (next == prev) return;
+
+		// Insert into the beginning of the ring
+		assert(pRoot);
+		assert(pRoot->next);
+		pRoot->next->prev = prev;
+		prev->next = pRoot->next;
+		pRoot->next = next;
+		next->prev = pRoot;
+
+		// Empty self
+		next = prev = this;
+	}
+										///< Separate objects except self & insert into the beginning of the ring
+
+	void  Remove()
+	{
+			// Separate the relevant objects
+		assert(next);
+		assert(prev);
+		next->prev = prev;
+		prev->next = next;
+		// To be safe, assign self (nothing stops you from separating any number of times)
+		next = prev = this;
+	}
+										///< Separate objects
+
+private:
+	CRing* next;						///< Next element
+	CRing* prev;						///< Previous element
+};
+
+//===========================================================================
+//
+/// Directory Entry: File Name
+//
+//===========================================================================
+class CHostFilename {
+public:
+	CHostFilename() = default;
+	~CHostFilename() = default;
+
+	static size_t Offset() { return offsetof(CHostFilename, m_szHost); }	///< Get offset location
+
+	void SetHost(const TCHAR* szHost);					///< Set the name of the host
+	const TCHAR* GetHost() const { return m_szHost; }	///< Get the name of the host
+	void ConvertHuman(int nCount = -1);					///< Convert the Human68k name
+	void CopyHuman(const uint8_t* szHuman);					///< Copy the Human68k name
+	bool isReduce() const;							///< Inspect if the Human68k name is generated
+	bool isCorrect() const { return m_bCorrect; }		///< Inspect if the Human68k file name adhers to naming rules
+	const uint8_t* GetHuman() const { return m_szHuman; }	///< Get Human68k file name
+	const uint8_t* GetHumanLast() const
+	{ return m_pszHumanLast; }				///< Get Human68k file name
+	const uint8_t* GetHumanExt() const { return m_pszHumanExt; }///< Get Human68k file name
+	void SetEntryName();							///< Set Human68k directory entry
+	void SetEntryAttribute(uint8_t nHumanAttribute)
+	{ m_dirHuman.attr = nHumanAttribute; }			///< Set Human68k directory entry
+	void  SetEntrySize(uint32_t nHumanSize)
+	{ m_dirHuman.size = nHumanSize; }				///< Set Human68k directory entry
+	void SetEntryDate(uint16_t nHumanDate)
+	{ m_dirHuman.date = nHumanDate; }				///< Set Human68k directory entry
+	void SetEntryTime(uint16_t nHumanTime)
+	{ m_dirHuman.time = nHumanTime; }				///< Set Human68k directory entry
+	void SetEntryCluster(uint16_t nHumanCluster)
+	{ m_dirHuman.cluster = nHumanCluster; }			///< Set Human68k directory entry
+	const Human68k::dirent_t*  GetEntry() const
+	{ return &m_dirHuman; }					///< Get Human68k directory entry
+	int CheckAttribute(uint32_t nHumanAttribute) const;			///< Determine Human68k directory entry attributes
+	bool isSameEntry(const Human68k::dirent_t* pdirHuman) const
+	{ assert(pdirHuman); return memcmp(&m_dirHuman, pdirHuman, sizeof(m_dirHuman)) == 0; }
+										///< Determine Human68k directory entry match
+
+	// Path name operations
+	static const uint8_t* SeparateExt(const uint8_t* szHuman);			///< Extract extension from Human68k file name
+
+private:
+	static uint8_t* CopyName(uint8_t* pWrite, const uint8_t* pFirst, const uint8_t* pLast);
+										///< Copy Human68k file name elements
+
+	const uint8_t* m_pszHumanLast = nullptr;		///< Last position of the Human68k internal name of the relevant entry
+	const uint8_t* m_pszHumanExt = nullptr;		///< Position of the extension of the Human68k internal name of the relevant entry
+	bool m_bCorrect = false;			///< TRUE if the relevant entry of the Human68k internal name is correct
+	uint8_t m_szHuman[24];			///< Human68k internal name of the relevant entry
+	Human68k::dirent_t m_dirHuman;		///< All information for the Human68k relevant entry
+	TCHAR m_szHost[FILEPATH_MAX];		///< The host name of the relevant entry (variable length)
+};
+
+//===========================================================================
+//
+/// Directory entry: path name
+///
+/// A file path in Human68k always begings with / and ends with /
+/// They don't hold unit numbers.
+/// Include the base path part of the name on the host side for a performance boost.
+//
+//===========================================================================
+/** @note
+Most Human68k applications are written in a way that expects time stamps not to
+get updated for new directories created as a result of file operations, which
+triggers updates to directory entires.
+However, on the host file system, new directories do typically get an updated time stamp.
+
+The unfortunate outcome is that when copying a directory for instance, the time stamp
+will get overwritten even if the application did not intend for the time stamp to get updated.
+
+Here follows an implementation of a directory cache FAT time stamp  emulation feature.
+At the time of a file system update on the host side, time stamp information will be restored
+in order to achieve expected behavior on the Human68k side.
+*/
+class CHostPath: public CRing {
+	/// For memory management
+	struct ring_t {
+		CRing r;
+		CHostFilename f;
+	};
+
+public:
+	/// Search buffer
+	struct find_t {
+		uint32_t count;			///< Search execution count + 1 (When 0 the below value is invalid)
+		uint32_t id;			///< Entry unique ID for the path of the next search
+		const ring_t* pos;		///< Position of the next search (When identical to unique ID)
+		Human68k::dirent_t entry;	///< Contents of the next seach entry
+
+		void  Clear() { count = 0; }	///< Initialize
+	};
+
+	CHostPath() = default;
+	~CHostPath();
+	CHostPath(CHostPath&) = default;
+	CHostPath& operator=(const CHostPath&) = default;
+
+	void Clean();								///< Initialialize for reuse
+
+	void SetHuman(const uint8_t* szHuman);					///< Directly specify the name on the Human68k side
+	void SetHost(const TCHAR* szHost);					///< Directly specify the name on the host side
+	bool isSameHuman(const uint8_t* szHuman) const;				///< Compare the name on the Human68k side
+	bool isSameChild(const uint8_t* szHuman) const;				///< Compare the name on the Human68k side
+	const TCHAR* GetHost() const { return m_szHost; }	///< Obtain the name on the host side
+	const CHostFilename* FindFilename(const uint8_t* szHuman, uint32_t nHumanAttribute = Human68k::AT_ALL) const;
+										///< Find file name
+	const CHostFilename* FindFilenameWildcard(const uint8_t* szHuman, uint32_t nHumanAttribute, find_t* pFind) const;
+										///< Find file name (with support for wildcards)
+	bool isRefresh() const;							///< Check that the file change has been done
+	void Refresh();							///< Refresh file
+	void Backup();								/// Backup the time stamp on the host side
+	void Restore() const;							/// Restore the time stamp on the host side
+	void Release();							///< Update
+
+	// CHostEntry is an external API that we use
+	static void InitId() { g_nId = 0; }					///< Initialize the counter for the unique ID generation
+
+private:
+	static ring_t* Alloc(size_t nLength);					///< Allocate memory for the file name
+	static void Free(ring_t* pRing);					///< Release memory for the file name
+	static int Compare(const uint8_t* pFirst, const uint8_t* pLast, const uint8_t* pBufFirst, const uint8_t* pBufLast);
+										///< Compare string (with support for wildcards)
+
+	CRing m_cRing;								///< For CHostFilename linking
+	time_t m_tBackup = 0;					///< For time stamp restoration
+	bool m_bRefresh = true;						///< Refresh flag
+	uint32_t m_nId = 0;								///< Unique ID (When the value has changed, it means an update has been made)
+	uint8_t m_szHuman[HUMAN68K_PATH_MAX];					///< The internal Human68k name for the relevant entry
+	TCHAR m_szHost[FILEPATH_MAX];						///< The host side name for the relevant entry
+
+	static uint32_t g_nId;							///< Counter for the unique ID generation
+};
+
+//===========================================================================
+//
+/// File search processing
+///
+/// It's pretty much impossible to process Human68k file names as Unicode internally.
+/// So, we carry out binary conversion for processing. We leave it up to the
+/// directory entry cache to handle the conversion, which allows WINDRV to read
+/// everything as Shift-JIS. Additionally, it allows Human68k names to be
+/// fully independent of base path assignments.
+///
+/// We create directory entry cache just before file handling.
+/// Since creating directory entires is very costly, we try to reuse created entries
+/// as much as humanly possible.
+///
+/// There are three kinds of file search. They are all processed in CHostFiles::Find()
+/// 1. Search by path name only; the only attribute is 'directory'; _CHKDIR _CREATE
+/// 2. Path + file name + attribute search; _OPEN
+/// 3. Path + wildcard + attribute search; _FILES _NFILES
+/// The search results are kept as directory entry data.
+//
+//===========================================================================
+class CHostFiles {
+public:
+	CHostFiles() = default;
+	~CHostFiles() = default;
+
+	void Init();
+
+	void SetKey(uint32_t nKey) { m_nKey = nKey; }			///< Set search key
+	bool isSameKey(uint32_t nKey) const { return m_nKey == nKey; }	///< Compare search key
+	void SetPath(const Human68k::namests_t* pNamests);				///< Create path and file name internally
+	bool isRootPath() const { return m_szHumanPath[1] == '\0'; }			///< Check if root directory
+	void SetPathWildcard() { m_nHumanWildcard = 1; }				///< Enable file search using wildcards
+	void SetPathOnly() { m_nHumanWildcard = 0xFF; }				///< Enable only path names
+	bool isPathOnly() const { return m_nHumanWildcard == 0xFF; }			///< Check if set to only path names
+	void SetAttribute(uint32_t nHumanAttribute) { m_nHumanAttribute = nHumanAttribute; }	///< Set search attribute
+	bool Find(uint32_t nUnit, const class CHostEntry* pEntry);				///< Find files on the Human68k side, generating data on the host side
+	const CHostFilename* Find(const CHostPath* pPath);					///< Find file name
+	void SetEntry(const CHostFilename* pFilename);					///< Store search results on the Human68k side
+	void SetResult(const TCHAR* szPath);						///< Set names on the host side
+	void AddResult(const TCHAR* szPath);						///< Add file name to the name on the host side
+	void AddFilename();								///< Add the new Human68k file name to the name on the host side
+
+	const TCHAR* GetPath() const { return m_szHostResult; }		///< Get the name on the host side
+
+	const Human68k::dirent_t* GetEntry() const { return &m_dirHuman; }///< Get Human68k directory entry
+
+	uint32_t GetAttribute() const { return m_dirHuman.attr; }		///< Get Human68k attribute
+	uint16_t GetDate() const { return m_dirHuman.date; }			///< Get Human68k date
+	uint16_t GetTime() const { return m_dirHuman.time; }			///< Get Human68k time
+	uint32_t GetSize() const { return m_dirHuman.size; }		///< Get Human68k file size
+	const uint8_t* GetHumanFilename() const { return m_szHumanFilename; }///< Get Human68k file name
+	const uint8_t* GetHumanResult() const { return m_szHumanResult; }	///< Get Human68k file name search results
+	const uint8_t* GetHumanPath() const { return m_szHumanPath; }	///< Get Human68k path name
+
+private:
+	uint32_t m_nKey = 0;						///< FILES buffer address for Human68k; 0 is unused
+	uint32_t m_nHumanWildcard = 0;				///< Human68k wildcard data
+	uint32_t m_nHumanAttribute = 0;			///< Human68k search attribute
+	CHostPath::find_t m_findNext = {};		///< Next search location data
+	Human68k::dirent_t m_dirHuman = {};		///< Search results: Human68k file data
+	uint8_t m_szHumanFilename[24] = {};		///< Human68k file name
+	uint8_t m_szHumanResult[24] = {};			///< Search results: Human68k file name
+	uint8_t m_szHumanPath[HUMAN68K_PATH_MAX] = {};	///< Human68k path name
+	TCHAR m_szHostResult[FILEPATH_MAX] = {};	///< Search results: host's full path name
+};
+
+//===========================================================================
+//
+/// File search memory manager
+//
+//===========================================================================
+class CHostFilesManager {
+public:
+#ifdef _DEBUG
+	~CHostFilesManager();
+#endif	// _DEBUG
+	void  Init();						///< Initialization (when the driver is installed)
+	void  Clean();						///< Release (when starting up or resetting)
+
+	CHostFiles*  Alloc(uint32_t nKey);
+	CHostFiles*  Search(uint32_t nKey);
+	void  Free(CHostFiles* pFiles);
+private:
+	/// For memory management
+	struct ring_t {
+		CRing r;
+		CHostFiles f;
+	};
+
+	CRing m_cRing;						///< For attaching to CHostFiles
+};
+
+//===========================================================================
+//
+/// FCB processing
+//
+//===========================================================================
+class CHostFcb {
+public:
+	CHostFcb() = default;
+	~CHostFcb() { Close(); }
+	CHostFcb(CHostFcb&) = default;
+	CHostFcb& operator=(const CHostFcb&) = default;
+
+	void Init();
+
+	void SetKey(uint32_t nKey) { m_nKey = nKey; }			///< Set search key
+	bool isSameKey(uint32_t nKey) const { return m_nKey == nKey; }	///< Compare search key
+	void SetUpdate() { m_bUpdate = true; }				///< Update
+	bool isUpdate() const { return m_bUpdate; }			///< Get update state
+	bool SetMode(uint32_t nHumanMode);						///< Set file open mode
+	void SetFilename(const TCHAR* szFilename);					///< Set file name
+	void SetHumanPath(const uint8_t* szHumanPath);					///< Set Human68k path name
+	const uint8_t* GetHumanPath() const { return m_szHumanPath; }	///< Get Human68k path name
+
+	bool Create(uint32_t nHumanAttribute, bool bForce);	///< Create file
+	bool Open();									///< Open file
+	uint32_t Read(uint8_t* pBuffer, uint32_t nSize);					///< Read file
+	uint32_t Write(const uint8_t* pBuffer, uint32_t nSize);					///< Write file
+	bool Truncate() const;								///< Truncate file
+	uint32_t Seek(uint32_t nOffset, Human68k::seek_t nHumanSeek);		///< Seek file
+	bool TimeStamp(uint32_t nHumanTime) const;						///< Set file time stamp
+	void Close();									///< Close file
+
+private:
+	uint32_t m_nKey = 0;								///< Human68k FCB buffer address (0 if unused)
+	bool m_bUpdate = false;							///< Update flag
+	FILE* m_pFile = nullptr;						///< Host side file object
+	const char* m_pszMode = nullptr;				///< Host side file open mode
+	bool m_bFlag = false;							///< Host side file open flag
+	uint8_t m_szHumanPath[HUMAN68K_PATH_MAX] = {};		///< Human68k path name
+	TCHAR m_szFilename[FILEPATH_MAX] = {};			///< Host side file name
+};
+
+//===========================================================================
+//
+/// FCB processing manager
+//
+//===========================================================================
+class CHostFcbManager {
+public:
+	#ifdef _DEBUG
+	~CHostFcbManager();
+	#endif	// _DEBUG
+	void  Init();								///< Initialization (when the driver is installed)
+	void  Clean() const;						///< Release (when starting up or resetting)
+
+	CHostFcb*  Alloc(uint32_t nKey);
+	CHostFcb*  Search(uint32_t nKey);
+	void  Free(CHostFcb* p);
+
+private:
+	/// For memory management
+	struct ring_t {
+		CRing r;
+		CHostFcb f;
+	};
+
+	CRing m_cRing;								///< For attaching to CHostFcb
+};
+
+//===========================================================================
+//
+/// Host side drive
+///
+/// Keeps the required data for each drive, managed in CHostEntry.
+//
+//===========================================================================
+class CHostDrv
+{
+public:
+	CHostDrv() = default;
+	~CHostDrv();
+	CHostDrv(CHostDrv&) = default;
+	CHostDrv& operator=(const CHostDrv&) = default;
+
+	void Init(const TCHAR* szBase, uint32_t nFlag);				///< Initialization (device startup and load)
+
+	bool isWriteProtect() const { return m_bWriteProtect; }
+	bool isEnable() const { return m_bEnable; }		///< Is it accessible?
+	bool isMediaOffline() const;
+	uint8_t GetMediaByte() const;
+	uint32_t GetStatus() const;
+	void SetEnable(bool);						///< Set media status
+	bool CheckMedia();							///< Check if media was changed
+	void Update();								///< Update media status
+	void Eject();
+	void GetVolume(TCHAR* szLabel);					///< Get volume label
+	bool GetVolumeCache(TCHAR* szLabel) const;				///< Get volume label from cache
+	uint32_t GetCapacity(Human68k::capacity_t* pCapacity);
+	bool GetCapacityCache(Human68k::capacity_t* pCapacity) const;		///< Get capacity from cache
+
+	// Cache operations
+	void CleanCache() const;							///< Update all cache
+	void CleanCache(const uint8_t* szHumanPath);				///< Update cache for the specified path
+	void CleanCacheChild(const uint8_t* szHumanPath) const;	///< Update all cache below the specified path
+	void DeleteCache(const uint8_t* szHumanPath);				///< Delete the cache for the specified path
+	CHostPath* FindCache(const uint8_t* szHuman);				///< Inspect if the specified path is cached
+	CHostPath* CopyCache(CHostFiles* pFiles);				///< Acquire the host side name on the basis of cache information
+	CHostPath* MakeCache(CHostFiles* pFiles);				///< Get all required data to construct a host side name
+	bool Find(CHostFiles* pFiles);						///< Find host side name (path + file name (can be abbreviated) + attribute)
+
+private:
+	// Path name operations
+	static const uint8_t*  SeparateCopyFilename(const uint8_t* szHuman, uint8_t* szBuffer);
+										///< Split and copy the first element of the Human68k full path name
+
+	/// For memory management
+	struct ring_t {
+		CRing r;
+		CHostPath f;
+	};
+
+	bool m_bWriteProtect = false;						///< TRUE if write-protected
+	bool m_bEnable = false;							///< TRUE if media is usable
+	uint32_t m_nRing = 0;							///< Number of stored path names
+	CRing m_cRing;							///< For attaching to CHostPath
+	Human68k::capacity_t m_capCache;				///< Sector data cache: if "sectors == 0" then not cached
+	bool m_bVolumeCache = false;						///< TRUE if the volume label has been read
+	TCHAR m_szVolumeCache[24] = {};					///< Volume label cache
+	TCHAR m_szBase[FILEPATH_MAX] = {};					///< Base path
+};
+
+//===========================================================================
+//
+/// Directory entry management
+//
+//===========================================================================
+class CHostEntry {
+
+public:
+
+	/// Max number of drive candidates
+	static const int DRIVE_MAX = 10;
+
+	CHostEntry() = default;
+	~CHostEntry();
+	CHostEntry(CHostEntry&) = default;
+	CHostEntry& operator=(const CHostEntry&) = default;
+
+	void Init() const;							///< Initialization (when the driver is installed)
+	void Clean();								///< Release (when starting up or resetting)
+
+	// Cache operations
+	void CleanCache() const;							///< Update all cache
+	void CleanCache(uint32_t nUnit) const;						///< Update cache for the specified unit
+	void CleanCache(uint32_t nUnit, const uint8_t* szHumanPath) const;	///< Update cache for the specified path
+	void CleanCacheChild(uint32_t nUnit, const uint8_t* szHumanPath) const;	///< Update cache below the specified path
+	void DeleteCache(uint32_t nUnit, const uint8_t* szHumanPath) const;	///< Delete cache for the specified path
+	bool Find(uint32_t nUnit, CHostFiles* pFiles) const;				///< Find host side name (path + file name (can be abbreviated) + attribute)
+	void ShellNotify(uint32_t nEvent, const TCHAR* szPath);			///< Notify status change in the host side file system
+
+	// Drive object operations
+	void SetDrv(uint32_t nUnit, CHostDrv* pDrv);
+	bool isWriteProtect(uint32_t nUnit) const;
+	bool isEnable(uint32_t nUnit) const;					///< Is it accessible?
+	bool isMediaOffline(uint32_t nUnit) const;
+	uint8_t GetMediaByte(uint32_t nUnit) const;
+	uint32_t GetStatus(uint32_t nUnit) const;					///< Get drive status
+	bool CheckMedia(uint32_t nUnit) const;						///< Media change check
+	void Eject(uint32_t nUnit) const;
+	void GetVolume(uint32_t nUnit, TCHAR* szLabel) const;				///< Get volume label
+	bool GetVolumeCache(uint32_t nUnit, TCHAR* szLabel) const;		///< Get volume label from cache
+	uint32_t GetCapacity(uint32_t nUnit, Human68k::capacity_t* pCapacity) const;
+	bool GetCapacityCache(uint32_t nUnit, Human68k::capacity_t* pCapacity) const;		///< Get cluster size from cache
+
+private:
+
+	CHostDrv* m_pDrv[DRIVE_MAX] = {};				///< Host side drive object
+	uint32_t m_nTimeout = 0;							///< Last time a timeout check was carried out
+};
+
+//===========================================================================
+//
+/// Host side file system
+//
+//===========================================================================
+/** @note
+Current state of affairs:
+
+While it violates the design philosophy of XM6, we should find a way for
+'class Windrv' and 'class CWindrv' to have a direct pointer to 'class CFileSys'.
+This way, we get the following benefits.
+
+Benefit no. 1
+Makes it possible to manage a large number of command handler methods in one place.
+There is a high chance the command handlers will change drastically because of
+host system architectural changes, so we will save a huge amount of maintenance work
+in the long run.
+
+Benefit no. 2
+We would get rid of virtual funcion code for processing table creation and lookup.
+It is not feasible to implement code in XM6 for simultaneous use of file system objects.
+Therefore file system object polymorphism is a waste of CPU cycles.
+
+I made the change as an experiment. Performance did improve.
+The improvement was obvious from looking at the source the compiler spit out
+after changing the FILESYS_FAST_STRUCTURE value in windrv.h.
+You may understand now why I decided to rant here.
+
+The easy solution is to put the content of 'class CFileSys' into 'class CWindrv'.
+(To be honest, I really want to deprecate 'class CHost'... I wonder if there's a good way...)
+*/
+class CFileSys
+{
+public:
+	CFileSys() = default;
+	virtual ~CFileSys() = default;
+
+	void Reset();								///< Reset (close all)
+	void Init();								///< Initialization (device startup and load)
+
+	// Command handlers
+	uint32_t InitDevice(const Human68k::argument_t* pArgument);		///< $40 - Device startup
+	int CheckDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const;		///< $41 - Directory check
+	int MakeDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const;		///< $42 - Create directory
+	int RemoveDir(uint32_t nUnit, const Human68k::namests_t* pNamests) const;	///< $43 - Delete directory
+	int Rename(uint32_t nUnit, const Human68k::namests_t* pNamests, const Human68k::namests_t* pNamestsNew) const;
+										///< $44 - Change file name
+	int Delete(uint32_t nUnit, const Human68k::namests_t* pNamests) const;		///< $45 - Delete file
+	int Attribute(uint32_t nUnit, const Human68k::namests_t* pNamests, uint32_t nHumanAttribute) const;
+										///< $46 - Get / set file attribute
+	int Files(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::files_t* pFiles);
+										///< $47 - Find file
+	int NFiles(uint32_t nUnit, uint32_t nKey, Human68k::files_t* pFiles);		///< $48 - Find next file
+	int Create(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::fcb_t* pFcb, uint32_t nHumanAttribute, bool bForce);
+										///< $49 - Create file
+	int Open(uint32_t nUnit, uint32_t nKey, const Human68k::namests_t* pNamests, Human68k::fcb_t* pFcb);
+										///< $4A - Open file
+	int Close(uint32_t nUnit, uint32_t nKey, const Human68k::fcb_t* pFcb);		///< $4B - Close file
+	int Read(uint32_t nKey, Human68k::fcb_t* pFcb, uint8_t* pAddress, uint32_t nSize);
+										///< $4C - Read file
+	int Write(uint32_t nKey, Human68k::fcb_t* pFcb, const uint8_t* pAddress, uint32_t nSize);
+										///< $4D - Write file
+	int Seek(uint32_t nKey, Human68k::fcb_t* pFcb, uint32_t nSeek, int nOffset);	///< $4E - Seek file
+	uint32_t TimeStamp(uint32_t nUnit, uint32_t nKey, Human68k::fcb_t* pFcb, uint32_t nHumanTime);
+										///< $4F - Get / set file timestamp
+	int GetCapacity(uint32_t nUnit, Human68k::capacity_t* pCapacity) const;		///< $50 - Get capacity
+	int CtrlDrive(uint32_t nUnit, Human68k::ctrldrive_t* pCtrlDrive) const;		///< $51 - Inspect / control drive status
+	int GetDPB(uint32_t nUnit, Human68k::dpb_t* pDpb) const;				///< $52 - Get DPB
+	int DiskRead(uint32_t nUnit, uint8_t* pBuffer, uint32_t nSector, uint32_t nSize);	///< $53 - Read sectors
+	int DiskWrite(uint32_t nUnit) const;						///< $54 - Write sectors
+	int Ioctrl(uint32_t nUnit, uint32_t nFunction, Human68k::ioctrl_t* pIoctrl);	///< $55 - IOCTRL
+	int Flush(uint32_t nUnit) const;							///< $56 - Flush
+	int CheckMedia(uint32_t nUnit) const;						///< $57 - Media change check
+	int Lock(uint32_t nUnit) const;							///< $58 - Lock
+
+	void SetOption(uint32_t nOption);						///< Set option
+	uint32_t GetOption() const { return m_nOption; }		///< Get option
+	uint32_t GetDefault() const { return m_nOptionDefault; }	///< Get default options
+	static uint32_t GetFileOption() { return g_nOption; }			///< Get file name change option
+
+	static const int DriveMax = CHostEntry::DRIVE_MAX;			///< Max number of drive candidates
+
+private:
+	void InitOption(const Human68k::argument_t* pArgument);
+	bool FilesVolume(uint32_t nUnit, Human68k::files_t* pFiles) const;		///< Get volume label
+
+	uint32_t m_nUnits = 0;								///< Number of current drive objects (Changes for every resume)
+
+	uint32_t m_nOption = 0;							///< Current runtime flag
+	uint32_t m_nOptionDefault = 0;						///< Runtime flag at reset
+
+	uint32_t m_nDrives = 0;							///< Number of candidates for base path status restoration (scan every time if 0)
+
+	uint32_t m_nKernel = 0;							///< Counter for kernel check
+	uint32_t m_nKernelSearch = 0;						///< Initial address for NUL device
+
+	uint32_t m_nHostSectorCount = 0;					///< Virtual sector identifier
+
+	CHostFilesManager m_cFiles;						///< File search memory
+	CHostFcbManager m_cFcb;							///< FCB operation memory
+	CHostEntry m_cEntry;							///< Drive object and directory entry
+
+	uint32_t m_nHostSectorBuffer[XM6_HOST_PSEUDO_CLUSTER_MAX];
+										///< Entity that the virtual sector points to
+
+	uint32_t m_nFlag[DriveMax] = {};					///< Candidate runtime flag for base path restoration
+	TCHAR m_szBase[DriveMax][FILEPATH_MAX] = {};	///< Candidate for base path restoration
+	static uint32_t g_nOption;							///< File name change flag
+};

--- a/cpp/devices/ctapdriver.cpp
+++ b/cpp/devices/ctapdriver.cpp
@@ -18,6 +18,7 @@
 #include <spdlog/spdlog.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 
@@ -106,22 +107,22 @@ bool CTapDriver::Init(const param_map& const_params)
 			return false;
 		}
 		if (*configured_uplink != interface) {
-			spdlog::error("DaynaPort proxy-ARP interface '" + interface + "' does not match configured uplink '" +
+			spdlog::error("PiSCSI proxy-ARP interface '" + interface + "' does not match configured uplink '" +
 					*configured_uplink + "'");
 			return false;
 		}
 	}
 
 	if (m_hTAP != -1) {
-		spdlog::error("DaynaPort TAP device is already active");
+		spdlog::error("PiSCSI TAP device piscsi0 is already active");
 		return false;
 	}
 	const auto interface_mac = GetMacAddress(interface);
-	if (interface_mac.size() != m_MacAddr.size()) {
-		spdlog::error("Can't determine the MAC address of DaynaPort network interface '" + interface + "'");
+	if (interface_mac.size() != m_UplinkMac.size()) {
+		spdlog::error("Can't determine the MAC address of PiSCSI network interface '" + interface + "'");
 		return false;
 	}
-	m_MacAddr = DeriveDaynaPortMac(interface_mac);
+	copy_n(interface_mac.begin(), m_UplinkMac.size(), m_UplinkMac.begin());
 
 	if (!CreateTap()) {
 		return false;
@@ -141,8 +142,8 @@ bool CTapDriver::Init(const param_map& const_params)
 		}
 	}
 
-	spdlog::info("Tap device piscsi0 created for DaynaPort " + mode + " mode (TAP MAC " +
-			FormatMac(m_TapMac) + ", DaynaPort MAC " + FormatMac(m_MacAddr) + ")");
+	spdlog::info("PiSCSI TAP device piscsi0 created for " + mode + " mode (TAP MAC " +
+			FormatMac(m_TapMac) + ")");
 
 	return true;
 #endif
@@ -152,30 +153,30 @@ string CTapDriver::GetProfileValidationError(const string& mode, const string& i
 		const network_interface_map& interfaces)
 {
 	if (mode != DEFAULT_MODE && mode != "proxyarp") {
-		return "Unsupported DaynaPort network mode '" + mode + "'";
+		return "Unsupported PiSCSI network mode '" + mode + "'";
 	}
 	if (interfaces.contains("piscsi0")) {
-		return "DaynaPort TAP device piscsi0 is already in use";
+		return "PiSCSI TAP device piscsi0 is already in use";
 	}
 	if (!IsValidInterfaceName(interface)) {
-		return "Invalid DaynaPort network interface '" + interface + "'";
+		return "Invalid PiSCSI network interface '" + interface + "'";
 	}
 	if (mode == DEFAULT_MODE && interface != BRIDGE_NAME) {
-		return "DaynaPort bridge mode requires the pre-configured " + BRIDGE_NAME + " interface";
+		return "PiSCSI bridge mode requires the pre-configured " + BRIDGE_NAME + " interface";
 	}
 
 	const auto it = interfaces.find(interface);
 	if (it == interfaces.end()) {
-		return "DaynaPort network interface '" + interface + "' does not exist";
+		return "PiSCSI network interface '" + interface + "' does not exist";
 	}
 	if (!it->second.up) {
-		return "DaynaPort network interface '" + interface + "' is down";
+		return "PiSCSI network interface '" + interface + "' is down";
 	}
 	if (mode == DEFAULT_MODE && it->second.type != NetworkInterfaceType::BRIDGE) {
-		return "DaynaPort bridge mode requires " + BRIDGE_NAME + " to be a Linux bridge";
+		return "PiSCSI bridge mode requires " + BRIDGE_NAME + " to be a Linux bridge";
 	}
 	if (mode == "proxyarp" && it->second.type != NetworkInterfaceType::WIFI) {
-		return "DaynaPort proxyarp mode requires an active Wi-Fi interface";
+		return "PiSCSI proxyarp mode requires an active Wi-Fi interface";
 	}
 
 	return "";
@@ -303,11 +304,11 @@ void CTapDriver::Flush() const
 	}
 }
 
-void CTapDriver::GetMacAddr(uint8_t *mac) const
+void CTapDriver::GetUplinkMacAddr(uint8_t *mac) const
 {
 	assert(mac);
 
-	memcpy(mac, m_MacAddr.data(), m_MacAddr.size());
+	memcpy(mac, m_UplinkMac.data(), m_UplinkMac.size());
 }
 
 bool CTapDriver::HasPendingPackets() const
@@ -335,17 +336,6 @@ uint32_t CTapDriver::Crc32(span<const uint8_t> data) {
       }
    }
    return ~crc;
-}
-
-array<uint8_t, 6> CTapDriver::DeriveDaynaPortMac(span<const uint8_t> interface_mac)
-{
-	if (interface_mac.size() != 6) {
-		return {};
-	}
-
-	// Retain the Dayna OUI and derive the unique suffix from
-	// the selected bridge or proxy-ARP uplink.
-	return { 0x00, 0x80, 0x19, interface_mac[3], interface_mac[4], interface_mac[5] };
 }
 
 int CTapDriver::Receive(uint8_t *buf) const

--- a/cpp/devices/ctapdriver.h
+++ b/cpp/devices/ctapdriver.h
@@ -47,7 +47,9 @@ public:
 	param_map GetDefaultParams() const;
 	static string GetProfileValidationError(const string&, const string&, const network_util::network_interface_map&);
 
-	void GetMacAddr(uint8_t *) const;
+	// The selected bridge or proxy-ARP uplink MAC is transport information.
+	// Each emulated Ethernet device derives its own client MAC from it.
+	void GetUplinkMacAddr(uint8_t *) const;
 	int Receive(uint8_t *) const;
 	int Send(const uint8_t *, int) const;
 	bool HasPendingPackets() const;		// Check if there are IP packets available
@@ -55,8 +57,6 @@ public:
 	void Flush() const;			// Purge all of the packets that are waiting to be processed
 
 	static uint32_t Crc32(span<const uint8_t>);
-	static array<uint8_t, 6> DeriveDaynaPortMac(span<const uint8_t>);
-
 private:
 
 	bool CreateTap();
@@ -64,9 +64,7 @@ private:
 	string AttachTapToBridge();
 	void ReleaseTap();
 
-	// The kernel TAP port and emulated DaynaPort must use different MACs. A
-	// bridge treats a port's MAC as local and will not forward frames for it.
-	array<uint8_t, 6> m_MacAddr {};
+	array<uint8_t, 6> m_UplinkMac {};
 #ifdef __linux__
 	array<uint8_t, 6> m_TapMac {};
 #endif

--- a/cpp/devices/device_factory.cpp
+++ b/cpp/devices/device_factory.cpp
@@ -14,6 +14,7 @@
 #include "scsimo.h"
 #include "scsicd.h"
 #include "scsi_printer.h"
+#include "scsi_host_bridge.h"
 #include "scsi_daynaport.h"
 #include "host_services.h"
 #include "device_factory.h"
@@ -80,6 +81,11 @@ shared_ptr<PrimaryDevice> DeviceFactory::CreateDevice(PbDeviceType type, int lun
 		device = make_shared<SCSICD>(lun,
             GetExtensionLowerCase(filename) == "is1" ? scsi_level::scsi_1_ccs : scsi_level::scsi_2);
 		device->SetProduct("SCSI CD-ROM");
+		break;
+
+	case SCBR:
+		device = make_shared<SCSIBR>(lun);
+		device->SetProduct("RASCSI BRIDGE");
 		break;
 
 	case SCDP:

--- a/cpp/devices/device_factory.h
+++ b/cpp/devices/device_factory.h
@@ -53,6 +53,7 @@ private:
 	};
 
 	const inline static unordered_map<string, PbDeviceType, piscsi_util::StringHash, equal_to<>> DEVICE_MAPPING = {
+			{ "bridge", SCBR },
 			{ "daynaport", SCDP },
 			{ "printer", SCLP },
 			{ "services", SCHS }

--- a/cpp/devices/scsi_daynaport.cpp
+++ b/cpp/devices/scsi_daynaport.cpp
@@ -62,8 +62,9 @@ bool SCSIDaynaPort::Init(const param_map& params)
 		return false;
 #endif
 	} else {
-		array<uint8_t, 6> mac = {};
-		tap.GetMacAddr(mac.data());
+		array<uint8_t, 6> uplink_mac = {};
+		tap.GetUplinkMacAddr(uplink_mac.data());
+		const auto mac = DeriveMac(uplink_mac);
 		memcpy(m_scsi_link_stats.mac_address.data(), mac.data(), mac.size());
 		LogTrace("Tap interface created");
 	}
@@ -73,6 +74,17 @@ bool SCSIDaynaPort::Init(const param_map& params)
 	SetReset(false);
 
 	return true;
+}
+
+array<uint8_t, 6> SCSIDaynaPort::DeriveMac(span<const uint8_t> uplink_mac)
+{
+	if (uplink_mac.size() != 6) {
+		return {};
+	}
+
+	// Retain the Dayna OUI and derive the unique suffix from the selected
+	// bridge or proxy-ARP uplink.
+	return { 0x00, 0x80, 0x19, uplink_mac[3], uplink_mac[4], uplink_mac[5] };
 }
 
 void SCSIDaynaPort::CleanUp()

--- a/cpp/devices/scsi_daynaport.h
+++ b/cpp/devices/scsi_daynaport.h
@@ -74,6 +74,7 @@ public:
 	void EnableInterface() const;
 
 	vector<PbStatistics> GetStatistics() const override;
+	static array<uint8_t, 6> DeriveMac(span<const uint8_t>);
 
 	static const int DAYNAPORT_BUFFER_SIZE = 0x1000000;
 

--- a/cpp/devices/scsi_host_bridge.cpp
+++ b/cpp/devices/scsi_host_bridge.cpp
@@ -1,0 +1,1238 @@
+//---------------------------------------------------------------------------
+//
+//	SCSI Target Emulator PiSCSI
+//	for Raspberry Pi
+//
+//	Copyright (C) 2001-2006 ＰＩ．(ytanaka@ipc-tokai.or.jp)
+//	Copyright (C) 2014-2020 GIMONS
+//	Copyright (C) akuker
+//
+//	Licensed under the BSD 3-Clause License.
+//	See LICENSE file in the project root folder.
+//
+//	[ SCSI Host Bridge for the Sharp X68000 ]
+//
+//  Note: This requires a special driver on the host system and will only
+//        work with the Sharp X68000 operating system.
+//---------------------------------------------------------------------------
+
+#include "shared/piscsi_exceptions.h"
+#include "scsi_command_util.h"
+#include "scsi_host_bridge.h"
+#include <arpa/inet.h>
+#include <algorithm>
+
+using namespace std;
+using namespace scsi_defs;
+using namespace scsi_command_util;
+
+SCSIBR::SCSIBR(int lun) : PrimaryDevice(SCBR, lun)
+{
+	SupportsParams(true);
+}
+
+bool SCSIBR::Init(const param_map& params)
+{
+	PrimaryDevice::Init(params);
+
+	// Create host file system
+	fs.Reset();
+
+	AddCommand(scsi_command::eCmdTestUnitReady, [this] { TestUnitReady(); });
+	// The X68000 bridge protocol overloads READ(10) and WRITE(10), using
+	// bytes 2, 3 and 9 as type, function and phase and bytes 6--8 as a
+	// three-byte byte count. RASCTL, RASDRV and RASETHER all use these opcodes.
+	AddCommand(scsi_command::eCmdRead10, [this] { GetMessage10(); });
+	AddCommand(scsi_command::eCmdWrite10, [this] { SendMessage10(); });
+
+#ifdef __linux__
+	tap_enabled = tap.Init(GetParams());
+	if (!tap_enabled){
+		return false;
+	}
+#endif
+
+	// Generate MAC Address
+	if (tap_enabled) {
+		array<uint8_t, 6> uplink_mac = {};
+		tap.GetUplinkMacAddr(uplink_mac.data());
+		mac_addr = DeriveMac(uplink_mac);
+	}
+
+	// Packet reception flag OFF
+	packet_enable = false;
+
+	SetReady(tap_enabled);
+
+// Not terminating on regular Linux PCs is helpful for testing
+#if defined(__x86_64__) || defined(__X86__)
+	return true;
+#else
+	return tap_enabled;
+#endif
+}
+
+array<uint8_t, 6> SCSIBR::DeriveMac(span<const uint8_t> uplink_mac)
+{
+	if (uplink_mac.size() != 6) {
+		return {};
+	}
+
+	// The X68000 driver treats this as its sole mutable hardware address. Use
+	// a deterministic locally administered unicast address, distinct from the
+	// physical uplink, bridge, and kernel TAP MAC addresses.
+	uint64_t suffix = 14695981039346656037ULL;
+	for (const uint8_t byte : uplink_mac) {
+		suffix = (suffix ^ byte) * 1099511628211ULL;
+	}
+	return { 0x02, static_cast<uint8_t>(suffix >> 32), static_cast<uint8_t>(suffix >> 24),
+			static_cast<uint8_t>(suffix >> 16), static_cast<uint8_t>(suffix >> 8), static_cast<uint8_t>(suffix) };
+}
+
+void SCSIBR::CleanUp()
+{
+	tap.CleanUp();
+}
+
+vector<uint8_t> SCSIBR::InquiryInternal() const
+{
+	vector<uint8_t> buf = HandleInquiry(device_type::communications, scsi_level::scsi_2, false);
+
+	// The bridge returns more additional bytes than the other devices
+	buf.resize(0x1F + 8 + 5);
+
+	buf[4] = 0x1F + 8;
+
+	// RASCTL uses this flag to discover a bridge with its type-0 control channel.
+	// The control channel is disabled by default because it has no authentication.
+	if (IsRasctlControlEnabled()) {
+		buf[36] = '1';
+	}
+
+	// TAP Enable
+	if (tap_enabled) {
+		buf[37] = '1';
+	}
+
+	// CFileSys Enable
+	buf[38] = '1';
+
+	return buf;
+}
+
+void SCSIBR::TestUnitReady()
+{
+	// Always successful
+	EnterStatusPhase();
+}
+
+int SCSIBR::GetMessage10(cdb_t cdb, vector<uint8_t>& buf)
+{
+	// Type
+	const int type = cdb[2];
+
+	// Function number
+	const int func = cdb[3];
+
+	// Phase
+	const int phase = cdb[9];
+	const int len = GetInt24(cdb, 6);
+
+	switch (type) {
+		case 0: { // RASCTL compatibility control channel
+			if (!IsRasctlControlEnabled()) {
+				return 0;
+			}
+
+			const size_t response_length = min(static_cast<size_t>(len), buf.size());
+			fill_n(buf.begin(), response_length, 0);
+			memcpy(buf.data(), rasctl_control_response.data(), min(response_length, rasctl_control_response.size()));
+			rasctl_shutdown_ready = rasctl_shutdown != rasctl_shutdown_mode::none;
+			return len;
+		}
+
+		case 1:		// Ethernet
+			// Do not process if TAP is invalid
+			if (!tap_enabled) {
+				return 0;
+			}
+
+			switch (func) {
+				case 0:		// Get MAC address
+					return GetMacAddr(buf);
+
+				case 1:		// Received packet acquisition (size/buffer)
+					if (phase == 0) {
+						// Get packet size
+						ReceivePacket();
+						SetInt16(buf, 0, packet_len);
+						return 2;
+					} else {
+						// Get package data
+						GetPacketBuf(buf, 0);
+						return packet_len;
+					}
+
+				case 2:		// Received packet acquisition (size + buffer simultaneously)
+					ReceivePacket();
+					SetInt16(buf, 0, packet_len);
+					GetPacketBuf(buf, 2);
+					return packet_len + 2;
+
+				case 3:	{
+					// Simultaneous acquisition of multiple packets (size + buffer simultaneously)
+					// Currently the maximum number of packets is 10
+					// Isn't it too fast if I increase more?
+					int total_len = 0;
+					for (int i = 0; i < 10; i++) {
+						ReceivePacket();
+						SetInt16(buf, total_len, packet_len);
+						total_len += 2;
+						if (packet_len == 0)
+							break;
+						GetPacketBuf(buf, 0);
+						total_len += packet_len;
+					}
+					return total_len;
+				}
+
+				default:
+					assert(false);
+					return -1;
+			}
+			break;
+
+		case 2:		// Host Drive
+			switch (phase) {
+				case 0:		// Get result code
+					return ReadFsResult(buf);
+
+				case 1:		// Return data acquisition
+					return ReadFsOut(buf);
+
+				case 2:		// Return additional data acquisition
+					return ReadFsOpt(buf);
+
+				default:
+					break;
+			}
+			break;
+
+			default:
+				break;
+	}
+
+	// Error
+	assert(false);
+	return 0;
+}
+
+bool SCSIBR::ReadWrite(cdb_t cdb, vector<uint8_t>& buf)
+{
+	// Type
+	const int type = cdb[2];
+
+	// Function number
+	const int func = cdb[3];
+
+	// Phase
+	const int phase = cdb[9];
+
+	// Get the number of lights
+	const int len = GetInt24(cdb, 6);
+
+	switch (type) {
+		case 0: { // RASCTL compatibility control channel
+			if (!IsRasctlControlEnabled()) {
+				return false;
+			}
+
+			const size_t command_length = min(static_cast<size_t>(len), buf.size());
+			const char *command = reinterpret_cast<const char *>(buf.data());
+			rasctl_control_request = string(command, strnlen(command, command_length));
+			rasctl_control_response.clear();
+			rasctl_shutdown = rasctl_shutdown_mode::none;
+			rasctl_shutdown_ready = false;
+			return true;
+		}
+
+		case 1:		// Ethernet
+			// Do not process if TAP is invalid
+			if (!tap_enabled) {
+				return false;
+			}
+
+			switch (func) {
+				case 0:
+					SetMacAddr(buf);
+					return true;
+
+				case 1:
+					SendPacket(buf, len);
+					return true;
+
+				default:
+					break;
+			}
+			break;
+
+		case 2:		// Host drive
+			switch (phase) {
+				case 0:		// issue command
+					WriteFs(func, buf);
+					return true;
+
+				case 1:		// additional data writing
+					WriteFsOpt(buf, len);
+					return true;
+
+				default:
+					break;
+			}
+			break;
+
+			default:
+		break;
+	}
+
+	assert(false);
+	return false;
+}
+
+optional<string> SCSIBR::TakeRasctlControlRequest()
+{
+	return exchange(rasctl_control_request, nullopt);
+}
+
+void SCSIBR::SetRasctlControlResponse(string response, rasctl_shutdown_mode shutdown_mode)
+{
+	rasctl_control_response = std::move(response);
+	rasctl_shutdown = shutdown_mode;
+}
+
+SCSIBR::rasctl_shutdown_mode SCSIBR::TakeRasctlShutdownMode()
+{
+	if (!rasctl_shutdown_ready) {
+		return rasctl_shutdown_mode::none;
+	}
+
+	rasctl_shutdown_ready = false;
+	return exchange(rasctl_shutdown, rasctl_shutdown_mode::none);
+}
+
+void SCSIBR::GetMessage10()
+{
+	// Ensure a sufficient buffer size (because it is not a transfer for each block)
+	GetController()->AllocateBuffer(0x1000000);
+
+	GetController()->SetLength(GetMessage10(GetController()->GetCmd(), GetController()->GetBuffer()));
+	if (GetController()->GetLength() <= 0) {
+		throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
+	}
+
+	// Set next block
+	GetController()->SetBlocks(1);
+	GetController()->SetNext(1);
+
+	EnterDataInPhase();
+}
+
+//---------------------------------------------------------------------------
+//
+//	SEND MESSAGE(10)
+//
+//  This Send Message command is used by the X68000 host driver
+//
+//---------------------------------------------------------------------------
+void SCSIBR::SendMessage10() const
+{
+	GetController()->SetLength(GetInt24(GetController()->GetCmd(), 6));
+	if (GetController()->GetLength() <= 0) {
+		throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
+	}
+
+	// Ensure a sufficient buffer size (because it is not a transfer for each block)
+	GetController()->AllocateBuffer(0x1000000);
+
+	// Set next block
+	GetController()->SetBlocks(1);
+	GetController()->SetNext(1);
+
+	EnterDataOutPhase();
+}
+
+int SCSIBR::GetMacAddr(vector<uint8_t>& mac) const
+{
+	memcpy(mac.data(), mac_addr.data(), mac_addr.size());
+	return static_cast<int>(mac_addr.size());
+}
+
+void SCSIBR::SetMacAddr(span<const uint8_t> mac)
+{
+	memcpy(mac_addr.data(), mac.data(), mac_addr.size());
+}
+
+void SCSIBR::ReceivePacket()
+{
+	// previous packet has not been received
+	if (packet_enable) {
+		return;
+	}
+
+	// Receive packet
+	packet_len = tap.Receive(packet_buf.data());
+
+	// Check if received packet
+	if (memcmp(packet_buf.data(), mac_addr.data(), mac_addr.size()) != 0
+				&& memcmp(packet_buf.data(), bcast_addr.data(), bcast_addr.size()) != 0) {
+		packet_len = 0;
+	}
+
+	// RASETHER.SYS is based on a physical Ethernet adapter driver and expects
+	// a 60-byte Ethernet frame before the four-byte FCS. TAP can provide short
+	// local frames such as ARP without that wire-level padding.
+	if (packet_len >= ETH_FCS_LEN && packet_len < MINIMUM_FRAME_SIZE + ETH_FCS_LEN) {
+		fill(packet_buf.begin() + packet_len - ETH_FCS_LEN, packet_buf.begin() + MINIMUM_FRAME_SIZE, 0);
+		const uint32_t crc = CTapDriver::Crc32(span(packet_buf.data(), MINIMUM_FRAME_SIZE));
+		packet_buf[MINIMUM_FRAME_SIZE + 0] = static_cast<uint8_t>(crc >> 0);
+		packet_buf[MINIMUM_FRAME_SIZE + 1] = static_cast<uint8_t>(crc >> 8);
+		packet_buf[MINIMUM_FRAME_SIZE + 2] = static_cast<uint8_t>(crc >> 16);
+		packet_buf[MINIMUM_FRAME_SIZE + 3] = static_cast<uint8_t>(crc >> 24);
+		packet_len = MINIMUM_FRAME_SIZE + ETH_FCS_LEN;
+	}
+
+	// Discard if it exceeds the buffer size
+	if (packet_len > 2048) {
+		packet_len = 0;
+	}
+
+	// Store in receive buffer
+	if (packet_len > 0) {
+		packet_enable = true;
+	}
+}
+
+void SCSIBR::GetPacketBuf(vector<uint8_t>& buf, int index)
+{
+	// Size limit
+	int len = packet_len;
+	if (len > 2048) {
+		len = 2048;
+	}
+
+	// Copy
+	memcpy(buf.data() + index, packet_buf.data(), len);
+
+	// Received
+	packet_enable = false;
+}
+
+void SCSIBR::SendPacket(span<const uint8_t> buf, int len) const
+{
+	tap.Send(buf.data(), len);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $40 - Device Boot
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_InitDevice(vector<uint8_t>& buf)
+{
+	fs.Reset();
+	fsresult = fs.InitDevice((Human68k::argument_t*)buf.data());
+}
+
+//---------------------------------------------------------------------------
+//
+//  $41 - Directory Check
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_CheckDir(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	const int i = sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+
+	fsresult = fs.CheckDir(nUnit, pNamests);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $42 - Create Directory
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_MakeDir(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	const int i = sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+
+	fsresult = fs.MakeDir(nUnit, pNamests);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $43 - Remove Directory
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_RemoveDir(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	const int i = sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+
+	fsresult = fs.RemoveDir(nUnit, pNamests);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $44 - Rename
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Rename(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::namests_t);
+
+	const Human68k::namests_t *pNamestsNew = (Human68k::namests_t*)&(buf.data()[i]);
+
+	fsresult = fs.Rename(nUnit, pNamests, pNamestsNew);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $45 - Delete File
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Delete(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	const int i = sizeof(uint32_t);
+
+	const auto *pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+
+	fsresult = fs.Delete(nUnit, pNamests);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $46 - Get / Set file attributes
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Attribute(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::namests_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	uint32_t nHumanAttribute = ntohl(*dp);
+
+	fsresult = fs.Attribute(nUnit, pNamests, nHumanAttribute);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $47 - File Search
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Files(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::namests_t);
+
+	auto files = (Human68k::files_t*)&(buf.data()[i]);
+
+	files->sector = ntohl(files->sector);
+	files->offset = ntohs(files->offset);
+	files->time = ntohs(files->time);
+	files->date = ntohs(files->date);
+	files->size = ntohl(files->size);
+
+	fsresult = fs.Files(nUnit, nKey, pNamests, files);
+
+	files->sector = htonl(files->sector);
+	files->offset = htons(files->offset);
+	files->time = htons(files->time);
+	files->date = htons(files->date);
+	files->size = htonl(files->size);
+
+	i = 0;
+	memcpy(&fsout[i], files, sizeof(Human68k::files_t));
+	i += sizeof(Human68k::files_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $48 - File next search
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_NFiles(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto files = (Human68k::files_t*)&(buf.data()[i]);
+
+	files->sector = ntohl(files->sector);
+	files->offset = ntohs(files->offset);
+	files->time = ntohs(files->time);
+	files->date = ntohs(files->date);
+	files->size = ntohl(files->size);
+
+	fsresult = fs.NFiles(nUnit, nKey, files);
+
+	files->sector = htonl(files->sector);
+	files->offset = htons(files->offset);
+	files->time = htons(files->time);
+	files->date = htons(files->date);
+	files->size = htonl(files->size);
+
+	i = 0;
+	memcpy(&fsout[i], files, sizeof(Human68k::files_t));
+	i += sizeof(Human68k::files_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $49 - File Creation
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Create(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::namests_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::fcb_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nAttribute = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto bp = (int*)&(buf.data()[i]);
+	const uint32_t bForce = ntohl(*bp);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Create(nUnit, nKey, pNamests, pFcb, nAttribute, bForce);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4A - Open File
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Open(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	const auto pNamests = (Human68k::namests_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::namests_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Open(nUnit, nKey, pNamests, pFcb);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4B - Close File
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Close(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Close(nUnit, nKey, pFcb);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4C - Read File
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Read(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nKey = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::fcb_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nSize = ntohl(*dp);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Read(nKey, pFcb, fsopt.data(), nSize);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+
+	fsoptlen = fsresult;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4D - Write file
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Write(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nKey = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::fcb_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nSize = ntohl(*dp);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Write(nKey, pFcb, fsopt.data(), nSize);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4E - Seek file
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Seek(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nKey = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::fcb_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nMode = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto ip = (const int*)&(buf.data()[i]);
+	int nOffset = ntohl(*ip);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.Seek(nKey, pFcb, nMode, nOffset);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $4F - File Timestamp Get / Set
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_TimeStamp(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nKey = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto pFcb = (Human68k::fcb_t*)&(buf.data()[i]);
+	i += sizeof(Human68k::fcb_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	uint32_t nHumanTime = ntohl(*dp);
+
+	pFcb->fileptr = ntohl(pFcb->fileptr);
+	pFcb->mode = ntohs(pFcb->mode);
+	pFcb->time = ntohs(pFcb->time);
+	pFcb->date = ntohs(pFcb->date);
+	pFcb->size = ntohl(pFcb->size);
+
+	fsresult = fs.TimeStamp(nUnit, nKey, pFcb, nHumanTime);
+
+	pFcb->fileptr = htonl(pFcb->fileptr);
+	pFcb->mode = htons(pFcb->mode);
+	pFcb->time = htons(pFcb->time);
+	pFcb->date = htons(pFcb->date);
+	pFcb->size = htonl(pFcb->size);
+
+	i = 0;
+	memcpy(&fsout[i], pFcb, sizeof(Human68k::fcb_t));
+	i += sizeof(Human68k::fcb_t);
+
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $50 - Get Capacity
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_GetCapacity(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	Human68k::capacity_t cap = {};
+	fsresult = fs.GetCapacity(nUnit, &cap);
+
+	cap.freearea = htons(cap.freearea);
+	cap.clusters = htons(cap.clusters);
+	cap.sectors = htons(cap.sectors);
+	cap.bytes = htons(cap.bytes);
+
+	memcpy(fsout.data(), &cap, sizeof(Human68k::capacity_t));
+	fsoutlen = sizeof(Human68k::capacity_t);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $51 - Drive status inspection/control
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_CtrlDrive(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	const int i = sizeof(uint32_t);
+
+	auto pCtrlDrive = (Human68k::ctrldrive_t*)&(buf.data()[i]);
+
+	fsresult = fs.CtrlDrive(nUnit, pCtrlDrive);
+
+	memcpy(fsout.data(), pCtrlDrive, sizeof(Human68k::ctrldrive_t));
+	fsoutlen = sizeof(Human68k::ctrldrive_t);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $52 - Get DPB
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_GetDPB(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	Human68k::dpb_t dpb = {};
+	fsresult = fs.GetDPB(nUnit, &dpb);
+
+	dpb.sector_size = htons(dpb.sector_size);
+	dpb.fat_sector = htons(dpb.fat_sector);
+	dpb.file_max = htons(dpb.file_max);
+	dpb.data_sector = htons(dpb.data_sector);
+	dpb.cluster_max = htons(dpb.cluster_max);
+	dpb.root_sector = htons(dpb.root_sector);
+
+	memcpy(fsout.data(), &dpb, sizeof(Human68k::dpb_t));
+	fsoutlen = sizeof(Human68k::dpb_t);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $53 - Read Sector
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_DiskRead(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nSector = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	uint32_t nSize = ntohl(*dp);
+
+	fsresult = fs.DiskRead(nUnit, fsout.data(), nSector, nSize);
+	fsoutlen = 0x200;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $54 - Write Sector
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_DiskWrite(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	fsresult = fs.DiskWrite(nUnit);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $55 - IOCTRL
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Ioctrl(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+	int i = sizeof(uint32_t);
+
+	dp = (uint32_t*)&(buf.data()[i]);
+	const uint32_t nFunction = ntohl(*dp);
+	i += sizeof(uint32_t);
+
+	auto pIoctrl = (Human68k::ioctrl_t*)&(buf.data()[i]);
+
+	switch (nFunction) {
+		case 2:
+		case (uint32_t)-2:
+			pIoctrl->param = htonl(pIoctrl->param);
+			break;
+		default:
+			break;
+	}
+
+	fsresult = fs.Ioctrl(nUnit, nFunction, pIoctrl);
+
+	switch (nFunction) {
+		case 0:
+			pIoctrl->media = htons(pIoctrl->media);
+			break;
+		case 1:
+		case (uint32_t)-3:
+			pIoctrl->param = htonl(pIoctrl->param);
+			break;
+		default:
+			break;
+	}
+
+	i = 0;
+	memcpy(&fsout[i], pIoctrl, sizeof(Human68k::ioctrl_t));
+	i += sizeof(Human68k::ioctrl_t);
+	fsoutlen = i;
+}
+
+//---------------------------------------------------------------------------
+//
+//  $56 - Flush
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Flush(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	fsresult = fs.Flush(nUnit);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $57 - Check Media
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_CheckMedia(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	fsresult = fs.CheckMedia(nUnit);
+}
+
+//---------------------------------------------------------------------------
+//
+//  $58 - Lock
+//
+//---------------------------------------------------------------------------
+void SCSIBR::FS_Lock(vector<uint8_t>& buf)
+{
+	auto dp = (uint32_t*)buf.data();
+	const uint32_t nUnit = ntohl(*dp);
+
+	fsresult = fs.Lock(nUnit);
+}
+
+//---------------------------------------------------------------------------
+//
+//	Read Filesystem (result code)
+//
+//---------------------------------------------------------------------------
+int SCSIBR::ReadFsResult(vector<uint8_t>& buf) const
+{
+	auto dp = (uint32_t *)buf.data();
+	*dp = htonl(fsresult);
+	return sizeof(uint32_t);
+}
+
+//---------------------------------------------------------------------------
+//
+//	Read Filesystem (return data)
+//
+//---------------------------------------------------------------------------
+int SCSIBR::ReadFsOut(vector<uint8_t>& buf) const
+{
+	copy_n(fsout.begin(), fsoutlen, buf.begin());
+	return fsoutlen;
+}
+
+//---------------------------------------------------------------------------
+//
+//	Read file system (return option data)
+//
+//---------------------------------------------------------------------------
+int SCSIBR::ReadFsOpt(vector<uint8_t>& buf) const
+{
+	copy_n(fsopt.begin(), fsoptlen, buf.begin());
+	return fsoptlen;
+}
+
+//---------------------------------------------------------------------------
+//
+//	Write Filesystem
+//
+//---------------------------------------------------------------------------
+void SCSIBR::WriteFs(int func, vector<uint8_t>& buf)
+{
+	fsresult = FS_FATAL_INVALIDCOMMAND;
+	fsoutlen = 0;
+	fsoptlen = 0;
+
+	func &= 0x1f;
+	switch (func) {
+		case 0x00:
+			FS_InitDevice(buf);	// $40 - start device
+			break;
+		case 0x01:
+			FS_CheckDir(buf);	// $41 - directory check
+			break;
+		case 0x02:
+			FS_MakeDir(buf);	// $42 - create directory
+			break;
+		case 0x03:
+			FS_RemoveDir(buf);	// $43 - remove directory
+			break;
+		case 0x04:
+			FS_Rename(buf);		// $44 - change file name
+			break;
+		case 0x05:
+			FS_Delete(buf);		// $45 - delete file
+			break;
+		case 0x06:
+			FS_Attribute(buf);	// $46 - Get/set file attribute
+			break;
+		case 0x07:
+			FS_Files(buf);		// $47 - file search
+			break;
+		case 0x08:
+			FS_NFiles(buf);		// $48 - next file search
+			break;
+		case 0x09:
+			FS_Create(buf);		// $49 - create file
+			break;
+		case 0x0A:
+			FS_Open(buf);		// $4A - File open
+			break;
+		case 0x0B:
+			FS_Close(buf);		// $4B - File close
+			break;
+		case 0x0C:
+			FS_Read(buf);		// $4C - read file
+			break;
+		case 0x0D:
+			FS_Write(buf);		// $4D - write file
+			break;
+		case 0x0E:
+			FS_Seek(buf);		// $4E - File seek
+			break;
+		case 0x0F:
+			FS_TimeStamp(buf);	// $4F - Get/set file modification time
+			break;
+		case 0x10:
+			FS_GetCapacity(buf);	// $50 - get capacity
+			break;
+		case 0x11:
+			FS_CtrlDrive(buf);	// $51 - Drive control/state check
+			break;
+		case 0x12:
+			FS_GetDPB(buf);		// $52 - Get DPB
+			break;
+		case 0x13:
+			FS_DiskRead(buf);	// $53 - read sector
+			break;
+		case 0x14:
+			FS_DiskWrite(buf);	// $54 - write sector
+			break;
+		case 0x15:
+			FS_Ioctrl(buf);		// $55 - IOCTRL
+			break;
+		case 0x16:
+			FS_Flush(buf);		// $56 - flush
+			break;
+		case 0x17:
+			FS_CheckMedia(buf);	// $57 - check media exchange
+			break;
+		case 0x18:
+			FS_Lock(buf);		// $58 - exclusive control
+			break;
+		default:
+			break;
+	}
+}
+
+//---------------------------------------------------------------------------
+//
+//	File system write (input option data)
+//
+//---------------------------------------------------------------------------
+void SCSIBR::WriteFsOpt(const vector<uint8_t>& buf, int num)
+{
+	copy_n(buf.begin(), num, fsopt.begin());
+}

--- a/cpp/devices/scsi_host_bridge.h
+++ b/cpp/devices/scsi_host_bridge.h
@@ -1,0 +1,131 @@
+//---------------------------------------------------------------------------
+//
+//	SCSI Target Emulator PiSCSI
+//	for Raspberry Pi
+//
+//	Copyright (C) 2001-2006 ＰＩ．(ytanaka@ipc-tokai.or.jp)
+//	Copyright (C) 2014-2020 GIMONS
+//  	Copyright (C) akuker
+//
+//  	Licensed under the BSD 3-Clause License.
+//  	See LICENSE file in the project root folder.
+//
+//  	[ SCSI Host Bridge for the Sharp X68000 ]
+//
+//  Note: This requires a special driver on the host system and will only
+//        work with the Sharp X68000 operating system.
+//---------------------------------------------------------------------------
+#pragma once
+
+#include "primary_device.h"
+#include "ctapdriver.h"
+#include "cfilesystem.h"
+#include <string>
+#include <span>
+#include <array>
+#include <optional>
+
+using namespace std;
+
+class SCSIBR : public PrimaryDevice
+{
+	static constexpr const array<uint8_t, 6> bcast_addr = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+
+public:
+	enum class rasctl_control_mode {
+		disabled,
+		media,
+		full
+	};
+
+	// A RASCTL shutdown is deferred until the application has read its response.
+	enum class rasctl_shutdown_mode {
+		none,
+		stop_piscsi,
+		stop_system
+	};
+
+	explicit SCSIBR(int);
+	~SCSIBR() override = default;
+
+	bool Init(const param_map&) override;
+	void CleanUp() override;
+
+	param_map GetDefaultParams() const override { return tap.GetDefaultParams(); }
+
+	// Commands
+	vector<uint8_t> InquiryInternal() const override;
+	int GetMessage10(cdb_t, vector<uint8_t>&);
+	bool ReadWrite(cdb_t, vector<uint8_t>&);
+	void TestUnitReady() override;
+	void GetMessage10();
+	void SendMessage10() const;
+	// RASCTL compatibility transport on the X68000 bridge's type-0 control channel.
+	void SetRasctlControlMode(rasctl_control_mode mode) { rasctl_mode = mode; }
+	bool IsRasctlControlEnabled() const { return rasctl_mode != rasctl_control_mode::disabled; }
+	optional<string> TakeRasctlControlRequest();
+	void SetRasctlControlResponse(string, rasctl_shutdown_mode = rasctl_shutdown_mode::none);
+	rasctl_shutdown_mode TakeRasctlShutdownMode();
+	static array<uint8_t, 6> DeriveMac(span<const uint8_t>);
+
+private:
+
+	int GetMacAddr(vector<uint8_t>&) const;		// Get MAC address
+	void SetMacAddr(span<const uint8_t>);		// Set MAC address
+	void ReceivePacket();						// Receive a packet
+	void GetPacketBuf(vector<uint8_t>&, int);	// Get a packet
+	void SendPacket(span<const uint8_t>, int) const;	// Send a packet
+
+	CTapDriver tap;								// TAP driver
+	bool tap_enabled = false;					// TAP valid flag
+	array<uint8_t, 6> mac_addr = {};			// MAC Address
+	static constexpr int MINIMUM_FRAME_SIZE = 60;
+	int packet_len = 0;							// Receive packet size
+	array<uint8_t, 0x1000> packet_buf;			// Receive packet buffer
+	bool packet_enable = false;					// Received packet valid
+
+	int ReadFsResult(vector<uint8_t>&) const;		// Read filesystem (result code)
+	int ReadFsOut(vector<uint8_t>&) const;			// Read filesystem (return data)
+	int ReadFsOpt(vector<uint8_t>&) const;			// Read file system (optional data)
+	void WriteFs(int, vector<uint8_t>&);			// File system write (execute)
+	void WriteFsOpt(const vector<uint8_t>&, int);	// File system write (optional data)
+
+	// Command handlers
+	void FS_InitDevice(vector<uint8_t>&);				// $40 - boot
+	void FS_CheckDir(vector<uint8_t>&);				// $41 - directory check
+	void FS_MakeDir(vector<uint8_t>&);					// $42 - create directory
+	void FS_RemoveDir(vector<uint8_t>&);				// $43 - delete directory
+	void FS_Rename(vector<uint8_t>&);					// $44 - change filename
+	void FS_Delete(vector<uint8_t>&);					// $45 - delete file
+	void FS_Attribute(vector<uint8_t>&);				// $46 - get/set file attributes
+	void FS_Files(vector<uint8_t>&);					// $47 - file search
+	void FS_NFiles(vector<uint8_t>&);					// $48 - find next file
+	void FS_Create(vector<uint8_t>&);					// $49 - create file
+	void FS_Open(vector<uint8_t>&);					// $4A - open file
+	void FS_Close(vector<uint8_t>&);					// $4B - close file
+	void FS_Read(vector<uint8_t>&);					// $4C - read file
+	void FS_Write(vector<uint8_t>&);					// $4D - write file
+	void FS_Seek(vector<uint8_t>&);					// $4E - seek file
+	void FS_TimeStamp(vector<uint8_t>&);				// $4F - get/set file time
+	void FS_GetCapacity(vector<uint8_t>&);				// $50 - get capacity
+	void FS_CtrlDrive(vector<uint8_t>&);				// $51 - drive status check/control
+	void FS_GetDPB(vector<uint8_t>&);					// $52 - get DPB
+	void FS_DiskRead(vector<uint8_t>&);				// $53 - read sector
+	void FS_DiskWrite(vector<uint8_t>&);				// $54 - write sector
+	void FS_Ioctrl(vector<uint8_t>&);					// $55 - IOCTRL
+	void FS_Flush(vector<uint8_t>&);					// $56 - flush cache
+	void FS_CheckMedia(vector<uint8_t>&);				// $57 - check media
+	void FS_Lock(vector<uint8_t>&);					// $58 - get exclusive control
+
+	CFileSys fs;								// File system accessor
+	uint32_t fsresult = 0;						// File system access result code
+	array<uint8_t, 0x800> fsout;					// File system access result buffer
+	uint32_t fsoutlen = 0;						// File system access result buffer size
+	array<uint8_t, 0x1000000> fsopt;				// File system access buffer
+	uint32_t fsoptlen = 0;						// File system access buffer size
+	rasctl_control_mode rasctl_mode = rasctl_control_mode::disabled;
+	optional<string> rasctl_control_request;
+	string rasctl_control_response;
+	rasctl_shutdown_mode rasctl_shutdown = rasctl_shutdown_mode::none;
+	bool rasctl_shutdown_ready = false;
+};

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -7,6 +7,7 @@ controllers_src = [
 ]
 devices_src = [
     'devices/cd_track.cpp',
+    'devices/cfilesystem.cpp',
     'devices/ctapdriver.cpp',
     'devices/device_factory.cpp',
     'devices/device_logger.cpp',
@@ -20,6 +21,7 @@ devices_src = [
     'devices/scsi_command_util.cpp',
     'devices/sasi_hd.cpp',
     'devices/scsi_daynaport.cpp',
+    'devices/scsi_host_bridge.cpp',
     'devices/scsi_printer.cpp',
     'devices/scsi_streamer.cpp',
     'devices/scsicd.cpp',
@@ -122,6 +124,7 @@ test_src = [
     'test/sasi_hd_test.cpp',
     'test/scsi_controller_test.cpp',
     'test/scsi_daynaport_test.cpp',
+    'test/scsi_host_bridge_test.cpp',
     'test/scsi_printer_test.cpp',
     'test/scsicd_test.cpp',
     'test/scsictl_commands_test.cpp',
@@ -152,7 +155,7 @@ subdir('generated')
 if target.contains('piscsi')
     piscsi_bin = executable('piscsi',
         piscsi_core_src + piscsi_src + shared_src + protobuf_src + piscsi_interface_src[0],
-        dependencies : common_deps + [pcap_dep, protobuf_dep],
+        dependencies : common_deps + iconv_deps + [pcap_dep, protobuf_dep],
         install : true,
     )
 endif
@@ -202,7 +205,7 @@ endif
 if gtest_dep.found() and gmock_dep.found() and target.contains('test')
     test_bin = executable('piscsi_test',
         piscsi_core_src + scsictl_core_src + test_src + shared_src + protobuf_src + piscsi_interface_src[0],
-        dependencies : common_deps + [pcap_dep, protobuf_dep, gtest_dep, gmock_dep],
+        dependencies : common_deps + iconv_deps + [pcap_dep, protobuf_dep, gtest_dep, gmock_dep],
         link_args : test_link_args,
         install : false
     )

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -17,6 +17,7 @@
 #include "shared/piscsi_version.h"
 #include "controllers/scsi_controller.h"
 #include "devices/device_logger.h"
+#include "devices/scsi_host_bridge.h"
 #include "devices/storage_device.h"
 #include "hal/gpiobus_factory.h"
 #include "hal/gpiobus.h"
@@ -46,10 +47,10 @@ void Piscsi::Banner(span<char *> args) const
 
 	if ((args.size() > 1 && strcmp(args[1], "-h") == 0) || (args.size() > 1 && strcmp(args[1], "--help") == 0)){
 		cout << "\nUsage: " << args[0] << " [-C CONNECT_TYPE] [-idID[:LUN] FILE] ...\n\n"
+				<< " CONNECT_TYPE is FULLSPEC, STANDARD, or GAMERNIUM; FULLSPEC is the default.\n"
 				<< " ID is SCSI device ID (0-" << (ControllerManager::GetScsiIdMax() - 1) << ").\n"
 				<< " LUN is the optional logical unit (0-" << (ControllerManager::GetScsiLunMax() - 1) <<").\n"
-				<< " FILE is a disk image file, \"daynaport\", \"printer\" or \"services\".\n"
-				<< " CONNECT_TYPE is FULLSPEC, STANDARD, or GAMERNIUM; FULLSPEC is the default.\n"
+				<< " FILE is a disk image file, \"bridge\", \"daynaport\", \"printer\" or \"services\".\n"
 				<< " Image type is detected based on file extension if no explicit type is specified.\n\n"
 				<< "See the piscsi man page for a full list of supported parameters\n"
 				<< flush;
@@ -149,7 +150,7 @@ string Piscsi::ParseArguments(span<char *> args, PbCommand& command, int& port, 
 
 	opterr = 1;
 	int opt;
-	while ((opt = getopt(static_cast<int>(args.size()), args.data(), "-Iib:d:n:p:r:s:t:z:D:F:L:P:R:C:v")) != -1) {
+	while ((opt = getopt(static_cast<int>(args.size()), args.data(), "-Iib:c:d:n:p:r:s:t:z:D:F:L:P:R:C:v")) != -1) {
 		switch (opt) {
 			// The two options below are kind of a compound option with two letters
 			case 'i':
@@ -165,6 +166,10 @@ string Piscsi::ParseArguments(span<char *> args, PbCommand& command, int& port, 
 				if (!GetAsUnsignedInt(optarg, block_size)) {
 					throw parser_exception("Invalid block size " + string(optarg));
 				}
+				continue;
+
+			case 'c':
+				SetRasctlControlMode(optarg);
 				continue;
 
 			case 'z':
@@ -261,6 +266,34 @@ string Piscsi::ParseArguments(span<char *> args, PbCommand& command, int& port, 
 	}
 
 	return locale;
+}
+
+void Piscsi::SetRasctlControlMode(string_view value)
+{
+	string mode(value);
+	ranges::transform(mode, mode.begin(), ::tolower);
+
+	if (mode == "off") {
+		rasctl_control_mode = SCSIBR::rasctl_control_mode::disabled;
+	}
+	else if (mode == "media") {
+		rasctl_control_mode = SCSIBR::rasctl_control_mode::media;
+	}
+	else if (mode == "full") {
+		rasctl_control_mode = SCSIBR::rasctl_control_mode::full;
+	}
+	else {
+		throw parser_exception("Invalid RASCTL control mode '" + mode + "', must be off, media, or full");
+	}
+}
+
+void Piscsi::ConfigureRasctlControlChannels()
+{
+	for (const auto& device : controller_manager.GetAllDevices()) {
+		if (const auto bridge = dynamic_pointer_cast<SCSIBR>(device); bridge != nullptr) {
+			bridge->SetRasctlControlMode(rasctl_control_mode);
+		}
+	}
 }
 
 PbDeviceType Piscsi::ParseDeviceType(const string& value)
@@ -462,7 +495,9 @@ bool Piscsi::ExecuteCommand(const CommandContext& context)
 bool Piscsi::ExecuteWithLock(const CommandContext& context)
 {
 	scoped_lock<mutex> lock(execution_locker);
-	return executor->ProcessCmd(context);
+	const bool success = executor->ProcessCmd(context);
+	ConfigureRasctlControlChannels();
+	return success;
 }
 
 bool Piscsi::HandleDeviceListChange(const CommandContext& context, PbOperation operation) const
@@ -544,6 +579,8 @@ int Piscsi::run(span<char *> args)
 		}
 	}
 
+	ConfigureRasctlControlChannels();
+
 	// Display and log the device list
 	PbServerInfo server_info;
 	response.GetDevices(controller_manager.GetAllDevices(), server_info, piscsi_image.GetDefaultFolder());
@@ -617,8 +654,147 @@ void Piscsi::Process()
 				// When the bus is free PiSCSI or the Pi may be shut down.
 				ShutDown(shutdown_mode);
 			}
+
+			// Compatibility channel for the X68000 RASCTL control application. It
+			// writes a request and reads its response in the following SCSI command,
+			// so process it here while the controller-manager lock is still held.
+			ProcessRasctlControlCommands();
 		}
 	}
+}
+
+void Piscsi::ProcessRasctlControlCommands()
+{
+	for (const auto& device : controller_manager.GetAllDevices()) {
+		const auto bridge = dynamic_pointer_cast<SCSIBR>(device);
+		if (bridge == nullptr) {
+			continue;
+		}
+
+		if (const auto request = bridge->TakeRasctlControlRequest(); request) {
+			SCSIBR::rasctl_shutdown_mode shutdown_mode = SCSIBR::rasctl_shutdown_mode::none;
+			bridge->SetRasctlControlResponse(ExecuteRasctlControlCommand(*request, shutdown_mode), shutdown_mode);
+		}
+
+		switch (bridge->TakeRasctlShutdownMode()) {
+			case SCSIBR::rasctl_shutdown_mode::stop_piscsi:
+				ShutDown(AbstractController::piscsi_shutdown_mode::STOP_PISCSI);
+				return;
+
+			case SCSIBR::rasctl_shutdown_mode::stop_system:
+				ShutDown(AbstractController::piscsi_shutdown_mode::STOP_PI);
+				return;
+
+			case SCSIBR::rasctl_shutdown_mode::none:
+				break;
+		}
+	}
+}
+
+string Piscsi::ExecuteRasctlControlCommand(const string& request, SCSIBR::rasctl_shutdown_mode& shutdown_mode)
+{
+	istringstream input(request);
+	string operation;
+	input >> operation;
+	ranges::transform(operation, operation.begin(), ::tolower);
+
+	if (operation == "list") {
+		PbServerInfo server_info;
+		response.GetDevices(controller_manager.GetAllDevices(), server_info, piscsi_image.GetDefaultFolder());
+		const vector<PbDevice> devices = { server_info.devices_info().devices().begin(), server_info.devices_info().devices().end() };
+		return ListDevices(devices);
+	}
+
+	if (operation == "stop") {
+		if (rasctl_control_mode != SCSIBR::rasctl_control_mode::full) {
+			return "Error: RASCTL shutdown control is disabled\n";
+		}
+
+		shutdown_mode = SCSIBR::rasctl_shutdown_mode::stop_piscsi;
+		return "PiSCSI shutdown requested\n";
+	}
+
+	if (operation == "shutdown") {
+		if (rasctl_control_mode != SCSIBR::rasctl_control_mode::full) {
+			return "Error: RASCTL shutdown control is disabled\n";
+		}
+
+		shutdown_mode = SCSIBR::rasctl_shutdown_mode::stop_system;
+		return "System shutdown requested\n";
+	}
+
+	int id;
+	int lun;
+	int rasctl_operation;
+	int rasctl_type;
+	string file;
+	if (!(input >> id >> lun >> rasctl_operation >> rasctl_type >> file)) {
+		return "Error: Invalid RASCTL control command\n";
+	}
+
+	PbCommand command;
+	PbDeviceDefinition *device = command.add_devices();
+	device->set_id(id);
+	device->set_unit(lun);
+
+	switch (rasctl_operation) {
+		case 0: // Attach
+			command.set_operation(ATTACH);
+			switch (rasctl_type) {
+				case 0: // Select SASI/SCSI from the image extension, like RaSCSI
+					device->set_type(UNDEFINED);
+					break;
+
+				case 2:
+					device->set_type(SCMO);
+					break;
+
+				case 3:
+					device->set_type(SCCD);
+					break;
+
+				case 4:
+					device->set_type(SCBR);
+					SetParam(*device, "mode", "bridge");
+					SetParam(*device, "interface", "piscsi_bridge");
+					break;
+
+				default:
+					return "Error: Invalid device type\n";
+			}
+			break;
+
+		case 1:
+			command.set_operation(DETACH);
+			break;
+
+		case 2:
+			command.set_operation(INSERT);
+			break;
+
+		case 3:
+			command.set_operation(EJECT);
+			break;
+
+		case 4: { // RASCTL toggles MO write protection
+			const auto existing = controller_manager.GetDeviceForIdAndLun(id, lun);
+			if (existing == nullptr || existing->GetType() != SCMO) {
+				return "Error: Write protection is supported for MO devices only\n";
+			}
+			command.set_operation(existing->IsProtected() ? UNPROTECT : PROTECT);
+			break;
+		}
+
+		default:
+			return "Error: Invalid command\n";
+	}
+
+	if (file != "-") {
+		SetParam(*device, "file", file);
+	}
+
+	const CommandContext context(command, piscsi_image.GetDefaultFolder(), "en");
+	return executor->ProcessCmd(context) ? "" : "Error: Command failed\n";
 }
 
 // Shutdown on a remote interface command

--- a/cpp/piscsi/piscsi_core.h
+++ b/cpp/piscsi/piscsi_core.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "controllers/controller_manager.h"
+#include "devices/scsi_host_bridge.h"
 #include "piscsi/command_context.h"
 #include "piscsi/piscsi_service.h"
 #include "piscsi/piscsi_image.h"
@@ -45,6 +46,8 @@ private:
 	void LogDevices(string_view) const;
 	static void TerminationHandler(int);
 	string ParseArguments(span<char *>, PbCommand&, int&, string&);
+	void SetRasctlControlMode(string_view);
+	void ConfigureRasctlControlChannels();
 	void Process();
 	bool IsNotBusy() const;
 
@@ -54,6 +57,9 @@ private:
 	bool ExecuteCommand(const CommandContext&);
 	bool ExecuteWithLock(const CommandContext&);
 	bool HandleDeviceListChange(const CommandContext&, PbOperation) const;
+	// Translates the historic X68000 RASCTL text protocol into normal PiSCSI commands.
+	void ProcessRasctlControlCommands();
+	string ExecuteRasctlControlCommand(const string&, SCSIBR::rasctl_shutdown_mode&);
 
 	bool SetLogLevel(const string&) const;
 
@@ -64,6 +70,7 @@ private:
 	mutex execution_locker;
 
 	string access_token;
+	SCSIBR::rasctl_control_mode rasctl_control_mode = SCSIBR::rasctl_control_mode::disabled;
 
 	PiscsiImage piscsi_image;
 

--- a/cpp/scsictl/scsictl_core.cpp
+++ b/cpp/scsictl/scsictl_core.cpp
@@ -37,7 +37,7 @@ void ScsiCtl::Banner(const vector<char *>& args) const
 				<< "} for SCSI or {0-" << (ControllerManager::GetSasiLunMax() - 1) << "} for SASI, default is 0\n"
 				<< "Usage: " << args[0] << " -l\n"
 				<< "       Print device list.\n\n"
-				<< "DaynaPort profiles use one explicit parameter value, for example:\n"
+				<< "DaynaPort and Host Bridge profiles use one explicit parameter value, for example:\n"
 				<< "       -f 'mode=bridge:interface=piscsi_bridge'\n"
 				<< "       -f 'mode=proxyarp:interface=wlan0'\n\n"
 				<< "See the scsictl man page for all supported commands, types, and other parameters\n"
@@ -267,7 +267,7 @@ int ScsiCtl::run(const vector<char *>& args) const
 		}
 		else {
 			ParseParameters(*device, param);
-			if (command.operation() == ATTACH && device->type() == SCDP) {
+			if (command.operation() == ATTACH && (device->type() == SCDP || device->type() == SCBR)) {
 				const bool has_mode = device->params().contains("mode");
 				const bool has_interface = device->params().contains("interface");
 				if (!has_mode && !has_interface) {
@@ -275,7 +275,7 @@ int ScsiCtl::run(const vector<char *>& args) const
 					SetParam(*device, "interface", "piscsi_bridge");
 				}
 				else if (has_mode != has_interface) {
-					cerr << "Error: DaynaPort attachments require both mode and interface, for example "
+					cerr << "Error: DaynaPort and Host Bridge attachments require both mode and interface, for example "
 							"-f 'mode=proxyarp:interface=wlan0'" << endl;
 					return EXIT_FAILURE;
 				}

--- a/cpp/scsictl/scsictl_parser.h
+++ b/cpp/scsictl/scsictl_parser.h
@@ -38,6 +38,7 @@ private:
 	};
 
 	const unordered_map<int, PbDeviceType> device_types = {
+			{ 'b', SCBR },
 			{ 'c', SCCD },
 			{ 'd', SCDP },
 			{ 'h', SCHD },

--- a/cpp/shared/protobuf_util.cpp
+++ b/cpp/shared/protobuf_util.cpp
@@ -144,6 +144,10 @@ string protobuf_util::ListDevices(const vector<PbDevice>& pb_devices)
 	for (const auto& device : devices) {
 		string filename;
 		switch (device.type()) {
+			case SCBR:
+				filename = "X68000 HOST BRIDGE";
+				break;
+
 			case SCDP:
 				filename = "DaynaPort SCSI/Link";
 				break;

--- a/cpp/test/ctapdriver_test.cpp
+++ b/cpp/test/ctapdriver_test.cpp
@@ -50,21 +50,11 @@ TEST(CTapDriverTest, CleanupAndMacAreSafeWithoutATap)
 	CTapDriver driver;
 	array<uint8_t, 6> mac;
 	mac.fill(0xff);
-	driver.GetMacAddr(mac.data());
+	driver.GetUplinkMacAddr(mac.data());
 	EXPECT_THAT(mac, Each(0));
 
 	driver.CleanUp();
 	driver.CleanUp();
-}
-
-TEST(CTapDriverTest, DeriveDaynaPortMac)
-{
-	const array<uint8_t, 6> interface_mac = { 0xb8, 0x27, 0xeb, 0xb5, 0xa3, 0x15 };
-	EXPECT_EQ((array<uint8_t, 6> { 0x00, 0x80, 0x19, 0xb5, 0xa3, 0x15 }),
-			CTapDriver::DeriveDaynaPortMac(interface_mac));
-
-	const array<uint8_t, 5> invalid_mac = { 0, 1, 2, 3, 4 };
-	EXPECT_EQ((array<uint8_t, 6> {}), CTapDriver::DeriveDaynaPortMac(invalid_mac));
 }
 
 TEST(CTapDriverTest, Crc32)

--- a/cpp/test/device_factory_test.cpp
+++ b/cpp/test/device_factory_test.cpp
@@ -37,6 +37,7 @@ TEST(DeviceFactoryTest, GetTypeForFile)
 	EXPECT_EQ(device_factory.GetTypeForFile("test.suffix.iso"), SCCD);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.tar"), SCTP);
 	EXPECT_EQ(device_factory.GetTypeForFile("test.tap"), SCTP);
+	EXPECT_EQ(device_factory.GetTypeForFile("bridge"), SCBR);
 	EXPECT_EQ(device_factory.GetTypeForFile("daynaport"), SCDP);
 	EXPECT_EQ(device_factory.GetTypeForFile("printer"), SCLP);
 	EXPECT_EQ(device_factory.GetTypeForFile("services"), SCHS);
@@ -179,6 +180,19 @@ TEST(DeviceFactoryTest, SCCD_Device_Defaults)
 	EXPECT_EQ("SCSI CD-ROM", device->GetProduct());
 	EXPECT_EQ(string(piscsi_get_version_string()).substr(0, 2) + string(piscsi_get_version_string()).substr(3, 2),
 			device->GetRevision());
+}
+
+TEST(DeviceFactoryTest, SCBR_Device_Defaults)
+{
+	DeviceFactory device_factory;
+
+	auto device = device_factory.CreateDevice(UNDEFINED, 0, "bridge");
+	ASSERT_NE(nullptr, device);
+	EXPECT_EQ(SCBR, device->GetType());
+	EXPECT_FALSE(device->SupportsFile());
+	EXPECT_TRUE(device->SupportsParams());
+	EXPECT_EQ("PiSCSI", device->GetVendor());
+	EXPECT_EQ("RASCSI BRIDGE", device->GetProduct());
 }
 
 TEST(DeviceFactoryTest, SCDP_Device_Defaults)

--- a/cpp/test/device_test.cpp
+++ b/cpp/test/device_test.cpp
@@ -139,6 +139,9 @@ TEST(DeviceTest, GetTypeString)
 	MockDevice schs(SCHS);
 	EXPECT_EQ("SCHS", schs.GetTypeString());
 
+	MockDevice scbr(SCBR);
+	EXPECT_EQ("SCBR", scbr.GetTypeString());
+
 	MockDevice scdp(SCDP);
 	EXPECT_EQ("SCDP", scdp.GetTypeString());
 

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -171,7 +171,7 @@ TEST(PiscsiResponseTest, GetDeviceTypesInfo)
 
 	PbDeviceTypesInfo info;
 	response.GetDeviceTypesInfo(info);
-	EXPECT_EQ(9, info.properties().size());
+	EXPECT_EQ(10, info.properties().size());
 }
 
 TEST(PiscsiResponseTest, GetServerInfo)

--- a/cpp/test/protobuf_util_test.cpp
+++ b/cpp/test/protobuf_util_test.cpp
@@ -111,6 +111,8 @@ TEST(ProtobufUtil, ListDevices)
 	PbDevice device;
 	device.set_type(SCHD);
 	devices.push_back(device);
+	device.set_type(SCBR);
+	devices.push_back(device);
 	device.set_type(SCDP);
 	devices.push_back(device);
 	device.set_type(SCHS);
@@ -119,6 +121,7 @@ TEST(ProtobufUtil, ListDevices)
 	devices.push_back(device);
 	const string device_list = ListDevices(devices);
 	EXPECT_FALSE(device_list.empty());
+	EXPECT_NE(string::npos, device_list.find("X68000 HOST BRIDGE"));
 	EXPECT_NE(string::npos, device_list.find("DaynaPort SCSI/Link"));
 	EXPECT_NE(string::npos, device_list.find("Host Services"));
 	EXPECT_NE(string::npos, device_list.find("SCSI Printer"));

--- a/cpp/test/scsi_daynaport_test.cpp
+++ b/cpp/test/scsi_daynaport_test.cpp
@@ -20,6 +20,15 @@ TEST(ScsiDaynaportTest, GetDefaultParams)
 	EXPECT_FALSE(params.contains("inet"));
 }
 
+TEST(ScsiDaynaportTest, DeriveMac)
+{
+	const array<uint8_t, 6> uplink_mac = { 0xb8, 0x27, 0xeb, 0xb5, 0xa3, 0x15 };
+	EXPECT_EQ((array<uint8_t, 6> { 0x00, 0x80, 0x19, 0xb5, 0xa3, 0x15 }), SCSIDaynaPort::DeriveMac(uplink_mac));
+
+	const array<uint8_t, 5> invalid_mac = { 0, 1, 2, 3, 4 };
+	EXPECT_EQ((array<uint8_t, 6> {}), SCSIDaynaPort::DeriveMac(invalid_mac));
+}
+
 TEST(ScsiDaynaportTest, Inquiry)
 {
 	TestInquiry::Inquiry(SCDP, device_type::processor, scsi_level::scsi_2, "Dayna   SCSI/Link       1.4a", 0x20, false);

--- a/cpp/test/scsi_host_bridge_test.cpp
+++ b/cpp/test/scsi_host_bridge_test.cpp
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------------
+//
+// SCSI Target Emulator PiSCSI
+//---------------------------------------------------------------------------
+
+#include "devices/scsi_host_bridge.h"
+#include "mocks.h"
+
+TEST(ScsiHostBridgeTest, GetDefaultParams)
+{
+    const auto [controller, bridge] = CreateDevice(SCBR);
+    const auto params               = bridge->GetDefaultParams();
+    EXPECT_EQ(2, params.size());
+}
+
+TEST(ScsiHostBridgeTest, DeriveMac)
+{
+	const array<uint8_t, 6> uplink_mac = { 0xb8, 0x27, 0xeb, 0xb5, 0xa3, 0x15 };
+	const auto mac = SCSIBR::DeriveMac(uplink_mac);
+	EXPECT_EQ(0x02, mac[0]);
+	EXPECT_NE(uplink_mac, mac);
+	EXPECT_EQ(mac, SCSIBR::DeriveMac(uplink_mac));
+
+	const array<uint8_t, 5> invalid_mac = { 0, 1, 2, 3, 4 };
+	EXPECT_EQ((array<uint8_t, 6> {}), SCSIBR::DeriveMac(invalid_mac));
+}
+
+TEST(ScsiHostBridgeTest, InquiryDisablesRasctlControlByDefault)
+{
+	const auto [controller, bridge] = CreateDevice(SCBR);
+	const auto inquiry              = std::dynamic_pointer_cast<SCSIBR>(bridge)->InquiryInternal();
+	EXPECT_EQ(0, inquiry[36]);
+	EXPECT_EQ('1', inquiry[38]);
+}
+
+TEST(ScsiHostBridgeTest, RasctlControlUsesRasctlMessageFormat)
+{
+	const auto [controller, device] = CreateDevice(SCBR);
+	const auto bridge               = std::dynamic_pointer_cast<SCSIBR>(device);
+	const array<int, 10> write_cdb  = { 0x2a, 0, 0, 0, 0, 0, 0, 4, 0, 0 };
+	const array<int, 10> read_cdb   = { 0x28, 0, 0, 0, 0, 0, 0, 4, 0, 0 };
+	vector<uint8_t> buffer(1024);
+	EXPECT_FALSE(bridge->ReadWrite(write_cdb, buffer));
+	EXPECT_EQ(0, bridge->GetMessage10(read_cdb, buffer));
+	bridge->SetRasctlControlMode(SCSIBR::rasctl_control_mode::media);
+	EXPECT_EQ('1', bridge->InquiryInternal()[36]);
+
+	memcpy(buffer.data(), "list\n", 5);
+	EXPECT_TRUE(bridge->ReadWrite(write_cdb, buffer));
+	const auto command = bridge->TakeRasctlControlRequest();
+	ASSERT_TRUE(command.has_value());
+	EXPECT_EQ("list\n", *command);
+
+	bridge->SetRasctlControlResponse("No devices currently attached.\n");
+	buffer.assign(buffer.size(), 0xff);
+	EXPECT_EQ(1024, bridge->GetMessage10(read_cdb, buffer));
+	EXPECT_STREQ("No devices currently attached.\n", reinterpret_cast<const char *>(buffer.data()));
+
+	bridge->SetRasctlControlResponse("PiSCSI shutdown requested\n", SCSIBR::rasctl_shutdown_mode::stop_piscsi);
+	EXPECT_EQ(1024, bridge->GetMessage10(read_cdb, buffer));
+	EXPECT_EQ(SCSIBR::rasctl_shutdown_mode::stop_piscsi, bridge->TakeRasctlShutdownMode());
+}

--- a/cpp/test/scsictl_parser_test.cpp
+++ b/cpp/test/scsictl_parser_test.cpp
@@ -30,6 +30,8 @@ TEST(ScsictlParserTest, ParseType)
 {
 	ScsictlParser parser;
 
+	EXPECT_EQ(SCBR, parser.ParseType("SCBR"));
+	EXPECT_EQ(SCBR, parser.ParseType("scbr"));
 	EXPECT_EQ(SCCD, parser.ParseType("SCCD"));
 	EXPECT_EQ(SCCD, parser.ParseType("sccd"));
 	EXPECT_EQ(SCDP, parser.ParseType("scdp"));
@@ -40,6 +42,8 @@ TEST(ScsictlParserTest, ParseType)
 	EXPECT_EQ(SCRM, parser.ParseType("scrm"));
 	EXPECT_EQ(SCTP, parser.ParseType("sctp"));
 
+	EXPECT_EQ(SCBR, parser.ParseType("B"));
+	EXPECT_EQ(SCBR, parser.ParseType("b"));
 	EXPECT_EQ(SCCD, parser.ParseType("C"));
 	EXPECT_EQ(SCCD, parser.ParseType("c"));
 	EXPECT_EQ(SCDP, parser.ParseType("d"));

--- a/doc/piscsi-network-profile.8
+++ b/doc/piscsi-network-profile.8
@@ -1,9 +1,9 @@
-.Dd August 22, 2026
+.Dd August 30, 2026
 .Dt PISCSI-NETWORK-PROFILE 8
 .Os PiSCSI
 .Sh NAME
 .Nm piscsi-network-profile
-.Nd explicitly manage PiSCSI DaynaPort network profiles
+.Nd manage PiSCSI network profiles on the Linux host
 .Sh SYNOPSIS
 .Nm
 .Op Fl Fl dry-run
@@ -23,7 +23,7 @@
 .Sh DESCRIPTION
 .Nm
 creates or removes only the named NetworkManager connections and PiSCSI
-configuration used by the DaynaPort network adapter.
+configuration used by the DaynaPort and Host Bridge network adapters.
 It is not a general installer and does not modify existing user connections,
 routes, addresses, or firewall rules.
 .Pp
@@ -36,8 +36,13 @@ and
 NetworkManager connections, then activates the bridge.
 It disables STP to avoid an unnecessary forwarding delay and pins the bridge
 MAC address to the selected physical Ethernet interface, keeping it distinct
-from the DaynaPort TAP MAC.
-It is the protocol-complete profile for a wired connection.
+from the emulated client MAC address on the
+.Pa piscsi0
+TAP interface.
+It is the protocol-complete host-side profile for a wired connection.
+DaynaPort can use the complete Ethernet service it provides.
+Host Bridge uses the same profile, but its native driver receives only its own
+unicast frames and Ethernet broadcasts; it does not receive multicast traffic.
 .Pp
 The
 .Cm proxyarp
@@ -51,9 +56,9 @@ It requires the separately installed
 and
 .Nm dhcp-helper
 programs.
-Proxy ARP supports IPv4 unicast and DHCP only; it is not an Ethernet bridge
-and does not support IPv6, AppleTalk, multicast, mDNS, or other non-IP
-Ethernet traffic.
+Both adapters can use proxy ARP for IPv4 unicast and DHCP.
+It is not an Ethernet bridge and does not support IPv6, AppleTalk, multicast,
+mDNS, or other non-IP Ethernet traffic.
 .Sh SAFETY
 .Fl Fl dry-run
 prints the complete plan without changing the system.

--- a/doc/piscsi.1
+++ b/doc/piscsi.1
@@ -1,4 +1,4 @@
-.Dd August 23, 2026
+.Dd August 30, 2026
 .Dt PISCSI 1
 .Os PiSCSI
 .Sh NAME
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl b Ar BLOCK_SIZE
+.Op Fl c Ar RASCTL_CONTROL
 .Op Fl F Ar FOLDER
 .Op Fl L Ar LOG_LEVEL Ns Oo : Ar ID Ns Oo : Ar LUN Oc Oc
 .Op Fl n Ar VENDOR:PRODUCT:REVISION
@@ -38,35 +39,6 @@ However, typically SCSI ID 7 is reserved for the "initiator" (the host computer)
 The LUN is limited from 0-31.
 SASI hard disks support LUNs 0-1 only.
 .Pp
-PiSCSI will determine the type of device based upon the file extension of the FILE argument.
-    hds: Hard Disk image (generic, non-removable)
-    hd1: Hard Disk image (generic, non-removable, SCSI-1 compatibility mode)
-    hdr: Hard Disk image (generic, removable)
-    hdn: Hard Disk image (NEC compatible - only used with PC-98 computers)
-    hdi: Hard Disk image (Anex86 proprietary - only used with PC-98 computers)
-    nhd: Hard Disk image (T98Next proprietary - only used with PC-98 computers)
-    hda: Hard Disk image (Apple compatible - typically used with Macintosh computers)
-    hdf: Hard Disk image (XM6 SASI HD image - typically used with X68000)
-    mos: Magneto-Optical image (generic - typically used with NeXT, X68000, etc.)
-    iso: CD-ROM or DVD-ROM image (ISO 9660 image)
-    is1: CD-ROM or DVD-ROM image (ISO 9660 image, SCSI-1 compatibility mode)
-    tap: Tape image (raw tape image containing non-block data)
-    tar: Tape archive (tape block data in tar format)
-.Pp
-If the file extension is not recognized, the device type can be specified explicitly using the -t option and a four letter code.
-    SAHD: SASI Hard Disk (raw, non-removable)
-    SCCD: SCSI CD-ROM (generic CD-ROM or DVD-ROM drive)
-    SCDP: SCSI DaynaPort (DaynaPort compatible network adapter)
-    SCHD: SCSI Hard Disk (generic, non-removable)
-    SCHS: SCSI Host Services (used for special host services)
-    SCLP: SCSI Printer (generic line printer)
-    SCMO: SCSI Magneto-Optical Drive (generic MO drive)
-    SCRM: SCSI Removable Hard Disk (generic, removable)
-    SCTP: SCSI Tape Drive (generic tape, or streamer, drive)
-.Pp
-For example, if you want to specify an Apple-compatible HD image on ID 0, you can use the following command:
-    sudo piscsi -ID0 /path/to/drive/hdimage.hda
-.Pp
 Note: PiSCSI cannot be run in parallel with other applications that use the same GPIO pins, such as RaSCSI or SCSI2Pi.
 .Pp
 Once PiSCSI starts, it will open a socket (default port is 6868) to allow external management commands.
@@ -74,11 +46,11 @@ If another process is using this port, PiSCSI will terminate.
 Once PiSCSI has initialized, the scsictl utility can be used to send commands.
 .Pp
 To quit PiSCSI, press Control + C. If it is running in the background, you can kill it using an INT signal.
-.Sh CONNECTION TYPE
+.Sh CONNECTION TYPES
 The GPIO-facing tools select the board layout when they start. Use
 .Fl C
 to select one of the following types:
-.Bl -tag -width GAMERNIUM
+.Bl -tag -offset indent-two -width GAMERNIUM
 .It Dv FULLSPEC
 For boards with initiator support.
 .It Dv STANDARD
@@ -115,6 +87,202 @@ The supplied systemd service defaults to
 Override its
 .Ev PISCSI_CONNECTION_TYPE
 environment variable and restart the service to use a different mapping.
+.Sh DEVICE TYPES
+PiSCSI can emulate the following device types.
+The four letter code (case insensitive) can be passed to the -t option to select the device.
+A non-removable disk drive must be attached with an image file,
+while a removable disk drive can be attached either empty or with an image file.
+The other device types may require other parameters to attach, see the FILE argument documentation below.
+.Bl -tag -offset indent-two -width SAHD
+.It Dv SAHD
+SASI Hard Disk (takes image, non-removable)
+.It Dv SCBR
+SCSI Host Bridge (X68000 host bridge and Neptune-X compatible network adapter)
+.It Dv SCCD
+SCSI CD-ROM (CD-ROM or DVD-ROM drive, takes images, removable)
+.It Dv SCDP
+SCSI DaynaPort (DaynaPort SCSI/Link compatible network adapter)
+.It Dv SCHD
+SCSI Hard Disk (takes image, non-removable)
+.It Dv SCHS
+SCSI Host Services (used for special host services)
+.It Dv SCLP
+SCSI Printer (generic line printer)
+.It Dv SCMO
+SCSI Magneto-Optical Drive (takes image, removable)
+.It Dv SCRM
+SCSI Removable Hard Disk (takes image, removable)
+.It Dv SCTP
+SCSI Tape Drive (takes image, removable)
+.El
+.Pp
+If the device type is not specified as described above,
+PiSCSI will determine the type of device based upon the file extension of the FILE argument.
+.Bl -tag -offset indent-two -width toast
+.It Dv hds
+Hard Disk image (generic, non-removable)
+.It Dv hd1
+Hard Disk image (generic, non-removable, SCSI-1 compatibility mode)
+.It Dv hdr
+Hard Disk image (generic, removable)
+.It Dv hdn
+Hard Disk image (NEC compatible - only used with PC-98 computers)
+.It Dv hdi
+Hard Disk image (Anex86 proprietary - only used with PC-98 computers)
+.It Dv nhd
+Hard Disk image (T98Next proprietary - only used with PC-98 computers)
+.It Dv hda
+Hard Disk image (Apple compatible - typically used with Macintosh computers)
+.It Dv hdf
+Hard Disk image (raw SASI HD image - typically used with X68000)
+.It Dv mos
+Magneto-Optical image (generic, typically used with NeXT, X68000, etc.)
+.It Dv iso
+CD-ROM or DVD-ROM image (ISO 9660 image)
+.It Dv cdr
+CD-ROM or DVD-ROM image (ISO 9660 image)
+.It Dv toast
+CD-ROM or DVD-ROM image (ISO 9660 image)
+.It Dv is1
+CD-ROM or DVD-ROM image (ISO 9660 image, SCSI-1 compatibility mode)
+.It Dv tap
+Tape image (raw tape image containing non-block data)
+.It Dv tar
+Tape archive (tape block data in tar format)
+.El
+.Pp
+For example, if you want to specify an Apple-compatible HD image on ID 0, you can use the following command:
+    sudo piscsi -ID0 /path/to/drive/hdimage.hda
+.Sh IMAGE FILE FORMATS
+File extensions are case-insensitive.
+They select the default device type as described above, and some also enable
+compatibility handling or cause PiSCSI to read an image-format header.
+Most other hard disk images are raw block images and have no PiSCSI-specific
+on-disk header.
+.Ss Apple hard disks
+The
+.Pa .hda
+extension selects a generic hard disk with the INQUIRY identification
+.Dq QUANTUM FIREBALL .
+This compatibility identity allows Apple HD SC Setup on classic Mac OS to
+recognize and format the hard disk.
+.Ss PC-98 hard disks
+The
+.Pa .hdn ,
+.Pa .hdi ,
+and
+.Pa .nhd
+extensions select the PC-98 hard-disk implementation.
+It reports SCSI-1 CCS inquiry data and supplies PC-98 disk geometry in MODE
+SENSE pages.
+.Pp
+.Pa .hdn
+is a raw NEC PC-9801-55-style image.
+PiSCSI treats its data as beginning at offset zero and uses a geometry of 512
+bytes per sector, 25 sectors per track, and 8 heads.
+.Pp
+.Pa .hdi
+is the Anex86 format.
+PiSCSI reads its 512-byte image header for the data offset, image size, sector
+size, and geometry.
+.Pp
+.Pa .nhd
+is the T98Next format.
+PiSCSI requires the
+.Dq T98HDDIMAGE.R0
+signature in its header and reads the data offset and geometry from that
+header.
+For both formats, this metadata determines how PiSCSI accesses the payload;
+it is not interpreted as a PC-98 boot sector.
+.Ss SASI hard disks
+The
+.Pa .hdf
+extension selects a SASI hard disk, typically used with X68000 systems.
+It is a raw image, not a separately parsed HDF container.
+The default sector size is 256 bytes; use
+.Fl b
+to select 256, 512, or 1024 bytes.
+SASI addressing limits an image to 2,097,152 blocks.
+.Pp
+PiSCSI derives the capacity from the file length; it does not recognize
+capacity-specific HDF variants.
+.Ss Other extension-specific handling
+.Pa .hd1
+and
+.Pa .is1
+select SCSI-1 CCS compatibility for hard disks and CD-ROMs, respectively.
+.Pa .hdr
+selects a removable hard disk.
+.Pa .mos
+selects a removable magneto-optical disk; several common medium capacities
+have predefined geometry.
+.Pp
+.Pa .iso ,
+.Pa .cdr ,
+and
+.Pa .toast
+select a read-only CD-ROM.
+PiSCSI inspects the beginning of the file to distinguish a raw Mode 1 CD image
+from a normal ISO image; CUE sheets are detected and rejected.
+.Sh NETWORK INTERFACES
+PiSCSI emulates two SCSI network interfaces: SCDP (DaynaPort) and SCBR (Host Bridge).
+For these devices, the
+.Ar FILE
+argument is not an image file; it selects a host networking profile with a complete
+.Cm mode
+and
+.Cm interface
+pair.
+For example, use
+.Dq mode=bridge:interface=piscsi_bridge
+or
+.Dq mode=proxyarp:interface=wlan0 .
+The
+.Xr piscsi-network-profile 8
+script configures the host-side profile before the network adapter is attached;
+see its manual page for setup instructions and examples.
+.Ss Device compatibility
+SCDP is reverse engineered from the DaynaPort SCSI/Link Ethernet adapter and uses its drivers or compatible drivers.
+SCBR is reverse engineered from the Neptune-X Ethernet adapter and uses its drivers or compatible drivers, including the RASETHER driver from the RaSCSI project.
+SCBR also provides the X68000 host bridge, including its host file-system service and support for the RASCTL wire protocol.
+.Ss Wired bridge
+The
+.Cm bridge
+profile connects the emulated adapter to a preconfigured wired Linux bridge and provides complete Ethernet service, including DHCP, AppleTalk, multicast, and non-IP Ethernet protocols.
+Configure this profile with a NetworkManager-managed Ethernet interface.
+It creates the
+.Pa piscsi_bridge
+bridge, which owns the physical Ethernet port, its address, and DHCP configuration.
+Attach an adapter using
+.Dq mode=bridge:interface=piscsi_bridge .
+SCDP can use the complete Ethernet service; the SCBR driver accepts only its own unicast frames and Ethernet broadcasts.
+.Ss Wi-Fi proxy ARP
+The
+.Cm proxyarp
+profile connects an emulated adapter to a NetworkManager-managed Wi-Fi uplink.
+Configure it with the Wi-Fi interface holding the Pi's IPv4 lease.
+This profile requires the
+.Pa parprouted
+and
+.Pa dhcp-helper
+packages.
+It provides IPv4 unicast and DHCP only; it is not an Ethernet bridge and does not support IPv6, AppleTalk, multicast, mDNS, or other non-IP Ethernet traffic.
+Attach an adapter using
+.Dq mode=proxyarp:interface=wlan0 .
+The SCBR driver remains limited to its own unicast frames and Ethernet broadcasts.
+.Ss Profile management
+The profile script manages only the named PiSCSI NetworkManager connections and
+.Pa /etc/piscsi/network.conf .
+Applying or removing a profile may interrupt host connectivity; see
+.Xr piscsi-network-profile 8
+for its usage and examples.
+Always provide both
+.Cm mode
+and
+.Cm interface ;
+the retired
+.Cm inet
+parameter and comma-separated interface lists are not supported.
 .Sh OPTIONS
 .Bl -tag -width Ds
 .It Fl b Ar BLOCK_SIZE
@@ -125,6 +293,16 @@ Other disk devices support 512, 1024, 2048, or 4096 bytes and default to 512 byt
 Select the board connection type for this process. See
 .Sx CONNECTION TYPE
 for the available mappings and their appropriate boards.
+.It Fl c Ar RASCTL_CONTROL
+Enable the unauthenticated RASCTL compatibility control channel on SCBR host bridges.
+The default is
+.Dq off .
+Use
+.Dq media
+to permit listing and media-management commands, or
+.Dq full
+to additionally permit PiSCSI and system shutdown commands.
+Only enable this option when all SCSI initiators are trusted.
 .It Fl F Ar FOLDER
 The default folder for image files. For files in this folder no absolute path needs to be specified. The folder must already exist. The initial default folder is '/var/lib/piscsi/images'.
 .It Fl h
@@ -155,7 +333,11 @@ n is the SCSI or SASI ID number (0-7).
 u is the optional LUN (logical unit): 0-31 for SCSI and 0-1 for SASI.
 The default LUN is 0.
 .Pp
-FILE is the name of the image file to use for a SCSI or SASI mass storage device. For devices that do not support an image file (SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCDP it selects one explicit host networking profile: \fBmode=bridge:interface=piscsi_bridge\fR for a preconfigured wired Linux bridge, or \fBmode=proxyarp:interface=wlan0\fR for the configured Wi-Fi proxy-ARP uplink. The proxy-ARP profile supports IPv4 unicast and DHCP only; it is not an Ethernet bridge and does not support IPv6, AppleTalk, multicast, mDNS, or other non-IP Ethernet traffic. For SCLP it is the print command to be used and a reservation timeout in seconds, e.g. "cmd=lp -oraw %f:timeout=60".
+FILE is the name of the image file to use for a SCSI or SASI mass storage device.
+For devices that do not support an image file (SCBR, SCDP, SCLP, SCHS) the filename may have a special meaning
+or a dummy name can be provided. For SCBR and SCDP it selects the host networking profile; see
+.Sx NETWORK INTERFACES .
+For SCLP it is the print command to be used and a reservation timeout in seconds, e.g. "cmd=lp -oraw %f:timeout=60".
 .El
 .Sh EXAMPLES
 Launch PiSCSI with no emulated drives attached:

--- a/doc/scsictl.1
+++ b/doc/scsictl.1
@@ -116,6 +116,8 @@ Specifies the device type. This type overrides the type derived from the file ex
 .It
 cd: CD-ROM
 .It
+bridge: X68000 host bridge (networking and host file system)
+.It
 daynaport: DaynaPort Network Adapter
 .It
 hd: Hard Disk
@@ -159,10 +161,10 @@ Example output:
 Request the PiSCSI process to attach a disk to SCSI ID 0 with the contents of the file system image "HDIIMAGE0.HDS".
 .Dl Nm scsictl Fl c No a Fl i No 0 Fl f No HDIIMAGE0.HDS
 .Pp
-Attach a DaynaPort to the preconfigured wired bridge. DaynaPort mode and interface are a single, explicit parameter value:
+Attach a DaynaPort to the preconfigured wired bridge. Its mode and interface is a single, explicit parameter value:
 .Dl Nm scsictl Fl i No 6 Fl c No attach Fl t No scdp Fl f No "mode=bridge:interface=piscsi_bridge"
 .Pp
-Attach a DaynaPort through a configured Wi-Fi proxy-ARP uplink. This profile supports IPv4 unicast and DHCP only; it is not an Ethernet bridge:
+Attach a DaynaPort through a configured Wi-Fi proxy-ARP uplink:
 .Dl Nm scsictl Fl i No 6 Fl c No attach Fl t No scdp Fl f No "mode=proxyarp:interface=wlan0"
 .Sh SEE ALSO
 .Xr piscsi 1 ,

--- a/go/piscsi-ctrlboard/attach_menu.go
+++ b/go/piscsi-ctrlboard/attach_menu.go
@@ -29,10 +29,11 @@ type DeviceAttachSelection struct {
 	Params map[string]string
 }
 
-// NetworkTopologySelection identifies the daemon-advertised DaynaPort mode
-// and host interface selected by the user.
+// NetworkTopologySelection identifies the daemon-advertised network mode and
+// host interface selected by the user.
 type NetworkTopologySelection struct {
 	Slot      SCSISlot
+	Type      pb.PbDeviceType
 	Mode      string
 	Interface string
 }
@@ -104,9 +105,9 @@ func AddAttachWithoutMediaOption(menu *Menu, selection DeviceTypeSelection) {
 	menu.Items[1] = item
 }
 
-// NewNetworkTopologyMenu shows the DaynaPort profiles actively advertised by
-// the daemon. Down interfaces and unsupported modes are deliberately omitted.
-func NewNetworkTopologyMenu(slot SCSISlot, interfaces []*pb.PbNetworkInterface, pageSize int) (*Menu, error) {
+// NewNetworkTopologyMenu shows the network profiles actively advertised by the
+// daemon. Down interfaces and unsupported modes are deliberately omitted.
+func NewNetworkTopologyMenu(slot SCSISlot, deviceType pb.PbDeviceType, interfaces []*pb.PbNetworkInterface, pageSize int) (*Menu, error) {
 	profiles := make([]NetworkTopologySelection, 0)
 	for _, networkInterface := range interfaces {
 		if networkInterface == nil || !networkInterface.GetUp() || networkInterface.GetName() == "" {
@@ -114,7 +115,7 @@ func NewNetworkTopologyMenu(slot SCSISlot, interfaces []*pb.PbNetworkInterface, 
 		}
 		for _, mode := range networkInterface.GetSupportedMode() {
 			if mode == "bridge" || mode == "proxyarp" {
-				profiles = append(profiles, NetworkTopologySelection{Slot: slot, Mode: mode, Interface: networkInterface.GetName()})
+				profiles = append(profiles, NetworkTopologySelection{Slot: slot, Type: deviceType, Mode: mode, Interface: networkInterface.GetName()})
 			}
 		}
 	}
@@ -154,6 +155,8 @@ func deviceTypeName(deviceType pb.PbDeviceType) string {
 		return "SCSI Magneto-Optical"
 	case pb.PbDeviceType_SCCD:
 		return "SCSI CD-ROM"
+	case pb.PbDeviceType_SCBR:
+		return "Host Bridge"
 	case pb.PbDeviceType_SCDP:
 		return "Ethernet Adapter"
 	case pb.PbDeviceType_SCHS:

--- a/go/piscsi-ctrlboard/attach_menu_test.go
+++ b/go/piscsi-ctrlboard/attach_menu_test.go
@@ -33,7 +33,7 @@ func TestDeviceTypeMenuUsesDaemonTypesAndRetainsSlot(t *testing.T) {
 }
 
 func TestNetworkTopologyMenuOnlyOffersReadySupportedProfiles(t *testing.T) {
-	menu, err := NewNetworkTopologyMenu(SCSISlot{ID: 2}, []*pb.PbNetworkInterface{
+	menu, err := NewNetworkTopologyMenu(SCSISlot{ID: 2}, pb.PbDeviceType_SCDP, []*pb.PbNetworkInterface{
 		{Name: "wlan0", Up: true, SupportedMode: []string{"proxyarp", "ignored"}},
 		{Name: "eth0", Up: true, SupportedMode: []string{"bridge"}},
 		{Name: "eth1", Up: false, SupportedMode: []string{"bridge"}},
@@ -48,7 +48,20 @@ func TestNetworkTopologyMenuOnlyOffersReadySupportedProfiles(t *testing.T) {
 		t.Fatalf("second topology = %q, want %q", got, want)
 	}
 	selection, ok := menu.Items[1].Data.(NetworkTopologySelection)
-	if !ok || selection.Mode != "bridge" || selection.Interface != "eth0" {
+	if !ok || selection.Type != pb.PbDeviceType_SCDP || selection.Mode != "bridge" || selection.Interface != "eth0" {
+		t.Fatalf("topology selection = %#v", menu.Items[1].Data)
+	}
+}
+
+func TestNetworkTopologyMenuRetainsHostBridgeType(t *testing.T) {
+	menu, err := NewNetworkTopologyMenu(SCSISlot{ID: 2}, pb.PbDeviceType_SCBR, []*pb.PbNetworkInterface{
+		{Name: "eth0", Up: true, SupportedMode: []string{"bridge"}},
+	}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection, ok := menu.Items[1].Data.(NetworkTopologySelection)
+	if !ok || selection.Type != pb.PbDeviceType_SCBR {
 		t.Fatalf("topology selection = %#v", menu.Items[1].Data)
 	}
 }

--- a/go/piscsi-ctrlboard/menu_builder.go
+++ b/go/piscsi-ctrlboard/menu_builder.go
@@ -85,6 +85,9 @@ func slotLabel(slot SCSISlot, deviceCount int) string {
 	if slot.Device == nil {
 		return fmt.Sprintf("%d: (empty)", slot.ID)
 	}
+	if slot.Device.GetType() == pb.PbDeviceType_SCBR {
+		return fmt.Sprintf("%d: Host Bridge", slot.ID)
+	}
 	if slot.Device.GetType() == pb.PbDeviceType_SCDP {
 		return fmt.Sprintf("%d: Daynaport", slot.ID)
 	}

--- a/go/piscsi-ctrlboard/menu_builder_test.go
+++ b/go/piscsi-ctrlboard/menu_builder_test.go
@@ -33,3 +33,14 @@ func TestSCSIMenuBuilderLabelsReservedAndAttachedSlots(t *testing.T) {
 		t.Fatalf("slot 3 = %q, want %q", got, want)
 	}
 }
+
+func TestSlotLabelRecognizesBothNetworkAdapters(t *testing.T) {
+	for deviceType, want := range map[pb.PbDeviceType]string{
+		pb.PbDeviceType_SCBR: "2: Host Bridge",
+		pb.PbDeviceType_SCDP: "2: Daynaport",
+	} {
+		if got := slotLabel(SCSISlot{ID: 2, Device: &pb.PbDevice{Type: deviceType}}, 1); got != want {
+			t.Fatalf("slot label for %s = %q, want %q", deviceType, got, want)
+		}
+	}
+}

--- a/go/piscsi-ctrlboard/workflow.go
+++ b/go/piscsi-ctrlboard/workflow.go
@@ -226,9 +226,9 @@ func (w *SCSIWorkflow) BuildDeviceTypeMenu(ctx context.Context, slot SCSISlot, p
 	return NewDeviceTypeMenu(slot, result.GetDeviceTypesInfo().GetProperties(), pageSize)
 }
 
-// BuildNetworkTopologyMenu retrieves the DaynaPort profiles advertised by the
+// BuildNetworkTopologyMenu retrieves the network profiles advertised by the
 // daemon, including their live interface state and supported modes.
-func (w *SCSIWorkflow) BuildNetworkTopologyMenu(ctx context.Context, slot SCSISlot, pageSize int) (*Menu, error) {
+func (w *SCSIWorkflow) BuildNetworkTopologyMenu(ctx context.Context, slot SCSISlot, deviceType pb.PbDeviceType, pageSize int) (*Menu, error) {
 	if err := w.ready(ctx); err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (w *SCSIWorkflow) BuildNetworkTopologyMenu(ctx context.Context, slot SCSISl
 	if !result.GetStatus() {
 		return nil, resultError("list network topologies", result)
 	}
-	return NewNetworkTopologyMenu(slot, result.GetNetworkInterfacesInfo().GetInterfaces(), pageSize)
+	return NewNetworkTopologyMenu(slot, deviceType, result.GetNetworkInterfacesInfo().GetInterfaces(), pageSize)
 }
 
 // AttachDevice attaches a file-less device using its selected defaults.
@@ -530,9 +530,9 @@ func (c *WorkflowController) Handle(item MenuItem) {
 			})
 			return
 		}
-		if selected.Type == pb.PbDeviceType_SCDP {
+		if selected.Type == pb.PbDeviceType_SCBR || selected.Type == pb.PbDeviceType_SCDP {
 			c.start("Loading topologies", func(ctx context.Context) (string, error) {
-				topologies, err := c.workflow.BuildNetworkTopologyMenu(ctx, selected.Slot, c.pageSize)
+				topologies, err := c.workflow.BuildNetworkTopologyMenu(ctx, selected.Slot, selected.Type, c.pageSize)
 				if err == nil {
 					err = c.menu.Push(topologies)
 				}
@@ -555,7 +555,7 @@ func (c *WorkflowController) Handle(item MenuItem) {
 	case NetworkTopologySelection:
 		c.start("Working", func(ctx context.Context) (string, error) {
 			return c.workflow.AttachDevice(ctx, DeviceAttachSelection{
-				Slot: selected.Slot, Type: pb.PbDeviceType_SCDP,
+				Slot: selected.Slot, Type: selected.Type,
 				Params: map[string]string{"mode": selected.Mode, "interface": selected.Interface},
 			})
 		})

--- a/go/piscsi-web/internal/server/device_workflows.go
+++ b/go/piscsi-web/internal/server/device_workflows.go
@@ -143,24 +143,28 @@ func removableDeviceType(deviceType pb.PbDeviceType) bool {
 	}
 }
 
-func parseDaynaPortProfile(value string) (string, string, error) {
+func networkTopologyDeviceType(deviceType pb.PbDeviceType) bool {
+	return deviceType == pb.PbDeviceType_SCBR || deviceType == pb.PbDeviceType_SCDP
+}
+
+func parseNetworkTopology(value string) (string, string, error) {
 	mode, interfaceName, found := strings.Cut(value, ":")
 	if !found || mode == "" || interfaceName == "" || strings.Contains(interfaceName, ":") {
-		return "", "", fmt.Errorf("invalid DaynaPort network profile")
+		return "", "", fmt.Errorf("invalid network topology")
 	}
 	if mode != "bridge" && mode != "proxyarp" {
-		return "", "", fmt.Errorf("unsupported DaynaPort network mode %q", mode)
+		return "", "", fmt.Errorf("unsupported network mode %q", mode)
 	}
 	return mode, interfaceName, nil
 }
 
-// daynaPortProfileStatus validates the topology advertised by the daemon. The
+// networkTopologyStatus validates the topology advertised by the daemon. The
 // daemon is also responsible for the final host-side validation (notably the
 // configured proxy-ARP uplink), so the web app never infers readiness from
 // obsolete NAT, dhcpcd, or ifupdown files.
-func daynaPortProfileStatus(mode string, networkInterface *pb.PbNetworkInterface) (bool, string) {
+func networkTopologyStatus(mode string, networkInterface *pb.PbNetworkInterface) (bool, string) {
 	if mode != "bridge" && mode != "proxyarp" {
-		return false, fmt.Sprintf("Unsupported DaynaPort network mode %q", mode)
+		return false, fmt.Sprintf("Unsupported network mode %q", mode)
 	}
 	if networkInterface == nil {
 		return false, "The selected network interface is not advertised by the PiSCSI daemon"
@@ -177,5 +181,5 @@ func daynaPortProfileStatus(mode string, networkInterface *pb.PbNetworkInterface
 		}
 		return true, "Wi-Fi proxy-ARP profile is active and ready (IPv4 unicast and DHCP only)"
 	}
-	return false, fmt.Sprintf("Network interface %s does not support the DaynaPort %s profile", networkInterface.GetName(), mode)
+	return false, fmt.Sprintf("Network interface %s does not support the selected %s topology", networkInterface.GetName(), mode)
 }

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -161,8 +161,8 @@ func (s *Server) handleIndex(c *gin.Context) {
 	validScsiIds, recommendedScsiId := validSCSIIDs(reserved, occupiedIDs)
 
 	// Build the attachment catalog from the daemon's advertised device
-	// capabilities. Typed network interfaces advertise the valid DaynaPort
-	// topology/profile combinations.
+	// capabilities. Typed network interfaces advertise valid topology/profile
+	// combinations for network devices.
 	var deviceTypesInfo *pb.PbDeviceTypesInfo
 	if result, err := s.piscsiClient.SendCommand(cmdBuilder.GetDeviceTypesInfo()); err == nil && result.GetStatus() {
 		deviceTypesInfo = result.GetDeviceTypesInfo()
@@ -514,6 +514,8 @@ func deviceTypeName(deviceType pb.PbDeviceType) string {
 		return "SCSI Magneto-Optical"
 	case pb.PbDeviceType_SCCD:
 		return "SCSI CD-ROM"
+	case pb.PbDeviceType_SCBR:
+		return "Host Bridge"
 	case pb.PbDeviceType_SCDP:
 		return "Ethernet Adapter"
 	case pb.PbDeviceType_SCLP:
@@ -541,12 +543,13 @@ type deviceCatalogEntry struct {
 	Removable     bool
 	SupportsFile  bool
 	Parameters    []deviceParameterControl
-	DaynaProfiles []daynaPortProfile
-	Files         []map[string]interface{}
-	DriveProfiles []string
+	UsesNetworkTopology bool
+	NetworkProfiles     []networkTopology
+	Files               []map[string]interface{}
+	DriveProfiles       []string
 }
 
-type daynaPortProfile struct {
+type networkTopology struct {
 	Mode      string
 	Interface string
 	Label     string
@@ -572,11 +575,12 @@ func (s *Server) buildDeviceCatalog(
 
 		properties := typeProperties.GetProperties()
 		entry := deviceCatalogEntry{
-			Key:          deviceType.String(),
-			Name:         deviceTypeName(deviceType),
-			MaxLUN:       piscsi.MaxLUN(deviceType),
-			Removable:    properties.GetRemovable(),
-			SupportsFile: properties.GetSupportsFile(),
+			Key:                 deviceType.String(),
+			Name:                deviceTypeName(deviceType),
+			MaxLUN:              piscsi.MaxLUN(deviceType),
+			Removable:           properties.GetRemovable(),
+			SupportsFile:        properties.GetSupportsFile(),
+			UsesNetworkTopology: networkTopologyDeviceType(deviceType),
 		}
 
 		paramKeys := make([]string, 0, len(properties.GetDefaultParams()))
@@ -585,7 +589,7 @@ func (s *Server) buildDeviceCatalog(
 		}
 		sort.Strings(paramKeys)
 		for _, key := range paramKeys {
-			if deviceType == pb.PbDeviceType_SCDP && (key == "interface" || key == "mode") {
+			if entry.UsesNetworkTopology && (key == "interface" || key == "mode") {
 				continue
 			}
 			defaultValue := properties.GetDefaultParams()[key]
@@ -606,13 +610,13 @@ func (s *Server) buildDeviceCatalog(
 			}
 			entry.Parameters = append(entry.Parameters, control)
 		}
-		if deviceType == pb.PbDeviceType_SCDP {
+		if entry.UsesNetworkTopology {
 			for _, networkInterface := range networkInterfaces {
 				if !networkInterface.GetUp() {
 					continue
 				}
 				for _, mode := range networkInterface.GetSupportedMode() {
-					profile := daynaPortProfile{Mode: mode, Interface: networkInterface.GetName()}
+					profile := networkTopology{Mode: mode, Interface: networkInterface.GetName()}
 					switch mode {
 					case "bridge":
 						profile.Label = "Wired bridge"
@@ -621,14 +625,14 @@ func (s *Server) buildDeviceCatalog(
 					default:
 						continue
 					}
-					entry.DaynaProfiles = append(entry.DaynaProfiles, profile)
+					entry.NetworkProfiles = append(entry.NetworkProfiles, profile)
 				}
 			}
-			sort.Slice(entry.DaynaProfiles, func(i, j int) bool {
-				if entry.DaynaProfiles[i].Mode == entry.DaynaProfiles[j].Mode {
-					return entry.DaynaProfiles[i].Interface < entry.DaynaProfiles[j].Interface
+			sort.Slice(entry.NetworkProfiles, func(i, j int) bool {
+				if entry.NetworkProfiles[i].Mode == entry.NetworkProfiles[j].Mode {
+					return entry.NetworkProfiles[i].Interface < entry.NetworkProfiles[j].Interface
 				}
-				return entry.DaynaProfiles[i].Mode == "bridge"
+				return entry.NetworkProfiles[i].Mode == "bridge"
 			})
 		}
 
@@ -762,23 +766,29 @@ func (s *Server) handleAttach(c *gin.Context) {
 
 	cmdBuilder := s.getCommandBuilder(c)
 
-	// DaynaPort attachments always use an explicit mode/interface pair. The
+	// Network-device attachments always use an explicit mode/interface pair. The
 	// profile selector is the web form representation; direct clients may send
 	// param_mode and param_interface instead.
 	profileMessage := ""
-	if pbType == pb.PbDeviceType_SCDP {
-		if profile := c.PostForm("daynaport_profile"); profile != "" {
-			mode, interfaceName, profileErr := parseDaynaPortProfile(profile)
+	if networkTopologyDeviceType(pbType) {
+		profile := c.PostForm("network_topology")
+		if profile == "" && pbType == pb.PbDeviceType_SCDP {
+			// Keep existing DaynaPort form submissions working while the UI
+			// switches to the device-neutral field name.
+			profile = c.PostForm("daynaport_profile")
+		}
+		if profile != "" {
+			mode, interfaceName, profileErr := parseNetworkTopology(profile)
 			if profileErr != nil {
 				s.respond(c, ResponseOptions{Error: true, Message: profileErr.Error()})
 				return
 			}
 			if requestedMode, ok := params["mode"]; ok && requestedMode != mode {
-				s.respond(c, ResponseOptions{Error: true, Message: "DaynaPort mode does not match the selected profile"})
+				s.respond(c, ResponseOptions{Error: true, Message: "Network mode does not match the selected topology"})
 				return
 			}
 			if requestedInterface, ok := params["interface"]; ok && requestedInterface != interfaceName {
-				s.respond(c, ResponseOptions{Error: true, Message: "DaynaPort interface does not match the selected profile"})
+				s.respond(c, ResponseOptions{Error: true, Message: "Network interface does not match the selected topology"})
 				return
 			}
 			params["mode"] = mode
@@ -788,7 +798,7 @@ func (s *Server) handleAttach(c *gin.Context) {
 		mode := params["mode"]
 		interfaceName := params["interface"]
 		if mode == "" || interfaceName == "" {
-			s.respond(c, ResponseOptions{Error: true, Message: "Select a DaynaPort network profile (mode and interface)"})
+			s.respond(c, ResponseOptions{Error: true, Message: "Select a network topology (mode and interface)"})
 			return
 		}
 		networkResult, networkErr := s.piscsiClient.SendCommand(cmdBuilder.GetNetworkInfo())
@@ -807,7 +817,7 @@ func (s *Server) handleAttach(c *gin.Context) {
 			s.respond(c, ResponseOptions{Error: true, Message: fmt.Sprintf("Network interface %s is not available", interfaceName)})
 			return
 		}
-		profileReady, message := daynaPortProfileStatus(mode, selectedInterface)
+		profileReady, message := networkTopologyStatus(mode, selectedInterface)
 		if !profileReady {
 			s.respond(c, ResponseOptions{Error: true, Message: message})
 			return

--- a/go/piscsi-web/internal/server/handlers_device_test.go
+++ b/go/piscsi-web/internal/server/handlers_device_test.go
@@ -122,7 +122,7 @@ func TestHandleAttach_ForwardsDaemonDefinedParameters(t *testing.T) {
 	}
 }
 
-func TestHandleAttach_UsesSelectedDaynaPortProfile(t *testing.T) {
+func TestHandleAttach_UsesSelectedNetworkTopology(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	var attached *pb.PbDeviceDefinition
 	server := &Server{
@@ -149,7 +149,7 @@ func TestHandleAttach_UsesSelectedDaynaPortProfile(t *testing.T) {
 
 	router := gin.New()
 	router.POST("/scsi/attach", server.handleAttach)
-	form := url.Values{"scsi_id": {"6"}, "type": {"SCDP"}, "daynaport_profile": {"proxyarp:wlan0"}}
+	form := url.Values{"scsi_id": {"6"}, "type": {"SCDP"}, "network_topology": {"proxyarp:wlan0"}}
 	request := httptest.NewRequest(http.MethodPost, "/scsi/attach", strings.NewReader(form.Encode()))
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response := httptest.NewRecorder()
@@ -163,8 +163,57 @@ func TestHandleAttach_UsesSelectedDaynaPortProfile(t *testing.T) {
 	}
 }
 
+func TestHandleAttach_HostBridgeUsesSelectedNetworkTopology(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var attached *pb.PbDeviceDefinition
+	server := &Server{
+		sessionStore: sessions.NewCookieStore([]byte("test-secret-key")),
+		config:       &config.Config{},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		piscsiClient: &testutil.MockPiSCSIClient{SendCommandFunc: func(command *pb.PbCommand) (*pb.PbResult, error) {
+			switch command.GetOperation() {
+			case pb.PbOperation_NETWORK_INTERFACES_INFO:
+				return &pb.PbResult{Status: true, Result: &pb.PbResult_NetworkInterfacesInfo{
+					NetworkInterfacesInfo: &pb.PbNetworkInterfacesInfo{Interfaces: []*pb.PbNetworkInterface{{
+						Name: "piscsi_bridge", Up: true, SupportedMode: []string{"bridge"},
+					}}},
+				}}, nil
+			case pb.PbOperation_ATTACH:
+				attached = command.GetDevices()[0]
+				return &pb.PbResult{Status: true}, nil
+			default:
+				t.Fatalf("unexpected operation %s", command.GetOperation())
+				return nil, nil
+			}
+		}},
+	}
+
+	router := gin.New()
+	router.POST("/scsi/attach", server.handleAttach)
+	form := url.Values{
+		"scsi_id":         {"6"},
+		"type":            {"SCBR"},
+		"network_topology": {"bridge:piscsi_bridge"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/scsi/attach", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d; body: %s", response.Code, response.Body.String())
+	}
+	if attached == nil || attached.GetType() != pb.PbDeviceType_SCBR {
+		t.Fatalf("attached device = %#v", attached)
+	}
+	if got := attached.GetParams(); got["mode"] != "bridge" || got["interface"] != "piscsi_bridge" {
+		t.Fatalf("Host Bridge params = %#v", got)
+	}
+}
+
 func TestParseDeviceTypeSupportsEveryCurrentProtobufType(t *testing.T) {
-	for _, name := range []string{"SAHD", "SCHD", "SCRM", "SCMO", "SCCD", "SCDP", "SCHS", "SCLP", "SCTP"} {
+	for _, name := range []string{"SAHD", "SCHD", "SCRM", "SCMO", "SCCD", "SCBR", "SCDP", "SCHS", "SCLP", "SCTP"} {
 		t.Run(name, func(t *testing.T) {
 			got, err := parseDeviceType(strings.ToLower(name))
 			if err != nil {
@@ -203,6 +252,12 @@ func TestBuildDeviceCatalogUsesDaemonCapabilities(t *testing.T) {
 			},
 		},
 		{
+			Type: pb.PbDeviceType_SCBR,
+			Properties: &pb.PbDeviceProperties{
+				DefaultParams: map[string]string{"interface": "piscsi_bridge", "mode": "bridge"},
+			},
+		},
+		{
 			Type: pb.PbDeviceType_SCTP,
 			Properties: &pb.PbDeviceProperties{
 				SupportsFile: true,
@@ -215,30 +270,37 @@ func TestBuildDeviceCatalogUsesDaemonCapabilities(t *testing.T) {
 		{Name: "piscsi_bridge", Type: pb.PbNetworkInterfaceType_NETWORK_INTERFACE_BRIDGE, Up: true, SupportedMode: []string{"bridge"}},
 		{Name: "wlan0", Type: pb.PbNetworkInterfaceType_NETWORK_INTERFACE_WIFI, Up: true, SupportedMode: []string{"proxyarp"}},
 	})
-	if len(catalog) != 3 {
-		t.Fatalf("catalog length = %d, want 3", len(catalog))
+	if len(catalog) != 4 {
+		t.Fatalf("catalog length = %d, want 4", len(catalog))
 	}
-	if catalog[2].Key != "SAHD" || catalog[2].Name != "SASI Hard Disk" || catalog[2].MaxLUN != 1 {
-		t.Fatalf("unexpected SASI catalog entry: %#v", catalog[2])
+	if catalog[3].Key != "SAHD" || catalog[3].Name != "SASI Hard Disk" || catalog[3].MaxLUN != 1 {
+		t.Fatalf("unexpected SASI catalog entry: %#v", catalog[3])
 	}
-	if got, want := catalogFileNames(catalog[2]), []string{"disk.hdf"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("SASI files = %#v", catalog[2].Files)
+	if got, want := catalogFileNames(catalog[3]), []string{"disk.hdf"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SASI files = %#v", catalog[3].Files)
 	}
 	if catalog[0].Key != "SCDP" || len(catalog[0].Parameters) != 2 {
 		t.Fatalf("unexpected network catalog entry: %#v", catalog[0])
 	}
-	if len(catalog[0].DaynaProfiles) != 2 || catalog[0].DaynaProfiles[0].Mode != "bridge" ||
-		catalog[0].DaynaProfiles[1].Mode != "proxyarp" {
-		t.Fatalf("DaynaPort profiles = %#v", catalog[0].DaynaProfiles)
+	if !catalog[0].UsesNetworkTopology || len(catalog[0].NetworkProfiles) != 2 || catalog[0].NetworkProfiles[0].Mode != "bridge" ||
+		catalog[0].NetworkProfiles[1].Mode != "proxyarp" {
+		t.Fatalf("DaynaPort topologies = %#v", catalog[0].NetworkProfiles)
 	}
 	if catalog[0].Parameters[1].Kind != "number" {
 		t.Fatalf("timeout control = %#v, want number", catalog[0].Parameters[1])
 	}
-	if !catalog[1].SupportsFile || !catalog[1].Removable {
-		t.Fatalf("unexpected tape capabilities: %#v", catalog[1])
+	if catalog[1].Key != "SCBR" || catalog[1].Name != "Host Bridge" || len(catalog[1].Parameters) != 0 {
+		t.Fatalf("unexpected Host Bridge catalog entry: %#v", catalog[1])
 	}
-	if len(catalog[1].Files) != 1 || catalog[1].Files[0]["Name"] != "backup.tap" {
-		t.Fatalf("tape files = %#v", catalog[1].Files)
+	if !catalog[1].UsesNetworkTopology || len(catalog[1].NetworkProfiles) != 2 ||
+		catalog[1].NetworkProfiles[0].Mode != "bridge" || catalog[1].NetworkProfiles[1].Mode != "proxyarp" {
+		t.Fatalf("Host Bridge topologies = %#v", catalog[1])
+	}
+	if !catalog[2].SupportsFile || !catalog[2].Removable {
+		t.Fatalf("unexpected tape capabilities: %#v", catalog[2])
+	}
+	if len(catalog[2].Files) != 1 || catalog[2].Files[0]["Name"] != "backup.tap" {
+		t.Fatalf("tape files = %#v", catalog[2].Files)
 	}
 }
 
@@ -377,26 +439,26 @@ func TestHandleAttachAppliesImagePropertiesIdentity(t *testing.T) {
 	}
 }
 
-func TestDaynaPortProfileStatus(t *testing.T) {
+func TestNetworkTopologyStatus(t *testing.T) {
 	bridge := &pb.PbNetworkInterface{Name: "piscsi_bridge", Up: true, SupportedMode: []string{"bridge"}}
-	if ready, message := daynaPortProfileStatus("bridge", bridge); !ready || !strings.Contains(message, "Wired bridge") {
+	if ready, message := networkTopologyStatus("bridge", bridge); !ready || !strings.Contains(message, "Wired bridge") {
 		t.Fatalf("bridge ready = %v, message = %q", ready, message)
 	}
 	wifi := &pb.PbNetworkInterface{Name: "wlan0", Up: true, SupportedMode: []string{"proxyarp"}}
-	if ready, message := daynaPortProfileStatus("proxyarp", wifi); !ready || !strings.Contains(message, "IPv4") {
+	if ready, message := networkTopologyStatus("proxyarp", wifi); !ready || !strings.Contains(message, "IPv4") {
 		t.Fatalf("proxyarp ready = %v, message = %q", ready, message)
 	}
-	if ready, message := daynaPortProfileStatus("bridge", wifi); ready || !strings.Contains(message, "does not support") {
+	if ready, message := networkTopologyStatus("bridge", wifi); ready || !strings.Contains(message, "does not support") {
 		t.Fatalf("mismatched profile ready = %v, message = %q", ready, message)
 	}
 }
 
-func TestParseDaynaPortProfile(t *testing.T) {
-	mode, interfaceName, err := parseDaynaPortProfile("proxyarp:wlan0")
+func TestParseNetworkTopology(t *testing.T) {
+	mode, interfaceName, err := parseNetworkTopology("proxyarp:wlan0")
 	if err != nil || mode != "proxyarp" || interfaceName != "wlan0" {
 		t.Fatalf("parse profile = %q, %q, %v", mode, interfaceName, err)
 	}
-	if _, _, err := parseDaynaPortProfile("proxyarp:eth0:extra"); err == nil {
+	if _, _, err := parseNetworkTopology("proxyarp:eth0:extra"); err == nil {
 		t.Fatal("invalid profile was accepted")
 	}
 }

--- a/go/piscsi-web/internal/server/manpage.go
+++ b/go/piscsi-web/internal/server/manpage.go
@@ -54,7 +54,7 @@ var piscsiManpages = []manpage{
 	{App: "scsidump", Section: 1, Description: "SCSI disk dumping tool for PiSCSI."},
 	{App: "scsiloop", Section: 1, Description: "Tests a PiSCSI board with a loopback adapter."},
 	{App: "scsimon", Section: 1, Description: "Captures traffic on the SCSI bus."},
-	{App: "piscsi-network-profile", Section: 8, Description: "Manages PiSCSI DaynaPort network profiles."},
+	{App: "piscsi-network-profile", Section: 8, Description: "Manages PiSCSI network profiles on the Linux host."},
 }
 
 // findSystemManpage finds a source manpage in the system locations used by

--- a/go/piscsi-web/web/static/themes/modern/style.css
+++ b/go/piscsi-web/web/static/themes/modern/style.css
@@ -517,6 +517,7 @@ table#attached-devices tr.reserved td {
     background-image: url("icons/device-optical.svg");
   }
 
+  table#attached-devices tr.device-scbr td.name,
   table#attached-devices tr.device-scdp td.name {
     background-image: url("icons/device-network.svg");
   }

--- a/go/piscsi-web/web/templates/index.html
+++ b/go/piscsi-web/web/templates/index.html
@@ -400,13 +400,13 @@ Please create the PiSCSI configuration dir to use configurations: {{.ConfigDir}}
         <td>
             <form action="/scsi/attach" method="post" class="device-attach">
                 <input name="type" type="hidden" value="{{.Key}}">
-                {{if eq .Key "SCDP"}}
-                <label for="daynaport_profile_{{.Key}}">Topology:</label>
-                <select name="daynaport_profile" id="daynaport_profile_{{.Key}}" required>
-                    {{if not .DaynaProfiles}}
+                {{if .UsesNetworkTopology}}
+                <label for="network_topology_{{.Key}}">Topology:</label>
+                <select name="network_topology" id="network_topology_{{.Key}}" required>
+                    {{if not .NetworkProfiles}}
                     <option value="" selected disabled>No active wired bridge or Wi-Fi proxy-ARP profile</option>
                     {{end}}
-                    {{range .DaynaProfiles}}
+                    {{range .NetworkProfiles}}
                     <option value="{{.Mode}}:{{.Interface}}">{{.Label}} ({{.Interface}})</option>
                     {{end}}
                 </select>

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,10 @@ spdlog_dep = dependency('spdlog', required : true)
 fmt_dep = dependency('fmt', required : true)
 gtest_dep = dependency('gtest', required : false)
 gmock_dep = dependency('gmock', required : false)
+iconv_deps = []
+if host_machine.system() == 'darwin'
+  iconv_deps += meson.get_compiler('cpp').find_library('iconv', required : true)
+endif
 
 common_deps = [pthread_dep, spdlog_dep, fmt_dep]
 

--- a/os_integration/piscsi-network-profile
+++ b/os_integration/piscsi-network-profile
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Configure the named NetworkManager/PiSCSI objects used by DaynaPort.
+# Configure the named NetworkManager/PiSCSI objects used by PiSCSI network adapters.
 # Copyright (c) 2026, Daniel Markstedt <daniel@mindani.net>
 # Banner ASCII art by sonique6784
 # BSD 3-Clause License
@@ -154,7 +154,8 @@ write_proxyarp_config() {
 	trap 'rm -f "$tmp"' EXIT HUP INT TERM
 	cat >"$tmp" <<EOF
 # Managed by piscsi-network-profile. Wi-Fi proxy-ARP is active only while a
-# DaynaPort is attached with mode=proxyarp.
+# PiSCSI network adapter (DaynaPort or Host Bridge) is attached with
+# mode=proxyarp.
 PISCSI_PROXYARP_UPLINK=$uplink
 PISCSI_PROXYARP_PROMISC=true
 EOF

--- a/os_integration/proxyarp/README.md
+++ b/os_integration/proxyarp/README.md
@@ -1,10 +1,10 @@
 # PiSCSI NetworkManager profiles
 
-PiSCSI supports two explicitly selected DaynaPort topologies on Raspberry Pi
-OS Trixie and Forky with NetworkManager. Installing the PiSCSI package only
-installs inert templates, services, and `/etc/piscsi/network.conf`; it never
-creates a bridge, changes an active connection, starts proxy-ARP, or changes
-firewall state.
+PiSCSI supports two explicitly selected network-adapter topologies on Raspberry
+Pi OS Trixie and Forky with NetworkManager. DaynaPort and Host Bridge use the
+same host-side profiles. Installing the PiSCSI package only installs inert
+templates, services, and `/etc/piscsi/network.conf`; it never creates a bridge,
+changes an active connection, starts proxy-ARP, or changes firewall state.
 
 The required `parprouted` and `dhcp-helper` packages are suggested rather than
 installed automatically. This prevents `dhcp-helper`'s generic service from
@@ -12,10 +12,12 @@ binding DHCP on an existing host interface before the user selects proxy-ARP.
 
 ## Wired bridge
 
-Bridge mode is the protocol-complete choice: it supports DHCP, AppleTalk,
-multicast, and non-IP Ethernet protocols. NetworkManager must own the bridge,
-the physical Ethernet port, and the bridge address. PiSCSI owns only the
-ephemeral `piscsi0` TAP membership while a DaynaPort is attached.
+Bridge mode is the protocol-complete host-side choice: it supports DHCP,
+AppleTalk, multicast, and non-IP Ethernet protocols. NetworkManager must own
+the bridge, the physical Ethernet port, and the bridge address. PiSCSI owns
+only the ephemeral `piscsi0` TAP membership while a network adapter is
+attached. DaynaPort can use that complete Ethernet service; the Host Bridge
+driver accepts only its own unicast frames and Ethernet broadcasts.
 
 From a local console, preview and apply the named profile with:
 
@@ -34,8 +36,8 @@ For manual configuration, the package provides inert keyfile templates in
 `/usr/share/piscsi/network/`. Substitute unique UUIDs, the physical NIC, and
 the physical Ethernet MAC in the templates, copy them to
 `/etc/NetworkManager/system-connections/` with mode `0600`, then reload
-NetworkManager. The bridge MAC must remain distinct from the DaynaPort TAP
-MAC. The equivalent commands are:
+NetworkManager. The bridge MAC must remain distinct from the emulated client
+MAC on `piscsi0`. The equivalent commands are:
 
 ```sh
 ethernet_mac=$(cat /sys/class/net/eth0/address)
@@ -46,14 +48,16 @@ nmcli connection up 'PiSCSI wired bridge'
 
 Replace `eth0` with the selected physical Ethernet interface. Verify that the
 bridge owns DHCP and the selected Ethernet MAC, and that the physical port has
-no independent IP address before attaching a DaynaPort with
+no independent IP address before attaching a PiSCSI network adapter with
 `mode=bridge:interface=piscsi_bridge`.
 
 ## Wi-Fi proxy ARP
 
-Proxy-ARP exposes a DaynaPort client directly on the Wi-Fi IPv4 LAN. It
-supports IPv4 unicast and DHCP only. It does not provide IPv6, AppleTalk,
-multicast, mDNS reflection, or general Ethernet bridging.
+Proxy-ARP exposes a PiSCSI network-adapter client directly on the Wi-Fi IPv4
+LAN. It supports IPv4 unicast and DHCP only. It does not provide IPv6,
+AppleTalk, multicast, mDNS reflection, or general Ethernet bridging. The Host
+Bridge driver additionally accepts only its own unicast frames and Ethernet
+broadcasts, regardless of the selected profile.
 
 Before selecting this profile, remove any legacy PiSCSI NAT/firewall rules
 manually. The package and profile command never remove, flush, or rewrite
@@ -98,13 +102,15 @@ On detach, PiSCSI removes only the exact `/32` it added to `piscsi0`, stops
 only PiSCSI-owned processes, and restores promiscuous mode only when it had
 changed it. It does not flush addresses, routes, or firewall state.
 
-## DaynaPort attachment
+## Network-adapter attachment
 
 Always submit a complete mode/interface pair. For example:
 
 ```sh
 scsictl -i 6 -c attach -t scdp -f 'mode=bridge:interface=piscsi_bridge'
 scsictl -i 6 -c attach -t scdp -f 'mode=proxyarp:interface=wlan0'
+scsictl -i 5 -c attach -t scbr -f 'mode=bridge:interface=piscsi_bridge'
+scsictl -i 5 -c attach -t scbr -f 'mode=proxyarp:interface=wlan0'
 ```
 
 Do not use the retired `inet` parameter or a comma-separated interface list.

--- a/proto/piscsi_interface.proto
+++ b/proto/piscsi_interface.proto
@@ -33,8 +33,8 @@ enum PbDeviceType {
     SCMO = 4;
     // CD-ROM drive
     SCCD = 5;
-    // Support for X68000 host bridge removed
-    SCBR = 6 [deprecated = true];
+    // X68000 host bridge
+    SCBR = 6;
     // DaynaPort network adapter
     SCDP = 7;
     // Host services device


### PR DESCRIPTION
Restore the SCBR device as an X68000 Host Bridge, including the Human68k-compatible host file-system service and the bridge-specific SCSI message handlers. Back its Ethernet path with the TAP driver, derive a stable locally administered MAC address, preserve the driver minimum-frame/FCS expectations, and restrict received traffic to its own unicast frames and broadcasts.

Match the RASCTL/RASETHER/RASDRV bridge protocol that originated in the parent RaSCSI project: dispatch its non-standard message format on READ(10)/WRITE(10) (0x28/0x2a), with type, function, phase, and a three-byte byte count carried in the CDB. Advertise the legacy control channel required by RASCTL, translate its list and device-management commands to PiSCSI operations, and defer stop or system-shutdown requests until after the response is sent, while gating this insecure interface behind a new '-c disabled|media|full' runtime option. Preserve the type-1 Ethernet exchange used by RASETHER and the type-2, phased filesystem exchange used by RASDRV.

Register the device in the factory, protobuf API, controller transfer path, command-line tooling, device listings, and web UI. Share the explicit bridge and proxy-ARP topology workflow with DaynaPort so both adapters validate and use the same mode/interface pair.

Add build support for iconv where needed, extend unit coverage for device creation, RAS* protocol handling, CLI parsing, web attachment, and topology selection, and update the man pages and network-profile documentation for Host Bridge operation and its networking limits.