### PR TITLE
improved horizontal scrolling and columns in OLED client

### DIFF
--- a/go/cmd/piscsi-oled/main.go
+++ b/go/cmd/piscsi-oled/main.go
@@ -119,17 +119,17 @@ func main() {
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-	var statusLines, visibleLines []string
+	var statusLines, visibleLines []oled.StatusLine
 	var horizontalScroll oled.HorizontalScroller
 	for {
 		now := time.Now()
-		lines, err := monitor.Poll(ctx)
+		lines, err := monitor.PollStatus(ctx)
 		if err != nil {
 			if ctx.Err() != nil {
 				break
 			}
 			logger.Warn("could not refresh PiSCSI status; retaining last screen", "error", err)
-		} else if !slices.Equal(lines, statusLines) {
+		} else if !slices.EqualFunc(lines, statusLines, func(a, b oled.StatusLine) bool { return a == b }) {
 			statusLines = slices.Clone(lines)
 			visibleLines = slices.Clone(lines)
 			horizontalScroll.Reset(len(visibleLines))
@@ -147,7 +147,7 @@ func main() {
 				if active, redraw := ipScreensaver.Update(now, lineCount); active {
 					showStatus = false
 					if redraw {
-						if err := display.Present(renderer.RenderLineAt(statusLines[len(statusLines)-1], ipScreensaver.Row())); err != nil {
+						if err := display.Present(renderer.RenderLineAt(statusLines[len(statusLines)-1].Text(), ipScreensaver.Row())); err != nil {
 							logger.Error("present screensaver", "error", err)
 						}
 					}
@@ -164,14 +164,10 @@ func main() {
 				}
 			}
 			if showStatus {
-				if err := display.Present(renderer.RenderScrolled(visibleLines, horizontalScroll.Offsets())); err != nil {
+				if err := display.Present(renderer.RenderStatusScrolled(visibleLines, horizontalScroll.Offsets())); err != nil {
 					logger.Error("present screen", "error", err)
 				}
-				widths := make([]int, len(visibleLines))
-				for i, line := range visibleLines {
-					widths[i] = renderer.TextWidth(line)
-				}
-				horizontalScroll.Advance(widths, *horizontalScrollStep)
+				horizontalScroll.Advance(renderer.ParameterScrollLimits(visibleLines), *horizontalScrollStep)
 				if len(visibleLines) > lineCount {
 					visibleLines = append(visibleLines[1:], visibleLines[0])
 					horizontalScroll.Rotate()

--- a/go/piscsi-oled/README.md
+++ b/go/piscsi-oled/README.md
@@ -2,12 +2,11 @@
 
 `piscsi-oled` is the standalone Go status monitor for 128×32 and 128×64
 SSD1306 I2C displays. It shares the PiSCSI daemon client and protobuf bindings
-with the web application.
+with piscsi-web and piscsi-ctrlboard.
 
 ## I2C prerequisites
 
-On Raspberry Pi OS, install the screen package baseline used by
-`easyinstall.sh`, then enable I2C:
+On Raspberry Pi OS, install supporting tools and enable I2C:
 
 ```sh
 sudo apt-get update
@@ -44,7 +43,7 @@ milliseconds. Useful flags are:
 - `--rotation=0|180`
 - `--height=32|64`
 - `--refresh_interval=1000`
-- `--horizontal_scroll_step=6` (pixels moved per screen refresh; `0` pauses scrolling)
+- `--horizontal_scroll_step=6` (parameter pixels moved per screen refresh; `0` pauses scrolling). SCSI ID and device type remain fixed while the parameter field scrolls. Each scroll cycle holds its starting position for three frames, moves to the end, holds that final position for one additional frame, then restarts at the beginning.
 - `--password=TOKEN`
 - `--host=localhost` and `--port=6868`
 - `--i2c-device=/dev/i2c-1` and `--i2c-address=0x3c`

--- a/go/piscsi-oled/renderer.go
+++ b/go/piscsi-oled/renderer.go
@@ -47,27 +47,72 @@ func NewRenderer(height, rotation int) (*Renderer, error) {
 func (r *Renderer) Close() error { return r.face.Close() }
 
 func (r *Renderer) Render(lines []string) Frame {
-	return r.RenderScrolled(lines, nil)
-}
-
-// RenderScrolled renders each line with its own horizontal pixel offset.
-// Positive offsets move text towards the left, exposing the part of a long
-// line that would otherwise be clipped at the right edge of the display.
-func (r *Renderer) RenderScrolled(lines []string, offsets []int) Frame {
 	canvas := image.NewGray(image.Rect(0, 0, Width, r.height))
 	drawer := &font.Drawer{Dst: canvas, Src: image.NewUniform(color.White), Face: r.face}
 	for i, line := range lines {
 		if i*lineSpacing >= r.height {
 			break
 		}
+		drawer.Dot = fixedPoint(0, i*lineSpacing+7)
+		drawer.DrawString(line)
+	}
+	return r.frame(canvas)
+}
+
+// RenderStatus renders structured lines at their initial parameter offsets.
+func (r *Renderer) RenderStatus(lines []StatusLine) Frame {
+	return r.RenderStatusScrolled(lines, nil)
+}
+
+// RenderStatusScrolled renders each parameter segment at its own pixel offset.
+// The fixed SCSI identifier/type prefix remains anchored at column zero.
+func (r *Renderer) RenderStatusScrolled(lines []StatusLine, offsets []int) Frame {
+	canvas := image.NewGray(image.Rect(0, 0, Width, r.height))
+	drawer := &font.Drawer{Dst: canvas, Src: image.NewUniform(color.White), Face: r.face}
+	parameterCanvas := image.NewGray(canvas.Bounds())
+	parameterDrawer := &font.Drawer{Dst: parameterCanvas, Src: image.NewUniform(color.White), Face: r.face}
+	for i, line := range lines {
+		row := i * lineSpacing
+		if row >= r.height {
+			break
+		}
+		parameterX := 0
+		if line.Fixed != "" {
+			prefix := line.Fixed
+			if line.Parameter != "" {
+				prefix += " "
+			}
+			drawer.Dot = fixedPoint(0, row+7)
+			drawer.DrawString(prefix)
+			parameterX = r.TextWidth(prefix)
+		}
+		if line.Parameter == "" || parameterX >= Width {
+			continue
+		}
 		offset := 0
 		if i < len(offsets) {
 			offset = offsets[i]
 		}
-		drawer.Dot = fixedPoint(-offset, i*lineSpacing+7)
-		drawer.DrawString(line)
+		parameterDrawer.Dot = fixedPoint(parameterX-offset, row+7)
+		parameterDrawer.DrawString(line.Parameter)
+		parameterBounds := image.Rect(parameterX, row, Width, row+lineSpacing)
+		draw.Draw(canvas, parameterBounds, parameterCanvas, parameterBounds.Min, draw.Src)
 	}
 	return r.frame(canvas)
+}
+
+// ParameterScrollLimits returns the maximum pixel offset for each parameter
+// segment after reserving its fixed prefix column.
+func (r *Renderer) ParameterScrollLimits(lines []StatusLine) []int {
+	limits := make([]int, len(lines))
+	for i, line := range lines {
+		parameterX := 0
+		if line.Fixed != "" && line.Parameter != "" {
+			parameterX = r.TextWidth(line.Fixed + " ")
+		}
+		limits[i] = max(r.TextWidth(line.Parameter)-(Width-parameterX), 0)
+	}
+	return limits
 }
 
 // TextWidth returns the rendered width of a line in pixels.

--- a/go/piscsi-oled/renderer_test.go
+++ b/go/piscsi-oled/renderer_test.go
@@ -65,20 +65,26 @@ func TestRendererRendersLineAtRequestedRow(t *testing.T) {
 	}
 }
 
-func TestRendererHorizontalScrollChangesVisiblePixels(t *testing.T) {
+func TestRendererStatusLineKeepsPrefixAtColumnZero(t *testing.T) {
 	renderer, err := NewRenderer(32, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer renderer.Close()
-	line := "a very long device filename that exceeds the display width"
-	if renderer.TextWidth(line) <= Width {
-		t.Fatalf("test line width = %d, want more than %d", renderer.TextWidth(line), Width)
-	}
-	first := renderer.RenderScrolled([]string{line}, []int{0})
-	shifted := renderer.RenderScrolled([]string{line}, []int{1})
+	prefix := "6 HD "
+	line := StatusLine{Fixed: "6 HD", Parameter: "a long device filename that exceeds the available parameter column"}
+	first := renderer.RenderStatusScrolled([]StatusLine{line}, []int{0})
+	shifted := renderer.RenderStatusScrolled([]StatusLine{line}, []int{1})
 	if bytes.Equal(first.Pix, shifted.Pix) {
-		t.Fatal("horizontal scroll offset did not change rendered pixels")
+		t.Fatal("pixel offset did not change the rendered parameter segment")
+	}
+	static := renderer.Render([]string{prefix})
+	for y := 0; y < first.Height; y++ {
+		for x := 0; x < renderer.TextWidth(prefix); x++ {
+			if first.At(x, y) != static.At(x, y) || shifted.At(x, y) != static.At(x, y) {
+				t.Fatalf("prefix pixel (%d,%d) moved while scrolling", x, y)
+			}
+		}
 	}
 }
 
@@ -90,6 +96,19 @@ func TestRendererEmbeddedFontUsesSixPixelGlyphAdvance(t *testing.T) {
 	defer renderer.Close()
 	if got := renderer.TextWidth("M"); got != DefaultHorizontalScrollStep {
 		t.Fatalf("glyph advance = %d, want %d", got, DefaultHorizontalScrollStep)
+	}
+}
+
+func TestRendererParameterScrollLimitsReserveFixedPrefix(t *testing.T) {
+	renderer, err := NewRenderer(32, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer renderer.Close()
+	line := StatusLine{Fixed: "6 HD", Parameter: "a very long device filename"}
+	want := renderer.TextWidth(line.Parameter) - (Width - renderer.TextWidth("6 HD "))
+	if got := renderer.ParameterScrollLimits([]StatusLine{line}); got[0] != want {
+		t.Fatalf("ParameterScrollLimits() = %v, want [%d]", got, want)
 	}
 }
 

--- a/go/piscsi-oled/scroll.go
+++ b/go/piscsi-oled/scroll.go
@@ -4,54 +4,88 @@ package oled
 // embedded Type Writer font at the renderer's 8-pixel text size.
 const DefaultHorizontalScrollStep = 6
 
-// HorizontalScroller advances overflowing lines and reverses direction at
-// either edge. Short lines remain anchored at x=0.
+// HorizontalScrollStartDelayFrames is the number of refreshes that show the
+// starting parameter window before scrolling begins.
+const HorizontalScrollStartDelayFrames = 3
+
+// HorizontalScrollEndDelayFrames is the number of additional refreshes that
+// show the final parameter window before wrapping to the start.
+const HorizontalScrollEndDelayFrames = 1
+
+// StatusLine separates the fixed SCSI identifier/type prefix from the
+// parameter text. Only Parameter is eligible for horizontal scrolling.
+type StatusLine struct {
+	Fixed     string
+	Parameter string
+}
+
+// Text returns the complete, unscrolled display text for a line.
+func (l StatusLine) Text() string {
+	if l.Fixed == "" || l.Parameter == "" {
+		return l.Fixed + l.Parameter
+	}
+	return l.Fixed + " " + l.Parameter
+}
+
+// HorizontalScroller advances overflowing parameters in pixels from left to right.
+// Each cycle holds the starting and final windows briefly, then returns to the
+// start. Fixed prefixes always remain at column zero.
 type HorizontalScroller struct {
-	offsets   []int
-	direction []int
+	offsets     []int
+	startFrames []int
+	endFrames   []int
 }
 
 // Reset anchors all lines at their initial position.
 func (s *HorizontalScroller) Reset(lineCount int) {
 	s.offsets = make([]int, lineCount)
-	s.direction = make([]int, lineCount)
-	for i := range s.direction {
-		s.direction[i] = 1
-	}
+	s.startFrames = make([]int, lineCount)
+	s.endFrames = make([]int, lineCount)
 }
 
-// Advance updates offsets using the supplied rendered line widths and pixel
-// step. It returns a copy so callers can safely pass the result to the
-// renderer. A zero step pauses scrolling.
-func (s *HorizontalScroller) Advance(widths []int, step int) []int {
-	if len(s.offsets) != len(widths) {
-		s.Reset(len(widths))
+// Advance updates parameter offsets using a pixel step. maxOffsets contains
+// the maximum pixel offset for each line. It returns a copy
+// so callers can inspect the positions. A zero step pauses scrolling.
+func (s *HorizontalScroller) Advance(maxOffsets []int, step int) []int {
+	if len(s.offsets) != len(maxOffsets) {
+		s.Reset(len(maxOffsets))
 	}
 	if step < 0 {
 		step = 0
 	}
-	for i, width := range widths {
-		maxOffset := width - Width
+	for i, maxOffset := range maxOffsets {
 		if maxOffset <= 0 {
 			s.offsets[i] = 0
+			s.startFrames[i] = 0
+			s.endFrames[i] = 0
 			continue
 		}
-		if s.direction[i] == 0 {
-			s.direction[i] = 1
+		if step == 0 {
+			continue
 		}
-		s.offsets[i] += s.direction[i] * step
+		if s.offsets[i] == 0 && s.startFrames[i] < HorizontalScrollStartDelayFrames {
+			s.startFrames[i]++
+			if s.startFrames[i] < HorizontalScrollStartDelayFrames {
+				continue
+			}
+		}
 		if s.offsets[i] >= maxOffset {
-			s.offsets[i] = maxOffset
-			s.direction[i] = -1
-		} else if s.offsets[i] <= 0 {
+			if s.endFrames[i] < HorizontalScrollEndDelayFrames {
+				s.endFrames[i]++
+				continue
+			}
 			s.offsets[i] = 0
-			s.direction[i] = 1
+			s.startFrames[i] = 0
+			s.endFrames[i] = 0
+			continue
 		}
+		s.offsets[i] = min(s.offsets[i]+step, maxOffset)
+		s.endFrames[i] = 0
 	}
 	return append([]int(nil), s.offsets...)
 }
 
-// Offsets returns the current positions without advancing them.
+// Offsets returns the current pixel positions without advancing them.
 func (s *HorizontalScroller) Offsets() []int {
 	return append([]int(nil), s.offsets...)
 }
@@ -63,5 +97,6 @@ func (s *HorizontalScroller) Rotate() {
 		return
 	}
 	s.offsets = append(s.offsets[1:], s.offsets[0])
-	s.direction = append(s.direction[1:], s.direction[0])
+	s.startFrames = append(s.startFrames[1:], s.startFrames[0])
+	s.endFrames = append(s.endFrames[1:], s.endFrames[0])
 }

--- a/go/piscsi-oled/scroll_test.go
+++ b/go/piscsi-oled/scroll_test.go
@@ -2,28 +2,56 @@ package oled
 
 import "testing"
 
-func TestHorizontalScrollerAnchorsShortLinesAndBouncesLongLines(t *testing.T) {
+func TestHorizontalScrollerAnchorsShortLinesDelaysAndWrapsLongLines(t *testing.T) {
 	scroller := HorizontalScroller{}
 	scroller.Reset(2)
-	widths := []int{Width - 1, Width + 2}
-	if got := scroller.Advance(widths, 1); got[0] != 0 || got[1] != 1 {
-		t.Fatalf("first advance = %v, want [0 1]", got)
+	maxOffsets := []int{0, 12}
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 0 {
+		t.Fatalf("after first frame = %v, want [0 0]", got)
 	}
-	if got := scroller.Advance([]int{Width - 1, Width + 2}, 1); got[0] != 0 || got[1] != 2 {
-		t.Fatalf("second advance = %v, want [0 2]", got)
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 0 {
+		t.Fatalf("after second frame = %v, want [0 0]", got)
 	}
-	if got := scroller.Advance([]int{Width - 1, Width + 2}, 1); got[1] != 1 {
-		t.Fatalf("third advance = %v, want second line to reverse", got)
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 6 {
+		t.Fatalf("after third frame = %v, want [0 6]", got)
+	}
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 12 {
+		t.Fatalf("at final window = %v, want [0 12]", got)
+	}
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 12 {
+		t.Fatalf("after first final frame = %v, want one extra final frame at [0 12]", got)
+	}
+	if got := scroller.Advance(maxOffsets, 6); got[0] != 0 || got[1] != 0 {
+		t.Fatalf("after final hold = %v, want reset to [0 0]", got)
 	}
 }
 
 func TestHorizontalScrollerUsesConfiguredStep(t *testing.T) {
 	scroller := HorizontalScroller{}
 	scroller.Reset(1)
-	if got := scroller.Advance([]int{Width + 10}, 4); got[0] != 4 {
+	maxOffsets := []int{24}
+	scroller.Advance(maxOffsets, 4)
+	scroller.Advance(maxOffsets, 4)
+	if got := scroller.Advance(maxOffsets, 4); got[0] != 4 {
 		t.Fatalf("advance = %v, want [4]", got)
 	}
-	if got := scroller.Advance([]int{Width + 10}, 0); got[0] != 4 {
+	if got := scroller.Advance(maxOffsets, 0); got[0] != 4 {
 		t.Fatalf("paused advance = %v, want [4]", got)
+	}
+}
+
+func TestHorizontalScrollerOffsetsReturnsCopy(t *testing.T) {
+	scroller := HorizontalScroller{}
+	scroller.Reset(1)
+	got := scroller.Offsets()
+	got[0] = 1
+	if scroller.Offsets()[0] != 0 {
+		t.Fatal("Offsets() exposed the scroller's internal state")
+	}
+}
+
+func TestStatusLineText(t *testing.T) {
+	if got := (StatusLine{Fixed: "6 HD", Parameter: "disk.hds"}).Text(); got != "6 HD disk.hds" {
+		t.Fatalf("Text() = %q", got)
 	}
 }

--- a/go/piscsi-oled/status.go
+++ b/go/piscsi-oled/status.go
@@ -64,9 +64,23 @@ func (m *Monitor) LoadDeviceTypes(ctx context.Context) error {
 	return nil
 }
 
-// Poll returns a fully formatted status screen. Context is checked before each
-// request; the shared client supplies bounded connection and I/O timeouts.
+// Poll returns a fully formatted status screen. It is kept for callers that
+// consume plain text; new display code should use PollStatus.
 func (m *Monitor) Poll(ctx context.Context) ([]string, error) {
+	status, err := m.PollStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	lines := make([]string, len(status))
+	for i, line := range status {
+		lines[i] = line.Text()
+	}
+	return lines, nil
+}
+
+// PollStatus returns structured display text. Context is checked before each
+// request; the shared client supplies bounded connection and I/O timeouts.
+func (m *Monitor) PollStatus(ctx context.Context) ([]StatusLine, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -81,7 +95,7 @@ func (m *Monitor) Poll(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("check authentication: %w", err)
 	}
 	if !auth.GetStatus() {
-		return withNetwork([]string{"Permission denied!"}, m.ip, m.hostname), nil
+		return withNetworkStatus([]StatusLine{{Parameter: "Permission denied!"}}, m.ip, m.hostname), nil
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -93,13 +107,24 @@ func (m *Monitor) Poll(ctx context.Context) ([]string, error) {
 	if !devices.GetStatus() {
 		return nil, fmt.Errorf("list devices: %s", devices.GetMsg())
 	}
-	return m.Format(devices.GetDevicesInfo().GetDevices()), nil
+	return m.FormatStatus(devices.GetDevicesInfo().GetDevices()), nil
 }
 
 func (m *Monitor) Format(devices []*pb.PbDevice) []string {
-	lines := make([]string, 0, len(devices)+1)
+	statusLines := m.FormatStatus(devices)
+	lines := make([]string, len(statusLines))
+	for i, line := range statusLines {
+		lines[i] = line.Text()
+	}
+	return lines
+}
+
+// FormatStatus returns display lines with the SCSI address/type kept apart
+// from the parameter field so the latter can scroll independently.
+func (m *Monitor) FormatStatus(devices []*pb.PbDevice) []StatusLine {
+	lines := make([]StatusLine, 0, len(devices)+1)
 	if len(devices) == 0 {
-		lines = append(lines, "No device attached!")
+		lines = append(lines, StatusLine{Parameter: "No device attached!"})
 	} else {
 		hasLUNs := false
 		for _, device := range devices {
@@ -109,34 +134,41 @@ func (m *Monitor) Format(devices []*pb.PbDevice) []string {
 			}
 		}
 		for _, device := range devices {
-			line := []string{fmt.Sprint(device.GetId())}
+			prefix := []string{fmt.Sprint(device.GetId())}
 			if hasLUNs {
-				line = append(line, fmt.Sprint(device.GetUnit()))
+				prefix = append(prefix, fmt.Sprint(device.GetUnit()))
 			}
-			line = append(line, typeSuffix(device.GetType()))
+			prefix = append(prefix, typeSuffix(device.GetType()))
+			parameter := make([]string, 0, 3)
 			filename := device.GetFile().GetName()
 			if filename == "" {
 				filename = device.GetParams()["file"]
 			}
 			if filename != "" {
-				line = append(line, filepath.Base(filename))
+				parameter = append(parameter, filepath.Base(filename))
 			} else if m.removable[device.GetType()] || device.GetProperties().GetRemovable() {
-				line = append(line, "[No Media]")
+				parameter = append(parameter, "[No Media]")
 			}
-			if vendor := strings.TrimSpace(device.GetVendor()); vendor != "" && vendor != "PiSCSI" {
-				line = append(line, vendor)
-				if product := strings.TrimSpace(device.GetProduct()); product != "" {
-					line = append(line, product)
-				}
+			vendor := strings.TrimSpace(device.GetVendor())
+			product := strings.TrimSpace(device.GetProduct())
+			showVendor := vendor != "" && vendor != "PiSCSI"
+			if showVendor {
+				parameter = append(parameter, vendor)
 			}
-			lines = append(lines, strings.Join(line, " "))
+			if product != "" && (showVendor || !device.GetProperties().GetSupportsFile()) {
+				parameter = append(parameter, product)
+			}
+			lines = append(lines, StatusLine{Fixed: strings.Join(prefix, " "), Parameter: strings.Join(parameter, " ")})
 		}
 	}
-	return withNetwork(lines, m.ip, m.hostname)
+	return withNetworkStatus(lines, m.ip, m.hostname)
 }
 
 func typeSuffix(deviceType pb.PbDeviceType) string {
 	name := deviceType.String()
+	if name == "SAHD" {
+		return "SA"
+	}
 	if len(name) >= 4 {
 		return name[2:4]
 	}
@@ -148,4 +180,11 @@ func withNetwork(lines []string, ip, hostname string) []string {
 		return append(lines, "No network connection")
 	}
 	return append(lines, fmt.Sprintf("IP %s - %s", ip, hostname))
+}
+
+func withNetworkStatus(lines []StatusLine, ip, hostname string) []StatusLine {
+	if ip == "" {
+		return append(lines, StatusLine{Parameter: "No network connection"})
+	}
+	return append(lines, StatusLine{Parameter: fmt.Sprintf("IP %s - %s", ip, hostname)})
 }

--- a/go/piscsi-oled/status_test.go
+++ b/go/piscsi-oled/status_test.go
@@ -64,6 +64,59 @@ func TestFormat(t *testing.T) {
 	})
 }
 
+func TestFormatStatusSeparatesFixedPrefixFromParameter(t *testing.T) {
+	monitor := NewMonitor(&fakeSender{}, "")
+	monitor.ip, monitor.hostname = "192.0.2.5", "piscsi"
+	devices := []*pb.PbDevice{{
+		Id:   3,
+		Type: pb.PbDeviceType_SCHD,
+		File: &pb.PbImageFile{Name: "/var/lib/piscsi/images/a-long-disk-name.hds"},
+	}}
+	want := []StatusLine{
+		{Fixed: "3 HD", Parameter: "a-long-disk-name.hds"},
+		{Parameter: "IP 192.0.2.5 - piscsi"},
+	}
+	if got := monitor.FormatStatus(devices); !reflect.DeepEqual(got, want) {
+		t.Errorf("FormatStatus() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFormatStatusUsesProductForNonFileDevices(t *testing.T) {
+	monitor := NewMonitor(&fakeSender{}, "")
+	monitor.ip, monitor.hostname = "192.0.2.5", "piscsi"
+	devices := []*pb.PbDevice{
+		{
+			Id: 3, Type: pb.PbDeviceType_SCHS,
+			Properties: &pb.PbDeviceProperties{SupportsFile: false},
+			Vendor:     "PiSCSI",
+			Product:    "Host Services",
+		},
+		{
+			Id: 4, Type: pb.PbDeviceType_SCDP,
+			Properties: &pb.PbDeviceProperties{SupportsFile: false},
+			Vendor:     "Dayna",
+			Product:    "SCSI/Link",
+		},
+	}
+	want := []StatusLine{
+		{Fixed: "3 HS", Parameter: "Host Services"},
+		{Fixed: "4 DP", Parameter: "Dayna SCSI/Link"},
+		{Parameter: "IP 192.0.2.5 - piscsi"},
+	}
+	if got := monitor.FormatStatus(devices); !reflect.DeepEqual(got, want) {
+		t.Errorf("FormatStatus() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTypeSuffix(t *testing.T) {
+	if got := typeSuffix(pb.PbDeviceType_SCCD); got != "CD" {
+		t.Errorf("typeSuffix(SCCD) = %q, want CD", got)
+	}
+	if got := typeSuffix(pb.PbDeviceType_SAHD); got != "SA" {
+		t.Errorf("typeSuffix(SAHD) = %q, want SA", got)
+	}
+}
+
 func TestPollAuthenticationAndDaemonFailures(t *testing.T) {
 	t.Run("permission denied", func(t *testing.T) {
 		monitor := NewMonitor(&fakeSender{results: []*pb.PbResult{{Status: false}}}, "")


### PR DESCRIPTION
rather than scrolling a long status strings horizontally back and forth, we now have:

- ID and type as frozen columns
- scroll from left to right then wrap to the beginning
- 3 frame pause before scrolling starts
- 2 frame pause before a fully scrolled string wraps
- print product names for all non-file device types
- special abbreviation of SAHD->SA (to disambiguate with SCHD)