### PR TITLE
ability to attach all devices in the Control Board UI

### DIFF
--- a/go/piscsi-ctrlboard/attach_menu.go
+++ b/go/piscsi-ctrlboard/attach_menu.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Daniel Markstedt. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package ctrlboard
+
+import (
+	"fmt"
+	"sort"
+
+	pb "github.com/piscsi/piscsi/go/proto"
+)
+
+const defaultPrinterCommand = "lp -oraw %f"
+
+// DeviceTypeSelection retains the slot and daemon-advertised capabilities as
+// the attachment flow moves from a device type to its options.
+type DeviceTypeSelection struct {
+	Slot       SCSISlot
+	Type       pb.PbDeviceType
+	Properties *pb.PbDeviceProperties
+}
+
+// DeviceAttachSelection is a complete file-less attach request. It is used
+// for devices such as Host Services and for the default printer workflow.
+type DeviceAttachSelection struct {
+	Slot   SCSISlot
+	Type   pb.PbDeviceType
+	Params map[string]string
+}
+
+// NetworkTopologySelection identifies the daemon-advertised DaynaPort mode
+// and host interface selected by the user.
+type NetworkTopologySelection struct {
+	Slot      SCSISlot
+	Mode      string
+	Interface string
+}
+
+// NewDeviceTypeMenu presents only the device types currently supported by the
+// connected daemon. SAHD remains last, matching the web interface.
+func NewDeviceTypeMenu(slot SCSISlot, properties []*pb.PbDeviceTypeProperties, pageSize int) (*Menu, error) {
+	types := append([]*pb.PbDeviceTypeProperties(nil), properties...)
+	sort.SliceStable(types, func(i, j int) bool {
+		left, right := types[i].GetType(), types[j].GetType()
+		if left == pb.PbDeviceType_SAHD {
+			return false
+		}
+		if right == pb.PbDeviceType_SAHD {
+			return true
+		}
+		return left < right
+	})
+	items := []MenuItem{{ID: "return", Label: "Return", Data: SlotAction{Kind: SlotActionReturn, Slot: slot}}}
+	for _, typeProperties := range types {
+		if typeProperties == nil || typeProperties.GetType() == pb.PbDeviceType_UNDEFINED {
+			continue
+		}
+		deviceType := typeProperties.GetType()
+		items = append(items, MenuItem{
+			ID:    "device:" + deviceType.String(),
+			Label: fmt.Sprintf("%s [%s]", deviceTypeName(deviceType), deviceType),
+			Data:  DeviceTypeSelection{Slot: slot, Type: deviceType, Properties: typeProperties.GetProperties()},
+		})
+	}
+	if len(items) == 1 {
+		items = append(items, MenuItem{ID: "empty", Label: "(No device types available)"})
+	}
+	return NewMenu("Select Device", items, pageSize)
+}
+
+// NewDeviceOptionMenu holds the final confirmation for non-file devices. The
+// daemon defaults are applied by the workflow when the item is selected.
+func NewDeviceOptionMenu(selection DeviceTypeSelection, pageSize int) (*Menu, error) {
+	items := []MenuItem{
+		{ID: "return", Label: "Return", Data: SlotAction{Kind: SlotActionReturn, Slot: selection.Slot}},
+		{ID: "attach", Label: deviceAttachLabel(selection.Type), Data: DeviceAttachSelection{
+			Slot: selection.Slot, Type: selection.Type, Params: copyParams(selection.Properties.GetDefaultParams()),
+		}},
+	}
+	return NewMenu(deviceTypeName(selection.Type), items, pageSize)
+}
+
+// AddAttachWithoutMediaOption adds the naked removable-device attachment at
+// the top of a new-device image picker. It must not be used for INSERT flows,
+// where a removable device is already attached.
+func AddAttachWithoutMediaOption(menu *Menu, selection DeviceTypeSelection) {
+	if menu == nil || !selection.Properties.GetRemovable() {
+		return
+	}
+	item := MenuItem{
+		ID:    "attach-empty:" + selection.Type.String(),
+		Label: "Attach with no media",
+		Data: DeviceAttachSelection{
+			Slot: selection.Slot, Type: selection.Type, Params: copyParams(selection.Properties.GetDefaultParams()),
+		},
+	}
+	if len(menu.Items) == 0 {
+		menu.Items = []MenuItem{item}
+		return
+	}
+	menu.Items = append(menu.Items, MenuItem{})
+	copy(menu.Items[2:], menu.Items[1:len(menu.Items)-1])
+	menu.Items[1] = item
+}
+
+// NewNetworkTopologyMenu shows the DaynaPort profiles actively advertised by
+// the daemon. Down interfaces and unsupported modes are deliberately omitted.
+func NewNetworkTopologyMenu(slot SCSISlot, interfaces []*pb.PbNetworkInterface, pageSize int) (*Menu, error) {
+	profiles := make([]NetworkTopologySelection, 0)
+	for _, networkInterface := range interfaces {
+		if networkInterface == nil || !networkInterface.GetUp() || networkInterface.GetName() == "" {
+			continue
+		}
+		for _, mode := range networkInterface.GetSupportedMode() {
+			if mode == "bridge" || mode == "proxyarp" {
+				profiles = append(profiles, NetworkTopologySelection{Slot: slot, Mode: mode, Interface: networkInterface.GetName()})
+			}
+		}
+	}
+	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].Mode == profiles[j].Mode {
+			return profiles[i].Interface < profiles[j].Interface
+		}
+		return profiles[i].Mode == "bridge"
+	})
+	items := []MenuItem{{ID: "return", Label: "Return", Data: SlotAction{Kind: SlotActionReturn, Slot: slot}}}
+	for _, profile := range profiles {
+		label := "Wi-Fi proxy ARP"
+		if profile.Mode == "bridge" {
+			label = "Wired bridge"
+		}
+		items = append(items, MenuItem{
+			ID:    fmt.Sprintf("topology:%s:%s", profile.Mode, profile.Interface),
+			Label: fmt.Sprintf("%s (%s)", label, profile.Interface),
+			Data:  profile,
+		})
+	}
+	if len(items) == 1 {
+		items = append(items, MenuItem{ID: "empty", Label: "(No network topologies available)"})
+	}
+	return NewMenu("Select Topology", items, pageSize)
+}
+
+func deviceTypeName(deviceType pb.PbDeviceType) string {
+	switch deviceType {
+	case pb.PbDeviceType_SAHD:
+		return "SASI Hard Disk"
+	case pb.PbDeviceType_SCHD:
+		return "SCSI Hard Disk"
+	case pb.PbDeviceType_SCRM:
+		return "SCSI Removable Media"
+	case pb.PbDeviceType_SCMO:
+		return "SCSI Magneto-Optical"
+	case pb.PbDeviceType_SCCD:
+		return "SCSI CD-ROM"
+	case pb.PbDeviceType_SCDP:
+		return "Ethernet Adapter"
+	case pb.PbDeviceType_SCHS:
+		return "Host Services"
+	case pb.PbDeviceType_SCLP:
+		return "Printer"
+	case pb.PbDeviceType_SCTP:
+		return "SCSI Tape"
+	default:
+		return deviceType.String()
+	}
+}
+
+func deviceAttachLabel(deviceType pb.PbDeviceType) string {
+	if deviceType == pb.PbDeviceType_SCLP {
+		return "Attach Printer (" + defaultPrinterCommand + ")"
+	}
+	return "Attach " + deviceTypeName(deviceType)
+}
+
+func copyParams(params map[string]string) map[string]string {
+	if len(params) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	return copied
+}

--- a/go/piscsi-ctrlboard/attach_menu_test.go
+++ b/go/piscsi-ctrlboard/attach_menu_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Daniel Markstedt. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package ctrlboard
+
+import (
+	"testing"
+
+	pb "github.com/piscsi/piscsi/go/proto"
+)
+
+func TestDeviceTypeMenuUsesDaemonTypesAndRetainsSlot(t *testing.T) {
+	slot := SCSISlot{ID: 6}
+	menu, err := NewDeviceTypeMenu(slot, []*pb.PbDeviceTypeProperties{
+		{Type: pb.PbDeviceType_SAHD},
+		{Type: pb.PbDeviceType_SCLP, Properties: &pb.PbDeviceProperties{DefaultParams: map[string]string{"cmd": "custom"}}},
+		{Type: pb.PbDeviceType_SCHD, Properties: &pb.PbDeviceProperties{SupportsFile: true}},
+	}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := menu.Items[1].Label, "SCSI Hard Disk [SCHD]"; got != want {
+		t.Fatalf("first device = %q, want %q", got, want)
+	}
+	if got, want := menu.Items[3].Label, "SASI Hard Disk [SAHD]"; got != want {
+		t.Fatalf("last device = %q, want %q", got, want)
+	}
+	selection, ok := menu.Items[2].Data.(DeviceTypeSelection)
+	if !ok || selection.Slot.ID != 6 || selection.Type != pb.PbDeviceType_SCLP {
+		t.Fatalf("printer selection = %#v", menu.Items[2].Data)
+	}
+}
+
+func TestNetworkTopologyMenuOnlyOffersReadySupportedProfiles(t *testing.T) {
+	menu, err := NewNetworkTopologyMenu(SCSISlot{ID: 2}, []*pb.PbNetworkInterface{
+		{Name: "wlan0", Up: true, SupportedMode: []string{"proxyarp", "ignored"}},
+		{Name: "eth0", Up: true, SupportedMode: []string{"bridge"}},
+		{Name: "eth1", Up: false, SupportedMode: []string{"bridge"}},
+	}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := menu.Items[1].Label, "Wired bridge (eth0)"; got != want {
+		t.Fatalf("first topology = %q, want %q", got, want)
+	}
+	if got, want := menu.Items[2].Label, "Wi-Fi proxy ARP (wlan0)"; got != want {
+		t.Fatalf("second topology = %q, want %q", got, want)
+	}
+	selection, ok := menu.Items[1].Data.(NetworkTopologySelection)
+	if !ok || selection.Mode != "bridge" || selection.Interface != "eth0" {
+		t.Fatalf("topology selection = %#v", menu.Items[1].Data)
+	}
+}
+
+func TestDeviceOptionMenuCopiesDefaultParams(t *testing.T) {
+	defaults := map[string]string{"cmd": "original"}
+	menu, err := NewDeviceOptionMenu(DeviceTypeSelection{
+		Slot: SCSISlot{ID: 1}, Type: pb.PbDeviceType_SCLP,
+		Properties: &pb.PbDeviceProperties{DefaultParams: defaults},
+	}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := menu.Items[1].Data.(DeviceAttachSelection)
+	selection.Params["cmd"] = "changed"
+	if got := defaults["cmd"]; got != "original" {
+		t.Fatalf("source default params mutated to %q", got)
+	}
+}
+
+func TestPrinterOptionShowsEffectiveDefaultCommand(t *testing.T) {
+	menu, err := NewDeviceOptionMenu(DeviceTypeSelection{Type: pb.PbDeviceType_SCLP}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := menu.Items[1].Label, "Attach Printer (lp -oraw %f)"; got != want {
+		t.Fatalf("printer option = %q, want %q", got, want)
+	}
+}
+
+func TestAddAttachWithoutMediaOptionAddsOnlyRemovableChoice(t *testing.T) {
+	menu, err := NewMenu("Select Image", []MenuItem{{ID: "return", Label: "Return"}, {ID: "image:disk", Label: "disk"}}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	AddAttachWithoutMediaOption(menu, DeviceTypeSelection{
+		Slot: SCSISlot{ID: 5}, Type: pb.PbDeviceType_SCMO,
+		Properties: &pb.PbDeviceProperties{Removable: true},
+	})
+	if got, want := menu.Items[1].Label, "Attach with no media"; got != want {
+		t.Fatalf("naked attach option = %q, want %q", got, want)
+	}
+	selection, ok := menu.Items[1].Data.(DeviceAttachSelection)
+	if !ok || selection.Slot.ID != 5 || selection.Type != pb.PbDeviceType_SCMO {
+		t.Fatalf("naked attach selection = %#v", menu.Items[1].Data)
+	}
+
+	AddAttachWithoutMediaOption(menu, DeviceTypeSelection{Type: pb.PbDeviceType_SCHD})
+	if got, want := len(menu.Items), 3; got != want {
+		t.Fatalf("non-removable option count = %d, want %d", got, want)
+	}
+}

--- a/go/piscsi-ctrlboard/workflow.go
+++ b/go/piscsi-ctrlboard/workflow.go
@@ -117,6 +117,20 @@ func (w *SCSIWorkflow) RunSystemCommand(ctx context.Context, selection SystemCom
 // minimal request as the Python Control Board, then returns a name-sorted
 // picker with a Return entry.
 func (w *SCSIWorkflow) BuildImageMenu(ctx context.Context, slot SCSISlot, pageSize int) (*Menu, error) {
+	return w.buildImageMenu(ctx, slot, pb.PbDeviceType_UNDEFINED, pageSize)
+}
+
+// BuildImageMenuForType lists only image files mapped by the daemon to the
+// selected device type. This is used for removable media and file-backed
+// device types selected for an empty SCSI ID.
+func (w *SCSIWorkflow) BuildImageMenuForType(ctx context.Context, slot SCSISlot, deviceType pb.PbDeviceType, pageSize int) (*Menu, error) {
+	if deviceType == pb.PbDeviceType_UNDEFINED {
+		return nil, fmt.Errorf("a device type is required to filter images")
+	}
+	return w.buildImageMenu(ctx, slot, deviceType, pageSize)
+}
+
+func (w *SCSIWorkflow) buildImageMenu(ctx context.Context, slot SCSISlot, deviceType pb.PbDeviceType, pageSize int) (*Menu, error) {
 	if err := w.ready(ctx); err != nil {
 		return nil, err
 	}
@@ -140,7 +154,7 @@ func (w *SCSIWorkflow) BuildImageMenu(ctx context.Context, slot SCSISlot, pageSi
 	items := make([]MenuItem, 0, len(images)+1)
 	items = append(items, MenuItem{ID: "return", Label: "Return", Data: SlotAction{Kind: SlotActionReturn, Slot: slot}})
 	for _, image := range images {
-		if image == nil || image.GetName() == "" {
+		if image == nil || image.GetName() == "" || (deviceType != pb.PbDeviceType_UNDEFINED && image.GetType() != deviceType) {
 			continue
 		}
 		items = append(items, MenuItem{
@@ -152,7 +166,11 @@ func (w *SCSIWorkflow) BuildImageMenu(ctx context.Context, slot SCSISlot, pageSi
 	if len(items) == 1 {
 		items = append(items, MenuItem{ID: "empty", Label: "(No image files found)"})
 	}
-	return NewMenu("Select Image", items, pageSize)
+	title := "Select Image"
+	if deviceType != pb.PbDeviceType_UNDEFINED {
+		title = "Select " + deviceTypeName(deviceType) + " Image"
+	}
+	return NewMenu(title, items, pageSize)
 }
 
 func (w *SCSIWorkflow) reportImageList(diagnostic ImageListDiagnostic) {
@@ -190,6 +208,71 @@ func (w *SCSIWorkflow) AttachOrInsert(ctx context.Context, selection ImageSelect
 		return "", resultError(lower(verb)+" image", result)
 	}
 	return fmt.Sprintf("%s ID %d", verb, selection.Slot.ID), nil
+}
+
+// BuildDeviceTypeMenu retrieves the device types supported by the connected
+// daemon so unsupported and legacy-only types are never offered.
+func (w *SCSIWorkflow) BuildDeviceTypeMenu(ctx context.Context, slot SCSISlot, pageSize int) (*Menu, error) {
+	if err := w.ready(ctx); err != nil {
+		return nil, err
+	}
+	result, err := w.client.SendCommand(w.commands.GetDeviceTypesInfo())
+	if err != nil {
+		return nil, fmt.Errorf("list device types: %w", err)
+	}
+	if !result.GetStatus() {
+		return nil, resultError("list device types", result)
+	}
+	return NewDeviceTypeMenu(slot, result.GetDeviceTypesInfo().GetProperties(), pageSize)
+}
+
+// BuildNetworkTopologyMenu retrieves the DaynaPort profiles advertised by the
+// daemon, including their live interface state and supported modes.
+func (w *SCSIWorkflow) BuildNetworkTopologyMenu(ctx context.Context, slot SCSISlot, pageSize int) (*Menu, error) {
+	if err := w.ready(ctx); err != nil {
+		return nil, err
+	}
+	result, err := w.client.SendCommand(w.commands.GetNetworkInfo())
+	if err != nil {
+		return nil, fmt.Errorf("list network topologies: %w", err)
+	}
+	if !result.GetStatus() {
+		return nil, resultError("list network topologies", result)
+	}
+	return NewNetworkTopologyMenu(slot, result.GetNetworkInterfacesInfo().GetInterfaces(), pageSize)
+}
+
+// AttachDevice attaches a file-less device using its selected defaults.
+// Printers explicitly use PiSCSI's documented raw lp command so the intended
+// default remains stable even when talking to an older daemon.
+func (w *SCSIWorkflow) AttachDevice(ctx context.Context, selection DeviceAttachSelection) (string, error) {
+	if err := w.ready(ctx); err != nil {
+		return "", err
+	}
+	if selection.Slot.Reserved {
+		return "", fmt.Errorf("SCSI ID %d is reserved", selection.Slot.ID)
+	}
+	if selection.Slot.Device != nil {
+		return "", fmt.Errorf("SCSI ID %d already has a device", selection.Slot.ID)
+	}
+	if selection.Type == pb.PbDeviceType_UNDEFINED {
+		return "", fmt.Errorf("selected device has no supported type")
+	}
+	params := copyParams(selection.Params)
+	if selection.Type == pb.PbDeviceType_SCLP {
+		if params == nil {
+			params = make(map[string]string)
+		}
+		params["cmd"] = defaultPrinterCommand
+	}
+	result, err := w.client.SendCommand(w.commands.AttachDevice(selection.Slot.ID, 0, selection.Type, "", 0, params))
+	if err != nil {
+		return "", fmt.Errorf("attach device: %w", err)
+	}
+	if !result.GetStatus() {
+		return "", resultError("attach device", result)
+	}
+	return fmt.Sprintf("Attached ID %d", selection.Slot.ID), nil
 }
 
 // DetachOrEject preserves the existing UI convention: removable media that is
@@ -355,10 +438,24 @@ func (c *WorkflowController) Handle(item MenuItem) {
 		case SlotActionReturn:
 			c.menu.Pop()
 		case SlotActionAttachInsert:
-			c.start("Loading images", func(ctx context.Context) (string, error) {
-				images, err := c.workflow.BuildImageMenu(ctx, selected.Slot, c.pageSize)
+			if device := selected.Slot.Device; device != nil {
+				if !device.GetProperties().GetRemovable() || !device.GetStatus().GetRemoved() {
+					c.report(fmt.Errorf("SCSI ID %d is not an empty removable device", selected.Slot.ID))
+					return
+				}
+				c.start("Loading images", func(ctx context.Context) (string, error) {
+					images, err := c.workflow.BuildImageMenuForType(ctx, selected.Slot, device.GetType(), c.pageSize)
+					if err == nil {
+						err = c.menu.Push(images)
+					}
+					return "", err
+				})
+				return
+			}
+			c.start("Loading devices", func(ctx context.Context) (string, error) {
+				devices, err := c.workflow.BuildDeviceTypeMenu(ctx, selected.Slot, c.pageSize)
 				if err == nil {
-					err = c.menu.Push(images)
+					err = c.menu.Push(devices)
 				}
 				return "", err
 			})
@@ -414,6 +511,53 @@ func (c *WorkflowController) Handle(item MenuItem) {
 	case ImageSelection:
 		c.start("Working", func(ctx context.Context) (string, error) {
 			return c.workflow.AttachOrInsert(ctx, selected)
+		})
+	case DeviceTypeSelection:
+		if selected.Properties.GetSupportsFile() {
+			c.start("Loading images", func(ctx context.Context) (string, error) {
+				images, err := c.workflow.BuildImageMenuForType(ctx, selected.Slot, selected.Type, c.pageSize)
+				if err == nil {
+					AddAttachWithoutMediaOption(images, selected)
+					err = c.menu.Push(images)
+				}
+				return "", err
+			})
+			return
+		}
+		if !selected.Properties.GetSupportsParams() {
+			c.start("Working", func(ctx context.Context) (string, error) {
+				return c.workflow.AttachDevice(ctx, DeviceAttachSelection{Slot: selected.Slot, Type: selected.Type})
+			})
+			return
+		}
+		if selected.Type == pb.PbDeviceType_SCDP {
+			c.start("Loading topologies", func(ctx context.Context) (string, error) {
+				topologies, err := c.workflow.BuildNetworkTopologyMenu(ctx, selected.Slot, c.pageSize)
+				if err == nil {
+					err = c.menu.Push(topologies)
+				}
+				return "", err
+			})
+			return
+		}
+		options, err := NewDeviceOptionMenu(selected, c.pageSize)
+		if err != nil {
+			c.report(err)
+			return
+		}
+		if err := c.menu.Push(options); err != nil {
+			c.report(err)
+		}
+	case DeviceAttachSelection:
+		c.start("Working", func(ctx context.Context) (string, error) {
+			return c.workflow.AttachDevice(ctx, selected)
+		})
+	case NetworkTopologySelection:
+		c.start("Working", func(ctx context.Context) (string, error) {
+			return c.workflow.AttachDevice(ctx, DeviceAttachSelection{
+				Slot: selected.Slot, Type: pb.PbDeviceType_SCDP,
+				Params: map[string]string{"mode": selected.Mode, "interface": selected.Interface},
+			})
 		})
 	case ProfileSelection:
 		c.start("Loading profile", func(ctx context.Context) (string, error) {

--- a/go/piscsi-ctrlboard/workflow_test.go
+++ b/go/piscsi-ctrlboard/workflow_test.go
@@ -66,6 +66,25 @@ func TestBuildImageMenuIncludesEmptyState(t *testing.T) {
 	}
 }
 
+func TestBuildImageMenuForTypeFiltersDaemonMappedImages(t *testing.T) {
+	workflow := NewSCSIWorkflow(&workflowClient{results: []*pb.PbResult{{
+		Status: true, Result: &pb.PbResult_ImageFilesInfo{ImageFilesInfo: &pb.PbImageFilesInfo{ImageFiles: []*pb.PbImageFile{
+			{Name: "disk.hds", Type: pb.PbDeviceType_SCHD},
+			{Name: "media.mos", Type: pb.PbDeviceType_SCMO},
+		}}},
+	}}}, "")
+	menu, err := workflow.BuildImageMenuForType(context.Background(), SCSISlot{ID: 1}, pb.PbDeviceType_SCMO, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(menu.Items), 2; got != want {
+		t.Fatalf("image item count = %d, want %d", got, want)
+	}
+	if got, want := menu.Items[1].Label, "media.mos [SCMO]"; got != want {
+		t.Fatalf("filtered image = %q, want %q", got, want)
+	}
+}
+
 func TestAttachOrInsertUsesInsertForEmptyRemovableDevice(t *testing.T) {
 	client := &workflowClient{results: []*pb.PbResult{{Status: true}}}
 	device := &pb.PbDevice{
@@ -91,6 +110,23 @@ func TestAttachOrInsertUsesInsertForEmptyRemovableDevice(t *testing.T) {
 	}
 	if got, want := command.GetDevices()[0].GetUnit(), int32(1); got != want {
 		t.Fatalf("LUN = %d, want %d", got, want)
+	}
+}
+
+func TestAttachDeviceUsesPrinterDefaultCommand(t *testing.T) {
+	client := &workflowClient{results: []*pb.PbResult{{Status: true}}}
+	message, err := NewSCSIWorkflow(client, "").AttachDevice(context.Background(), DeviceAttachSelection{
+		Slot: SCSISlot{ID: 3}, Type: pb.PbDeviceType_SCLP, Params: map[string]string{"cmd": "different"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := message, "Attached ID 3"; got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+	device := client.commands[0].GetDevices()[0]
+	if got, want := device.GetParams()["cmd"], defaultPrinterCommand; got != want {
+		t.Fatalf("printer command = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
when you do Attach/Insert on an empty slot, you now get a list of all available device types instead of list of all images; picking one of them either attaches the device immediately, or takes you to a submenu for making additional choices (network topology, image file)

add an option to attach a removable device without inserting media