### PR TITLE
harden piscsi-web and flag safe code to SonarQube

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -146,5 +146,5 @@ jobs:
             --define sonar.sources=cpp,go
             --define sonar.cfamily.gcov.reportsPath=cpp
             --define sonar.go.coverage.reportPaths=go/coverage.txt
-            --define sonar.coverage.exclusions=cpp/test/**
+            --define sonar.coverage.exclusions=cpp/test/**,go/**/*_test.go
             --define sonar.cpd.exclusions=cpp/test/**

--- a/cpp/test/test_shared.cpp
+++ b/cpp/test/test_shared.cpp
@@ -22,9 +22,8 @@ using namespace filesystem;
 
 // Inlude the process id in the temp file path so that multiple instances of the test procedures
 // could run on the same host.
-const path test_data_temp_path(temp_directory_path() /
-                               path(fmt::format("piscsi-test-{}",
-                                                getpid()))); // NOSONAR Publicly writable directory is fine here
+const path test_data_temp_path(temp_directory_path() / //NOSONAR Publicly writable directory is fine for tests
+                               path(fmt::format("piscsi-test-{}", getpid())));
 
 pair<shared_ptr<MockAbstractController>, shared_ptr<PrimaryDevice>> CreateDevice(PbDeviceType type, const string& extension)
 {

--- a/go/piscsi-web/internal/server/archive_workflows.go
+++ b/go/piscsi-web/internal/server/archive_workflows.go
@@ -184,7 +184,7 @@ func (s *Server) inspectArchive(path string, info os.FileInfo) ([]archiveMember,
 func inspectArchiveMembers(path string) ([]lsarMember, error) {
 	var lsarErr error
 	if _, err := exec.LookPath("lsar"); err == nil {
-		output, commandErr := exec.Command("lsar", "-json", "--", path).Output()
+		output, commandErr := exec.Command("lsar", "-json", "--", path).Output() //NOSONAR path protected by systemd policy
 		if commandErr == nil {
 			var result lsarResult
 			if jsonErr := json.Unmarshal(output, &result); jsonErr == nil {
@@ -289,7 +289,7 @@ func inspectWithBSDTar(path string) ([]lsarMember, error) {
 	if _, err := exec.LookPath("bsdtar"); err != nil {
 		return nil, fmt.Errorf("bsdtar is unavailable")
 	}
-	output, err := exec.Command("bsdtar", "-tf", path).Output()
+	output, err := exec.Command("bsdtar", "-tf", path).Output() //NOSONAR path protected by systemd policy
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func extractArchiveMembers(archivePath, outputDir string, members []archiveMembe
 		for _, member := range members {
 			args = append(args, regexp.QuoteMeta(member.Path))
 		}
-		return exec.Command("unar", args...).CombinedOutput()
+		return exec.Command("unar", args...).CombinedOutput() //NOSONAR path protected by systemd policy
 	}
 	if _, err := exec.LookPath("bsdtar"); err != nil {
 		return nil, fmt.Errorf("neither unar nor bsdtar is available")
@@ -510,5 +510,5 @@ func extractArchiveMembers(archivePath, outputDir string, members []archiveMembe
 	for _, member := range members {
 		args = append(args, member.Path)
 	}
-	return exec.Command("bsdtar", args...).CombinedOutput()
+	return exec.Command("bsdtar", args...).CombinedOutput() //NOSONAR path protected by systemd policy
 }

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -31,6 +31,12 @@ import (
 	pb "github.com/piscsi/piscsi/go/proto"
 )
 
+const (
+	contentDescriptionHeader = "Content-Description"
+	contentDispositionHeader = "Content-Disposition"
+	fileTransferDescription  = "File Transfer"
+)
+
 // serves the main control page
 func (s *Server) handleIndex(c *gin.Context) {
 	// Get base template data
@@ -1361,6 +1367,15 @@ func (s *Server) uploadDestination(formValues map[string]string) (string, error)
 	}
 }
 
+func setAttachmentHeader(c *gin.Context, filename string) {
+	c.Header(contentDispositionHeader, fmt.Sprintf("attachment; filename=%s", filename))
+}
+
+func setFileDownloadHeaders(c *gin.Context, filename string) {
+	c.Header(contentDescriptionHeader, fileTransferDescription)
+	setAttachmentHeader(c, filename)
+}
+
 // handles file downloads
 func (s *Server) handleFilesDownload(c *gin.Context) {
 	filename := c.Query("file")
@@ -1407,7 +1422,7 @@ func (s *Server) handleFilesDownload(c *gin.Context) {
 		}
 		defer file.Close()
 
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filename)))
+		setAttachmentHeader(c, filepath.Base(filename))
 		http.ServeContent(c.Writer, c.Request, filepath.Base(filename), info.ModTime(), file)
 		return
 	}
@@ -2026,8 +2041,7 @@ func (s *Server) handleFilesDownloadConfig(c *gin.Context) {
 	defer file.Close()
 
 	// Serve the file for download
-	c.Header("Content-Description", "File Transfer")
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
+	setFileDownloadHeaders(c, fileName)
 	http.ServeContent(c.Writer, c.Request, fileName, info.ModTime(), file)
 }
 
@@ -2097,8 +2111,7 @@ func (s *Server) handleConfigAction(c *gin.Context) {
 			return
 		}
 
-		c.Header("Content-Description", "File Transfer")
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
+		setFileDownloadHeaders(c, fileName)
 		c.File(fullPath)
 		return
 	}
@@ -2158,6 +2171,9 @@ const (
 	defaultSystemLogLines = 100
 	maxSystemLogLines     = 1000
 	systemLogTimeout      = 10 * time.Second
+	logsTemplate          = "logs.html"
+	systemLogsTitle       = "PiSCSI System Logs"
+	allLogsScope          = "All logs"
 )
 
 var systemLogScopes = map[string]struct{}{
@@ -2195,10 +2211,10 @@ func (s *Server) handleLogsShow(c *gin.Context) {
 		s.respond(c, ResponseOptions{
 			Error:    true,
 			Message:  err.Error(),
-			Template: "logs.html",
+			Template: logsTemplate,
 			TemplateData: gin.H{
-				"Title": "PiSCSI System Logs",
-				"Scope": "All logs",
+				"Title": systemLogsTitle,
+				"Scope": allLogsScope,
 				"Lines": defaultSystemLogLines,
 			},
 		})
@@ -2223,14 +2239,14 @@ func (s *Server) handleLogsShow(c *gin.Context) {
 			message += ": " + details
 		}
 		data := s.getBaseTemplateData(c)
-		data["Title"] = "PiSCSI System Logs"
+		data["Title"] = systemLogsTitle
 		data["ErrorMessage"] = message
-		c.HTML(http.StatusInternalServerError, "logs.html", data)
+		c.HTML(http.StatusInternalServerError, logsTemplate, data)
 		return
 	}
 
 	// Prepare scope display text
-	scopeDisplay := "All logs"
+	scopeDisplay := allLogsScope
 	if scope != "" {
 		scopeDisplay = scope
 	}
@@ -2240,9 +2256,9 @@ func (s *Server) handleLogsShow(c *gin.Context) {
 	data["Scope"] = scopeDisplay
 	data["Lines"] = strconv.Itoa(lines)
 	data["Logs"] = logs
-	data["Title"] = "PiSCSI System Logs"
+	data["Title"] = systemLogsTitle
 
-	c.HTML(http.StatusOK, "logs.html", data)
+	c.HTML(http.StatusOK, logsTemplate, data)
 }
 
 // restarts the system

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -3523,7 +3523,7 @@ func (s *Server) handleFilesCreateISO(c *gin.Context) {
 	}
 
 	args := append(append([]string{}, isoArgs...), "-o", isoPath, sourcePath)
-	output, err := exec.Command("genisoimage", args...).CombinedOutput()
+	output, err := exec.Command("genisoimage", args...).CombinedOutput() //NOSONAR path protected by systemd policy
 	if err != nil {
 		_ = os.Remove(isoPath)
 		detail := strings.TrimSpace(string(output))

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -1395,6 +1395,22 @@ func (s *Server) handleFilesDownload(c *gin.Context) {
 		c.String(http.StatusBadRequest, "Invalid filename")
 		return
 	}
+	if source == "config" {
+		file, info, err := openRegularFileWithin(sourcePath, filename)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				c.String(http.StatusNotFound, "File not found")
+			} else {
+				c.String(http.StatusBadRequest, "Invalid file")
+			}
+			return
+		}
+		defer file.Close()
+
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filename)))
+		http.ServeContent(c.Writer, c.Request, filepath.Base(filename), info.ModTime(), file)
+		return
+	}
 
 	// Check if file exists
 	if _, err := os.Stat(realPath); os.IsNotExist(err) {
@@ -1998,27 +2014,21 @@ func (s *Server) handleFilesDownloadConfig(c *gin.Context) {
 		return
 	}
 
-	// Construct full path
-	fullPath := filepath.Join(s.config.ConfigDir, fileName)
-
-	// Verify path is within config directory
-	cleanPath := filepath.Clean(fullPath)
-	configDir := filepath.Clean(s.config.ConfigDir)
-	if !strings.HasPrefix(cleanPath, configDir) {
-		c.String(http.StatusBadRequest, "Invalid file path")
+	file, info, err := openRegularFileWithin(s.config.ConfigDir, fileName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.String(http.StatusNotFound, "File not found: %s", fileName)
+		} else {
+			c.String(http.StatusBadRequest, "Invalid file")
+		}
 		return
 	}
-
-	// Check if file exists
-	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		c.String(http.StatusNotFound, "File not found: %s", fileName)
-		return
-	}
+	defer file.Close()
 
 	// Serve the file for download
 	c.Header("Content-Description", "File Transfer")
 	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
-	c.File(fullPath)
+	http.ServeContent(c.Writer, c.Request, fileName, info.ModTime(), file)
 }
 
 // performs an action on a configuration file (load, delete, or send)

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -537,12 +537,12 @@ type deviceParameterControl struct {
 }
 
 type deviceCatalogEntry struct {
-	Key           string
-	Name          string
-	MaxLUN        int32
-	Removable     bool
-	SupportsFile  bool
-	Parameters    []deviceParameterControl
+	Key                 string
+	Name                string
+	MaxLUN              int32
+	Removable           bool
+	SupportsFile        bool
+	Parameters          []deviceParameterControl
 	UsesNetworkTopology bool
 	NetworkProfiles     []networkTopology
 	Files               []map[string]interface{}

--- a/go/piscsi-web/internal/server/handlers.go
+++ b/go/piscsi-web/internal/server/handlers.go
@@ -2154,22 +2154,67 @@ func (s *Server) handleLogsLevel(c *gin.Context) {
 	})
 }
 
+const (
+	defaultSystemLogLines = 100
+	maxSystemLogLines     = 1000
+	systemLogTimeout      = 10 * time.Second
+)
+
+var systemLogScopes = map[string]struct{}{
+	"piscsi":           {},
+	"piscsi-web":       {},
+	"piscsi-oled":      {},
+	"piscsi-ctrlboard": {},
+}
+
+func parseSystemLogRequest(linesValue, scope string) (int, string, error) {
+	lines := defaultSystemLogLines
+	if linesValue != "" {
+		parsed, err := strconv.Atoi(linesValue)
+		if err != nil || parsed < 1 || parsed > maxSystemLogLines {
+			return 0, "", fmt.Errorf("log lines must be between 1 and %d", maxSystemLogLines)
+		}
+		lines = parsed
+	}
+
+	if scope != "" {
+		if _, ok := systemLogScopes[scope]; !ok {
+			return 0, "", fmt.Errorf("invalid log scope")
+		}
+	}
+
+	return lines, scope, nil
+}
+
 // displays system logs
 func (s *Server) handleLogsShow(c *gin.Context) {
-	lines := c.DefaultPostForm("lines", "100")
+	linesValue := c.PostForm("lines")
 	scope := c.PostForm("scope")
+	lines, scope, err := parseSystemLogRequest(linesValue, scope)
+	if err != nil {
+		s.respond(c, ResponseOptions{
+			Error:    true,
+			Message:  err.Error(),
+			Template: "logs.html",
+			TemplateData: gin.H{
+				"Title": "PiSCSI System Logs",
+				"Scope": "All logs",
+				"Lines": defaultSystemLogLines,
+			},
+		})
+		return
+	}
 
 	// Build journalctl command
-	args := []string{}
-	if lines != "" {
-		args = append(args, "-n", lines)
-	}
+	args := []string{"--no-pager", "--lines=" + strconv.Itoa(lines)}
 	if scope != "" {
-		args = append(args, "-u", scope)
+		args = append(args, "--unit="+scope)
 	}
 
 	// Execute journalctl command
-	output, err := s.runSystemCommand("journalctl", args...)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), systemLogTimeout)
+	defer cancel()
+	output, err := s.runSystemCommandContext(ctx, "journalctl", args...)
 
 	logs := string(output)
 	if err != nil {
@@ -2193,7 +2238,7 @@ func (s *Server) handleLogsShow(c *gin.Context) {
 	// Render the logs template
 	data := s.getBaseTemplateData(c)
 	data["Scope"] = scopeDisplay
-	data["Lines"] = lines
+	data["Lines"] = strconv.Itoa(lines)
 	data["Logs"] = logs
 	data["Title"] = "PiSCSI System Logs"
 

--- a/go/piscsi-web/internal/server/handlers_config_download_test.go
+++ b/go/piscsi-web/internal/server/handlers_config_download_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piscsi/piscsi/go/piscsi-web/internal/config"
+)
+
+func TestConfigurationDownloadsRejectSymlinks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	configDir := t.TempDir()
+	secretPath := filepath.Join(t.TempDir(), "secret.json")
+	if err := os.WriteFile(secretPath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secretPath, filepath.Join(configDir, "download.json")); err != nil {
+		t.Skipf("create symbolic link: %v", err)
+	}
+
+	server := &Server{config: &config.Config{ConfigDir: configDir}}
+	configDownloadRequest := httptest.NewRequest(http.MethodPost, "/files/download_config",
+		strings.NewReader(url.Values{"file": {"download.json"}}.Encode()))
+	configDownloadRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tests := []struct {
+		name    string
+		request *http.Request
+		handler func(*gin.Context)
+	}{
+		{
+			name:    "configuration download endpoint",
+			request: configDownloadRequest,
+			handler: server.handleFilesDownloadConfig,
+		},
+		{
+			name:    "generic download endpoint with config source",
+			request: httptest.NewRequest(http.MethodGet, "/files/download_image?source=config&file=download.json", nil),
+			handler: server.handleFilesDownload,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			context, _ := gin.CreateTestContext(response)
+			context.Request = test.request
+			test.handler(context)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusBadRequest, response.Body.String())
+			}
+			if strings.Contains(response.Body.String(), "secret") {
+				t.Fatal("download response exposed symlink target content")
+			}
+		})
+	}
+}

--- a/go/piscsi-web/internal/server/pathutil.go
+++ b/go/piscsi-web/internal/server/pathutil.go
@@ -6,10 +6,14 @@
 package server
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
+
+var errNotRegularFile = errors.New("not a regular file")
 
 // resolvePathWithin converts a browser-facing relative path into an absolute
 // path below root. It rejects absolute paths and lexical traversal.
@@ -99,4 +103,39 @@ func uploadDestinationPath(root, subdirectory string) (string, error) {
 		return "", fmt.Errorf("destination escapes the configured directory")
 	}
 	return target, nil
+}
+
+// openRegularFileWithin opens name beneath root without following a symlink
+// outside root. Symlink leaves are rejected so callers do not serve a file
+// selected by a locally planted link.
+func openRegularFileWithin(root, name string) (*os.File, os.FileInfo, error) {
+	rootHandle, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open root directory: %w", err)
+	}
+	defer rootHandle.Close()
+
+	entryInfo, err := rootHandle.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !entryInfo.Mode().IsRegular() {
+		return nil, nil, errNotRegularFile
+	}
+
+	file, err := rootHandle.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, nil, errNotRegularFile
+	}
+
+	return file, info, nil
 }

--- a/go/piscsi-web/internal/server/pathutil_test.go
+++ b/go/piscsi-web/internal/server/pathutil_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,5 +70,26 @@ func TestUploadDestinationPathRejectsEscapingSymlink(t *testing.T) {
 
 	if _, err := uploadDestinationPath(root, "outside-link"); err == nil {
 		t.Fatal("uploadDestinationPath() accepted a symlink outside the configured directory")
+	}
+}
+
+func TestOpenRegularFileWithinRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.json")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "download.json")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("create symbolic link: %v", err)
+	}
+
+	file, _, err := openRegularFileWithin(root, "download.json")
+	if file != nil {
+		file.Close()
+		t.Fatal("openRegularFileWithin() opened a symbolic link")
+	}
+	if !errors.Is(err, errNotRegularFile) {
+		t.Fatalf("openRegularFileWithin() error = %v, want errNotRegularFile", err)
 	}
 }

--- a/go/piscsi-web/internal/server/system_environment.go
+++ b/go/piscsi-web/internal/server/system_environment.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -32,10 +33,14 @@ type serviceStatus struct {
 }
 
 func (s *Server) runSystemCommand(name string, args ...string) ([]byte, error) {
+	return s.runSystemCommandContext(context.Background(), name, args...)
+}
+
+func (s *Server) runSystemCommandContext(ctx context.Context, name string, args ...string) ([]byte, error) {
 	if s.systemCommand != nil {
 		return s.systemCommand(name, args...)
 	}
-	return exec.Command(name, args...).CombinedOutput()
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
 }
 
 func (s *Server) systemHostname() string {

--- a/go/piscsi-web/internal/server/system_environment_test.go
+++ b/go/piscsi-web/internal/server/system_environment_test.go
@@ -95,3 +95,81 @@ func TestHandleLogsShowReturnsErrorWhenJournalctlFails(t *testing.T) {
 		t.Errorf("body = %q, want journal error details", response.Body.String())
 	}
 }
+
+func TestHandleLogsShowValidatesAndBoundsRequestParameters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, requestBody := range []string{
+		"lines=0",
+		"lines=1001",
+		"lines=all",
+		"scope=sshd",
+	} {
+		t.Run(requestBody, func(t *testing.T) {
+			journalctlCalled := false
+			server := &Server{
+				systemCommand: func(name string, _ ...string) ([]byte, error) {
+					if name == "journalctl" {
+						journalctlCalled = true
+					}
+					return nil, nil
+				},
+				sessionStore: sessions.NewCookieStore([]byte("test-secret-key")),
+			}
+			templates, err := web.GetTemplates()
+			if err != nil {
+				t.Fatal(err)
+			}
+			router := gin.New()
+			router.SetHTMLTemplate(templates)
+			router.POST("/logs/show", server.handleLogsShow)
+			request := httptest.NewRequest(http.MethodPost, "/logs/show", strings.NewReader(requestBody))
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+			}
+			if journalctlCalled {
+				t.Error("journalctl was called for an invalid request")
+			}
+		})
+	}
+}
+
+func TestHandleLogsShowPassesBoundedArgumentsToJournalctl(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var gotName string
+	var gotArgs []string
+	server := &Server{
+		systemCommand: func(name string, args ...string) ([]byte, error) {
+			if name == "journalctl" {
+				gotName = name
+				gotArgs = append([]string(nil), args...)
+			}
+			return []byte("test log"), nil
+		},
+		sessionStore: sessions.NewCookieStore([]byte("test-secret-key")),
+	}
+	templates, err := web.GetTemplates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.SetHTMLTemplate(templates)
+	router.POST("/logs/show", server.handleLogsShow)
+	request := httptest.NewRequest(http.MethodPost, "/logs/show", strings.NewReader("lines=200&scope=piscsi-web"))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if gotName != "journalctl" {
+		t.Fatalf("command = %q, want journalctl", gotName)
+	}
+	if got, want := strings.Join(gotArgs, ","), "--no-pager,--lines=200,--unit=piscsi-web"; got != want {
+		t.Errorf("arguments = %q, want %q", got, want)
+	}
+}

--- a/go/piscsi-web/web/templates/admin.html
+++ b/go/piscsi-web/web/templates/admin.html
@@ -25,7 +25,7 @@
 <div>
 <form action="/logs/show" method="post">
     <label for="log_lines">Log Lines:</label>
-    <input name="lines" id="log_lines" type="number" value="200" min="0" max="99999" step="100">
+    <input name="lines" id="log_lines" type="number" value="200" min="1" max="1000" step="1">
     <label for="log_scope">Scope:</label>
     <select name="scope" id="log_scope">
         <option value="">

--- a/go/piscsi-web/web/templates/logs.html
+++ b/go/piscsi-web/web/templates/logs.html
@@ -8,7 +8,7 @@
 <div>
 <form action="/logs/show" method="post">
     <label for="log_lines">Log Lines:</label>
-    <input name="lines" id="log_lines" type="number" value="200" min="0" max="99999" step="100">
+    <input name="lines" id="log_lines" type="number" value="200" min="1" max="1000" step="1">
     <label for="log_scope">Scope:</label>
     <select name="scope" id="log_scope">
         <option value="">

--- a/os_integration/systemd/piscsi-web.service
+++ b/os_integration/systemd/piscsi-web.service
@@ -8,6 +8,7 @@ Wants=piscsi.service
 Type=simple
 User=piscsi-web
 Group=piscsi
+SupplementaryGroups=systemd-journal
 UMask=0007
 ExecStart=/usr/bin/piscsi-web
 EnvironmentFile=/etc/piscsi-web/piscsi-web.env

--- a/os_integration/systemd/piscsi-web.service
+++ b/os_integration/systemd/piscsi-web.service
@@ -11,6 +11,7 @@ Group=piscsi
 SupplementaryGroups=systemd-journal
 UMask=0007
 ExecStart=/usr/bin/piscsi-web
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 EnvironmentFile=/etc/piscsi-web/piscsi-web.env
 NoNewPrivileges=true
 PrivateTmp=true

--- a/os_integration/systemd/piscsi.service
+++ b/os_integration/systemd/piscsi.service
@@ -7,6 +7,7 @@ After=network.target
 Type=simple
 Restart=always
 Environment=PISCSI_CONNECTION_TYPE=FULLSPEC
+Environment="PATH=/usr/sbin:/usr/bin:/sbin:/bin"
 ExecStart=/usr/bin/piscsi -C ${PISCSI_CONNECTION_TYPE} -r 7
 ExecStop=/usr/bin/scsictl -X
 SyslogIdentifier=PISCSI


### PR DESCRIPTION
this hardens the piscsi-web configuration file download and systemd log viewer hardening -- we now have a hard limit of 1000 lines of syslog to prevent bad outcomes

bind explicit PATH env variables in the systemd units for piscsi and piscsi-web to harden programmatic system shell calls

add or tweak a number of NOSONAR code comments to suppress false positives by the SonarQube scanner