### PR TITLE
add Host Services remote command support

### DIFF
--- a/cpp/devices/host_services.cpp
+++ b/cpp/devices/host_services.cpp
@@ -3,9 +3,9 @@
 // SCSI Target Emulator PiSCSI
 // for Raspberry Pi
 //
-// Copyright (C) 2022-2023 Uwe Seimet
+// Copyright (C) 2022-2026 Uwe Seimet
 //
-// Host Services with realtime clock and shutdown support
+// Host Services with realtime clock, shutdown and remote command support
 //
 //---------------------------------------------------------------------------
 
@@ -19,6 +19,14 @@
 //   b) !start && load (EJECT): Shut down the Raspberry Pi
 //   c) start && load (LOAD): Reboot the Raspberry Pi
 //
+// 3. Vendor-specific remote command execution:
+//   a) EXECUTE OPERATION (0xc0) receives a PbCommand
+//   b) RECEIVE OPERATION RESULTS (0xc1) returns the matching PbResult
+//
+// Byte 1 selects exactly one protobuf encoding: binary (bit 0), JSON (bit 1)
+// or text format (bit 2). Bytes 7-8 contain the transfer/allocation length.
+// Results are retained per initiator until read or replaced by another command.
+//
 
 #include "shared/piscsi_exceptions.h"
 #include "controllers/scsi_controller.h"
@@ -26,10 +34,14 @@
 #include "host_services.h"
 #include <algorithm>
 #include <chrono>
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/json_util.h>
 
 using namespace std::chrono;
 using namespace scsi_defs;
 using namespace scsi_command_util;
+using namespace google::protobuf;
+using namespace google::protobuf::util;
 
 bool HostServices::Init(const param_map& params)
 {
@@ -37,6 +49,8 @@ bool HostServices::Init(const param_map& params)
 
 	AddCommand(scsi_command::eCmdTestUnitReady, [this] { TestUnitReady(); });
 	AddCommand(scsi_command::eCmdStartStop, [this] { StartStopUnit(); });
+	AddCommand(scsi_command::eCmdExecuteOperation, [this] { ExecuteOperation(); });
+	AddCommand(scsi_command::eCmdReceiveOperationResults, [this] { ReceiveOperationResults(); });
 
 	SetReady(true);
 
@@ -77,10 +91,127 @@ void HostServices::StartStopUnit() const
 	EnterStatusPhase();
 }
 
+int HostServices::GetTransferLength() const
+{
+	return GetInt16(GetController()->GetCmd(), 7);
+}
+
+void HostServices::ExecuteOperation()
+{
+	execution_results.erase(GetController()->GetInitiatorId());
+	input_format = ConvertFormat();
+
+	const int length = GetTransferLength();
+	if (!length) {
+		throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
+	}
+
+	// The controller's default buffer is 4 KiB; this protocol permits 64 KiB.
+	GetController()->AllocateBuffer(length);
+	GetController()->SetLength(length);
+	GetController()->SetByteTransfer(true);
+	EnterDataOutPhase();
+}
+
+void HostServices::ReceiveOperationResults()
+{
+	const protobuf_format output_format = ConvertFormat();
+	const auto it = execution_results.find(GetController()->GetInitiatorId());
+	if (it == execution_results.end()) {
+		throw scsi_exception(sense_key::illegal_request, asc::data_currently_unavailable);
+	}
+
+	string data;
+	switch (output_format) {
+		case protobuf_format::binary:
+			data = it->second;
+			break;
+
+		case protobuf_format::json: {
+			if (PbResult result; !result.ParseFromString(it->second) || !MessageToJsonString(result, &data).ok()) {
+				throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+			}
+			break;
+		}
+
+		case protobuf_format::text: {
+			if (PbResult result; !result.ParseFromString(it->second) || !TextFormat::PrintToString(result, &data)) {
+				throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+			}
+			break;
+		}
+	}
+
+	execution_results.erase(it);
+	const int length = min(GetTransferLength(), static_cast<int>(data.size()));
+	GetController()->AllocateBuffer(length);
+	memcpy(GetController()->GetBuffer().data(), data.data(), length);
+	GetController()->SetLength(length);
+	EnterDataInPhase();
+}
+
+bool HostServices::ParseCommand(span<const uint8_t> buf, PbCommand& command) const
+{
+	const int length = GetTransferLength();
+	if (length <= 0 || static_cast<size_t>(length) > buf.size()) {
+		return false;
+	}
+
+	switch (input_format) {
+		case protobuf_format::binary:
+			return command.ParseFromArray(buf.data(), length);
+
+		case protobuf_format::json:
+			return JsonStringToMessage(string(reinterpret_cast<const char*>(buf.data()), length), &command).ok();
+
+		case protobuf_format::text:
+			return TextFormat::ParseFromString(string(reinterpret_cast<const char*>(buf.data()), length), &command);
+	}
+
+	return false;
+}
+
+bool HostServices::WriteByteSequence(span<const uint8_t> buf)
+{
+	if (GetController()->GetCmdByte(0) != static_cast<int>(scsi_command::eCmdExecuteOperation)) {
+		throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+	}
+
+	PbCommand command;
+	if (!ParseCommand(buf, command)) {
+		LogTrace("Failed to deserialize Host Services command");
+		throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+	}
+
+	if (!execute_command) {
+		LogError("Host Services command executor is not configured");
+		throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+	}
+
+	PbResult result;
+	if (!execute_command(command, result)) {
+		LogTrace("Failed to execute " + PbOperation_Name(command.operation()) + " operation");
+		throw scsi_exception(sense_key::aborted_command, asc::internal_target_failure);
+	}
+
+	execution_results[GetController()->GetInitiatorId()] = result.SerializeAsString();
+	return true;
+}
+
+HostServices::protobuf_format HostServices::ConvertFormat() const
+{
+	switch (GetController()->GetCmdByte(1) & 0x1f) {
+		case static_cast<int>(protobuf_format::binary): return protobuf_format::binary;
+		case static_cast<int>(protobuf_format::json): return protobuf_format::json;
+		case static_cast<int>(protobuf_format::text): return protobuf_format::text;
+		default: throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
+	}
+}
+
 int HostServices::ModeSense6(cdb_t cdb, vector<uint8_t>& buf) const
 {
-	// Block descriptors cannot be returned
-	if (!(cdb[1] & 0x08)) {
+	// Block descriptors and subpages are not supported.
+	if (cdb[3] || !(cdb[1] & 0x08)) {
 		throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
 	}
 
@@ -90,15 +221,16 @@ int HostServices::ModeSense6(cdb_t cdb, vector<uint8_t>& buf) const
 	// 4 bytes basic information
 	const int size = AddModePages(cdb, buf, 4, length, 255);
 
-	buf[0] = (uint8_t)size;
+	// The mode data length does not count its own byte.
+	buf[0] = static_cast<uint8_t>(size - 1);
 
 	return size;
 }
 
 int HostServices::ModeSense10(cdb_t cdb, vector<uint8_t>& buf) const
 {
-	// Block descriptors cannot be returned
-	if (!(cdb[1] & 0x08)) {
+	// Block descriptors and subpages are not supported.
+	if (cdb[3] || !(cdb[1] & 0x08)) {
 		throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
 	}
 
@@ -108,7 +240,8 @@ int HostServices::ModeSense10(cdb_t cdb, vector<uint8_t>& buf) const
 	// 8 bytes basic information
 	const int size = AddModePages(cdb, buf, 8, length, 65535);
 
-	SetInt16(buf, 0, size);
+	// The mode data length does not count its own two bytes.
+	SetInt16(buf, 0, size - 2);
 
 	return size;
 }

--- a/cpp/devices/host_services.h
+++ b/cpp/devices/host_services.h
@@ -15,6 +15,8 @@
 #include <span>
 #include <vector>
 #include <map>
+#include <functional>
+#include <utility>
 
 class HostServices: public ModePageDevice
 {
@@ -28,6 +30,12 @@ public:
 
 	vector<uint8_t> InquiryInternal() const override;
 	void TestUnitReady() override;
+
+	// Executes a remote-interface command without using its socket transport.
+	using command_executor = function<bool(const PbCommand&, PbResult&)>;
+	void SetCommandExecutor(command_executor executor) { execute_command = std::move(executor); }
+
+	bool WriteByteSequence(span<const uint8_t>) override;
 
 protected:
 
@@ -49,8 +57,20 @@ private:
 	};
 
 	void StartStopUnit() const;
+	void ExecuteOperation();
+	void ReceiveOperationResults();
 	int ModeSense6(cdb_t, vector<uint8_t>&) const override;
 	int ModeSense10(cdb_t, vector<uint8_t>&) const override;
 
 	void AddRealtimeClockPage(map<int, vector<byte>>&, bool) const;
+	bool ParseCommand(span<const uint8_t>, PbCommand&) const;
+	int GetTransferLength() const;
+
+	enum class protobuf_format { binary = 0x01, json = 0x02, text = 0x04 };
+	protobuf_format ConvertFormat() const;
+
+	// Operation results are isolated by initiator ID.
+	unordered_map<int, string> execution_results;
+	command_executor execute_command;
+	protobuf_format input_format = protobuf_format::binary;
 };

--- a/cpp/piscsi/command_context.cpp
+++ b/cpp/piscsi/command_context.cpp
@@ -37,6 +37,11 @@ bool CommandContext::ReadCommand()
 
 void CommandContext::WriteResult(const PbResult& result) const
 {
+	if (output_result != nullptr) {
+		*output_result = result;
+		return;
+	}
+
 	// The descriptor is -1 when devices are not attached via the remote interface but by the piscsi tool
 	if (fd != -1) {
 		SerializeMessage(fd, result);
@@ -78,7 +83,14 @@ bool CommandContext::ReturnStatus(bool status, const string& msg, PbErrorCode er
 		spdlog::error(msg);
 	}
 
-	if (fd == -1) {
+	if (output_result != nullptr) {
+		PbResult response;
+		response.set_status(status);
+		response.set_error_code(error_code);
+		response.set_msg(msg);
+		WriteResult(response);
+	}
+	else if (fd == -1) {
 		if (!msg.empty()) {
 			cerr << "Error: " << msg << endl;
 		}

--- a/cpp/piscsi/command_context.h
+++ b/cpp/piscsi/command_context.h
@@ -21,7 +21,8 @@ class CommandContext
 
 public:
 
-	CommandContext(const PbCommand& cmd, string_view f, string_view l) : command(cmd), default_folder(f), locale(l) {}
+	CommandContext(const PbCommand& cmd, string_view f, string_view l, PbResult *r = nullptr)
+		: command(cmd), default_folder(f), locale(l), output_result(r) {}
 	explicit CommandContext(int f) : fd(f) {}
 	~CommandContext() = default;
 
@@ -50,4 +51,7 @@ private:
 	string locale;
 
 	int fd = -1;
+
+	// Host Services uses the existing command router without its socket transport.
+	PbResult *output_result = nullptr;
 };

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -18,6 +18,7 @@
 #include "controllers/scsi_controller.h"
 #include "devices/device_logger.h"
 #include "devices/scsi_host_bridge.h"
+#include "devices/host_services.h"
 #include "devices/storage_device.h"
 #include "hal/gpiobus_factory.h"
 #include "hal/gpiobus.h"
@@ -349,7 +350,7 @@ bool Piscsi::SetLogLevel(const string& log_level) const
 	return true;
 }
 
-bool Piscsi::ExecuteCommand(const CommandContext& context)
+bool Piscsi::ExecuteCommand(const CommandContext& context, bool lock)
 {
 	const PbCommand& command = context.GetCommand();
 	const PbOperation operation = command.operation();
@@ -481,8 +482,17 @@ bool Piscsi::ExecuteCommand(const CommandContext& context)
 			return executor->ProcessCmd(context);
 
 		default:
-			// The remaining commands may only be executed when the target is idle
-			if (!ExecuteWithLock(context)) {
+			// Socket commands must not race the SCSI command loop. Host Services
+			// commands already execute under execution_locker.
+			bool success;
+			if (lock) {
+				success = ExecuteWithLock(context);
+			}
+			else {
+				success = executor->ProcessCmd(context);
+				ConfigureRasctlControlChannels();
+			}
+			if (!success) {
 				return false;
 			}
 
@@ -490,6 +500,12 @@ bool Piscsi::ExecuteCommand(const CommandContext& context)
 	}
 
 	return true;
+}
+
+bool Piscsi::ExecuteHostServiceCommand(const PbCommand& command, PbResult& result)
+{
+	const CommandContext context(command, piscsi_image.GetDefaultFolder(), GetParam(command, "locale"), &result);
+	return ExecuteCommand(context, false) && result.status();
 }
 
 bool Piscsi::ExecuteWithLock(const CommandContext& context)
@@ -500,8 +516,12 @@ bool Piscsi::ExecuteWithLock(const CommandContext& context)
 	return success;
 }
 
-bool Piscsi::HandleDeviceListChange(const CommandContext& context, PbOperation operation) const
+bool Piscsi::HandleDeviceListChange(const CommandContext& context, PbOperation operation)
 {
+	if (operation == ATTACH) {
+		ConfigureHostServices();
+	}
+
 	// ATTACH and DETACH return the resulting device list
 	if (operation == ATTACH || operation == DETACH) {
 		// A command with an empty device list is required here in order to return data for all devices
@@ -513,6 +533,17 @@ bool Piscsi::HandleDeviceListChange(const CommandContext& context, PbOperation o
 	}
 
 	return true;
+}
+
+void Piscsi::ConfigureHostServices()
+{
+	for (const auto& device : controller_manager.GetAllDevices()) {
+		if (const auto services = dynamic_pointer_cast<HostServices>(device); services != nullptr) {
+			services->SetCommandExecutor([this] (const PbCommand& command, PbResult& result) {
+				return ExecuteHostServiceCommand(command, result);
+			});
+		}
+	}
 }
 
 int Piscsi::run(span<char *> args)
@@ -578,6 +609,8 @@ int Piscsi::run(span<char *> args)
 			return EXIT_FAILURE;
 		}
 	}
+
+	ConfigureHostServices();
 
 	ConfigureRasctlControlChannels();
 

--- a/cpp/piscsi/piscsi_core.h
+++ b/cpp/piscsi/piscsi_core.h
@@ -54,9 +54,11 @@ private:
 	bool ShutDown(AbstractController::piscsi_shutdown_mode);
 	bool ShutDown(const CommandContext&, const string&);
 
-	bool ExecuteCommand(const CommandContext&);
+	bool ExecuteCommand(const CommandContext&, bool = true);
+	bool ExecuteHostServiceCommand(const PbCommand&, PbResult&);
 	bool ExecuteWithLock(const CommandContext&);
-	bool HandleDeviceListChange(const CommandContext&, PbOperation) const;
+	bool HandleDeviceListChange(const CommandContext&, PbOperation);
+	void ConfigureHostServices();
 	// Translates the historic X68000 RASCTL text protocol into normal PiSCSI commands.
 	void ProcessRasctlControlCommands();
 	string ExecuteRasctlControlCommand(const string&, SCSIBR::rasctl_shutdown_mode&);

--- a/cpp/shared/scsi.h
+++ b/cpp/shared/scsi.h
@@ -118,6 +118,9 @@ enum class scsi_command {
     eCmdReadCapacity16_ReadLong16  = 0x9E,
     eCmdWriteLong16                = 0x9F,
     eCmdReportLuns                 = 0xA0,
+    // Host Services vendor-specific remote command interface
+    eCmdExecuteOperation           = 0xC0,
+    eCmdReceiveOperationResults    = 0xC1,
     // SASI/OMTI Assign Disk Parameters. The CDB is six bytes and is followed
     // by a ten-byte parameter list in the data-out phase.
     eCmdAssignDiskParameters       = 0xC2
@@ -154,7 +157,9 @@ enum class asc {
     not_ready_to_ready_change       = 0x28,
     power_on_or_reset               = 0x29,
     medium_not_present              = 0x3a,
-    load_or_eject_failed            = 0x53
+    internal_target_failure         = 0x44,
+    load_or_eject_failed            = 0x53,
+    data_currently_unavailable     = 0x55
 };
 
 static const unordered_map<scsi_command, pair<int, string>> command_mapping = {
@@ -202,5 +207,7 @@ static const unordered_map<scsi_command, pair<int, string>> command_mapping = {
     {scsi_command::eCmdReadCapacity16_ReadLong16, make_pair(16, "ReadCapacity16/ReadLong16")},
     {scsi_command::eCmdWriteLong16, make_pair(16, "WriteLong16")},
     {scsi_command::eCmdReportLuns, make_pair(12, "ReportLuns")},
+    {scsi_command::eCmdExecuteOperation, make_pair(10, "ExecuteOperation")},
+    {scsi_command::eCmdReceiveOperationResults, make_pair(10, "ReceiveOperationResults")},
     {scsi_command::eCmdAssignDiskParameters, make_pair(6, "AssignDiskParameters")}};
 }; // namespace scsi_defs

--- a/cpp/test/bus_test.cpp
+++ b/cpp/test/bus_test.cpp
@@ -12,7 +12,7 @@
 
 TEST(BusTest, GetCommandByteCount)
 {
-    EXPECT_EQ(44, scsi_defs::command_mapping.size());
+	EXPECT_EQ(46, scsi_defs::command_mapping.size());
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x00));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x01));
     EXPECT_EQ(6, BUS::GetCommandByteCount(0x03));

--- a/cpp/test/host_services_test.cpp
+++ b/cpp/test/host_services_test.cpp
@@ -10,6 +10,9 @@
 #include "mocks.h"
 #include "shared/piscsi_exceptions.h"
 #include "devices/host_services.h"
+#include <array>
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/json_util.h>
 
 using namespace std;
 
@@ -102,7 +105,12 @@ TEST(HostServicesTest, ModeSense6)
     EXPECT_CALL(*controller, DataIn());
     services->Dispatch(scsi_command::eCmdModeSense6);
 	buffer = controller->GetBuffer();
-	EXPECT_EQ(0x02, buffer[0]);
+	EXPECT_EQ(0x01, buffer[0]);
+
+	controller->SetCmdByte(3, 1);
+	EXPECT_THAT([&] { s->Dispatch(scsi_command::eCmdModeSense6); }, Throws<scsi_exception>(AllOf(
+			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+			Property(&scsi_exception::get_asc, asc::invalid_field_in_cdb))));
 }
 
 TEST(HostServicesTest, ModeSense10)
@@ -139,12 +147,131 @@ TEST(HostServicesTest, ModeSense10)
 	// Day
 	EXPECT_NE(0x00, buffer[14]);
 
-    // ALLOCATION LENGTH
-	controller->SetCmdByte(8, 2);
+    // ALLOCATION LENGTH (the two-byte header must fit in the response)
+	controller->SetCmdByte(8, 4);
     EXPECT_CALL(*controller, DataIn());
     services->Dispatch(scsi_command::eCmdModeSense10);
 	buffer = controller->GetBuffer();
 	EXPECT_EQ(0x02, buffer[1]);
+
+	controller->SetCmdByte(3, 1);
+	EXPECT_THAT([&] { s->Dispatch(scsi_command::eCmdModeSense10); }, Throws<scsi_exception>(AllOf(
+			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+			Property(&scsi_exception::get_asc, asc::invalid_field_in_cdb))));
+}
+
+TEST(HostServicesTest, RemoteCommandExecution)
+{
+	auto [controller, services] = CreateDevice(SCHS);
+	EXPECT_TRUE(services->Init({}));
+
+	PbCommand command;
+	(*command.mutable_params())["locale"] = "en";
+	(*command.mutable_params())["payload"] = string(5000, 'x');
+	const string data = command.SerializeAsString();
+
+	controller->SetCmdByte(0, static_cast<int>(scsi_command::eCmdExecuteOperation));
+	controller->SetCmdByte(1, 0x01);
+	controller->SetCmdByte(7, static_cast<int>(data.size() >> 8));
+	controller->SetCmdByte(8, static_cast<int>(data.size()));
+	EXPECT_CALL(*controller, DataOut());
+	services->Dispatch(scsi_command::eCmdExecuteOperation);
+
+	auto host_services = dynamic_pointer_cast<HostServices>(services);
+	host_services->SetCommandExecutor([] (const PbCommand& received, PbResult& result) {
+		EXPECT_EQ("en", received.params().at("locale"));
+		EXPECT_EQ(5000, received.params().at("payload").size());
+		result.set_status(true);
+		result.set_msg("executed");
+		return true;
+	});
+	EXPECT_TRUE(host_services->WriteByteSequence(span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+	EXPECT_LE(data.size(), controller->GetBuffer().size());
+
+	controller->SetCmdByte(0, static_cast<int>(scsi_command::eCmdReceiveOperationResults));
+	controller->SetCmdByte(1, 0x01);
+	controller->SetCmdByte(7, 0x04);
+	controller->SetCmdByte(8, 0x00);
+	EXPECT_CALL(*controller, DataIn());
+	services->Dispatch(scsi_command::eCmdReceiveOperationResults);
+
+	PbResult result;
+	EXPECT_TRUE(result.ParseFromArray(controller->GetBuffer().data(), controller->GetLength()));
+	EXPECT_TRUE(result.status());
+	EXPECT_EQ("executed", result.msg());
+
+	EXPECT_THAT([&] { services->Dispatch(scsi_command::eCmdReceiveOperationResults); }, Throws<scsi_exception>(AllOf(
+		Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+		Property(&scsi_exception::get_asc, asc::data_currently_unavailable))));
+}
+
+TEST(HostServicesTest, RemoteCommandRejectsInvalidFormat)
+{
+	auto [controller, services] = CreateDevice(SCHS);
+	EXPECT_TRUE(services->Init({}));
+
+	controller->SetCmdByte(1, 0x03);
+	controller->SetCmdByte(8, 1);
+	EXPECT_THAT([&] { services->Dispatch(scsi_command::eCmdExecuteOperation); }, Throws<scsi_exception>(AllOf(
+		Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+		Property(&scsi_exception::get_asc, asc::invalid_field_in_cdb))));
+}
+
+TEST(HostServicesTest, RemoteCommandRejectsMalformedPayload)
+{
+	auto [controller, services] = CreateDevice(SCHS);
+	EXPECT_TRUE(services->Init({}));
+
+	controller->SetCmdByte(0, static_cast<int>(scsi_command::eCmdExecuteOperation));
+	controller->SetCmdByte(1, 0x01);
+	controller->SetCmdByte(8, 1);
+	EXPECT_CALL(*controller, DataOut());
+	services->Dispatch(scsi_command::eCmdExecuteOperation);
+
+	const array<uint8_t, 1> payload = { 0xff };
+	EXPECT_THAT([&] { services->WriteByteSequence(payload); }, Throws<scsi_exception>(AllOf(
+		Property(&scsi_exception::get_sense_key, sense_key::aborted_command),
+		Property(&scsi_exception::get_asc, asc::internal_target_failure))));
+}
+
+TEST(HostServicesTest, RemoteCommandTextFormats)
+{
+	auto [controller, services] = CreateDevice(SCHS);
+	EXPECT_TRUE(services->Init({}));
+
+	PbCommand command;
+	(*command.mutable_params())["locale"] = "en";
+	string data;
+	ASSERT_TRUE(google::protobuf::util::MessageToJsonString(command, &data).ok());
+
+	controller->SetCmdByte(0, static_cast<int>(scsi_command::eCmdExecuteOperation));
+	controller->SetCmdByte(1, 0x02);
+	controller->SetCmdByte(7, static_cast<int>(data.size() >> 8));
+	controller->SetCmdByte(8, static_cast<int>(data.size()));
+	EXPECT_CALL(*controller, DataOut());
+	services->Dispatch(scsi_command::eCmdExecuteOperation);
+
+	auto host_services = dynamic_pointer_cast<HostServices>(services);
+	host_services->SetCommandExecutor([] (const PbCommand& received, PbResult& result) {
+		EXPECT_EQ("en", received.params().at("locale"));
+		result.set_status(true);
+		result.set_msg("text result");
+		return true;
+	});
+	EXPECT_TRUE(host_services->WriteByteSequence(span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+
+	controller->SetCmdByte(0, static_cast<int>(scsi_command::eCmdReceiveOperationResults));
+	controller->SetCmdByte(1, 0x04);
+	controller->SetCmdByte(7, 0x04);
+	controller->SetCmdByte(8, 0x00);
+	EXPECT_CALL(*controller, DataIn());
+	services->Dispatch(scsi_command::eCmdReceiveOperationResults);
+
+	PbResult result;
+	EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+		string(reinterpret_cast<const char*>(controller->GetBuffer().data()), controller->GetLength()), &result));
+	EXPECT_TRUE(result.status());
+	EXPECT_EQ("text result", result.msg());
 }
 
 TEST(HostServicesTest, SetUpModePages)

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -157,6 +157,10 @@ class MockAbstractController : public AbstractController //NOSONAR Having many f
 	FRIEND_TEST(HostServicesTest, ModeSense6);
 	FRIEND_TEST(HostServicesTest, ModeSense10);
 	FRIEND_TEST(HostServicesTest, SetUpModePages);
+	FRIEND_TEST(HostServicesTest, RemoteCommandExecution);
+	FRIEND_TEST(HostServicesTest, RemoteCommandTextFormats);
+	FRIEND_TEST(HostServicesTest, RemoteCommandRejectsInvalidFormat);
+	FRIEND_TEST(HostServicesTest, RemoteCommandRejectsMalformedPayload);
 	FRIEND_TEST(ScsiPrinterTest, Print);
 	FRIEND_TEST(ScsiCdTest, ReadToc);
 	FRIEND_TEST(ScsiCdTest, ReadTocAllocationLength);


### PR DESCRIPTION
Port the SCSI2Pi Host Services execute-operation and result-retrieval commands, including binary, JSON and text protobuf formats. Route commands through PiSCSI's command handler without socket transport or lock re-entry, and configure attached Host Services devices automatically.

Validate CDB formats and payloads, support transfers larger than the controller's default buffer, correct Mode Sense response lengths, and cover the new protocol with unit tests.