### PR TITLE
abort timed-out SCSI data handshakes

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -444,8 +444,7 @@ void ScsiController::Send()
 		if (const int len = GetBus().SendHandShake(GetBuffer().data() + GetOffset(), GetLength(),
 				HasDeviceForLun(0) ? GetDeviceForLun(0)->GetSendDelay() : 0);
 			len != static_cast<int>(GetLength())) {
-			// If you cannot send all, move to status phase
-			Error(sense_key::aborted_command);
+			AbortTransfer("send", len, GetLength());
 			return;
 		}
 
@@ -507,6 +506,18 @@ void ScsiController::Send()
 	}
 }
 
+void ScsiController::AbortTransfer(const char* direction, uint32_t transferred, uint32_t expected)
+{
+	LogWarn("SCSI " + string(direction) + " handshake aborted after " + to_string(transferred) + " of "
+			+ to_string(expected) + " byte(s); releasing the bus");
+
+	// The initiator has stopped participating in this REQ/ACK handshake. Do
+	// not try to send CHECK CONDITION or MESSAGE IN: either transfer would wait
+	// for the same missing ACK. Reset releases all target signals and leaves the
+	// controller in bus-free state so the initiator can recover or retry.
+	Reset();
+}
+
 void ScsiController::Receive()
 {
 	assert(!GetBus().GetREQ());
@@ -515,11 +526,9 @@ void ScsiController::Receive()
 	if (HasValidLength()) {
 		LogTrace("Receiving data, transfer length: " + to_string(GetLength()) + " byte(s)");
 
-		// If not able to receive all, move to status phase
+		// An incomplete REQ/ACK handshake cannot be recovered with a status phase.
 		if (uint32_t len = GetBus().ReceiveHandShake(GetBuffer().data() + GetOffset(), GetLength()); len != GetLength()) {
-			LogError("Not able to receive " + to_string(GetLength()) + " byte(s) of data, only received "
-					+ to_string(len));
-			Error(sense_key::aborted_command);
+			AbortTransfer("receive", len, GetLength());
 			return;
 		}
 	}

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -102,6 +102,7 @@ private:
 	bool XferOut(bool);
 	bool XferOutBlockOriented(bool);
 	void ReceiveBytes();
+	void AbortTransfer(const char*, uint32_t, uint32_t);
 
 	void DataOutNonBlockOriented() const;
 	void Receive();

--- a/cpp/hal/bus.h
+++ b/cpp/hal/bus.h
@@ -51,6 +51,11 @@ const static int SCSI_DELAY_FAST_DESKEW_DELAY_NS         = 20;
 const static int SCSI_DELAY_FAST_HOLD_TIME_NS            = 10;
 const static int SCSI_DELAY_FAST_NEGATION_PERIOD_NS      = 30;
 
+// REQ/ACK handshakes normally complete in microseconds. A missing response
+// means the initiator has abandoned the transfer, so do not busy-poll for the
+// multi-second command timeout while PiSCSI is running with real-time priority.
+const static int SCSI_HANDSHAKE_TIMEOUT_MS               = 100;
+
 // The DaynaPort SCSI Link do a short delay in the middle of transfering
 // a packet. This is the number of uS that will be delayed between the
 // header and the actual data.

--- a/cpp/hal/gpiobus.cpp
+++ b/cpp/hal/gpiobus.cpp
@@ -317,8 +317,11 @@ int GPIOBUS::SendHandShake(uint8_t *buf, int count, int delay_after_bytes)
             buf++;
         }
 
-        // Wait for ACK to clear
-        WaitACK(OFF);
+        // The final ACK deassertion completes a successful transfer. A failed
+        // handshake is reset by the controller, so it must not wait again.
+        if (i == count) {
+            WaitACK(OFF);
+        }
     } else {
         // Get Phase
         Acquire();
@@ -412,7 +415,9 @@ bool GPIOBUS::WaitSignal(int pin, bool ast)
 {
     const auto now = chrono::steady_clock::now();
 
-    // Wait up to 3 s
+    // A REQ/ACK handshake is a short, bus-level operation. Longer command
+    // timeouts must not be implemented by busy-polling here: the caller has
+    // disabled IRQs and PiSCSI may be scheduled SCHED_FIFO.
     do {
         Acquire();
 
@@ -424,7 +429,8 @@ bool GPIOBUS::WaitSignal(int pin, bool ast)
         if (GetRST()) {
             return false;
         }
-    } while ((chrono::duration_cast<chrono::seconds>(chrono::steady_clock::now() - now).count()) < 3);
+    } while ((chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - now).count())
+            < SCSI_HANDSHAKE_TIMEOUT_MS);
 
     return false;
 }

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -203,6 +203,8 @@ class MockScsiController : public ScsiController
 	FRIEND_TEST(ScsiControllerTest, DataIn);
 	FRIEND_TEST(ScsiControllerTest, DataOut);
 	FRIEND_TEST(ScsiControllerTest, Error);
+	FRIEND_TEST(ScsiControllerTest, AbortSendTransfer);
+	FRIEND_TEST(ScsiControllerTest, AbortReceiveTransfer);
 	FRIEND_TEST(ScsiControllerTest, RequestSense);
 	FRIEND_TEST(PrimaryDeviceTest, RequestSense);
 	FRIEND_TEST(SasiHdTest, RequestSense);

--- a/cpp/test/scsi_controller_test.cpp
+++ b/cpp/test/scsi_controller_test.cpp
@@ -268,6 +268,38 @@ TEST(ScsiControllerTest, Error)
 	EXPECT_EQ(phase_t::reserved, controller.GetPhase());
 }
 
+TEST(ScsiControllerTest, AbortSendTransfer)
+{
+	auto bus = make_shared<NiceMock<MockBus>>();
+	MockScsiController controller(bus, 0);
+
+	controller.SetPhase(phase_t::datain);
+	controller.SetLength(2048);
+	ON_CALL(*bus, GetREQ).WillByDefault(Return(false));
+	ON_CALL(*bus, GetIO).WillByDefault(Return(true));
+	ON_CALL(*bus, SendHandShake).WillByDefault(Return(512));
+
+	EXPECT_CALL(controller, Reset);
+	EXPECT_CALL(controller, Status).Times(0);
+	controller.DataIn();
+}
+
+TEST(ScsiControllerTest, AbortReceiveTransfer)
+{
+	auto bus = make_shared<NiceMock<MockBus>>();
+	MockScsiController controller(bus, 0);
+
+	controller.SetPhase(phase_t::dataout);
+	controller.SetLength(2048);
+	ON_CALL(*bus, GetREQ).WillByDefault(Return(false));
+	ON_CALL(*bus, GetIO).WillByDefault(Return(false));
+	ON_CALL(*bus, ReceiveHandShake).WillByDefault(Return(512));
+
+	EXPECT_CALL(controller, Reset);
+	EXPECT_CALL(controller, Status).Times(0);
+	controller.DataOut();
+}
+
 TEST(ScsiControllerTest, RequestSense)
 {
 	auto bus = make_shared<NiceMock<MockBus>>();


### PR DESCRIPTION
Limit IRQ-masked REQ/ACK waits to 100 ms and reset the controller and bus when a data transfer is incomplete. Do not attempt status or message recovery after the initiator stops acknowledging, preventing repeated multi-second real-time busy waits from starving the Pi.

Add send and receive regression tests for partial handshakes.